### PR TITLE
fix: Fixing some buttons on insights home page

### DIFF
--- a/src/views/dashboards/Home/index.vue
+++ b/src/views/dashboards/Home/index.vue
@@ -8,12 +8,19 @@
           size="lg"
           scheme="neutral-black"
           clickable
+          @click="goToInsights"
         />
         <section class="dashboards__subheader-description">
           <h1 class="dashboards__title">Nome do projeto</h1>
           <p class="dashboards__description">Dashboards do projeto</p>
         </section>
-        <unnnic-icon icon="close" size="md" scheme="neutral-black" clickable />
+        <unnnic-icon
+          icon="close"
+          size="md"
+          scheme="neutral-black"
+          clickable
+          @click="goToInsights"
+        />
       </section>
     </header>
     <hr class="dashboards__separator" />
@@ -45,6 +52,12 @@ export default {
       },
     ],
   }),
+
+  methods: {
+    goToInsights() {
+      this.$router.push({ name: 'home' });
+    },
+  },
 };
 </script>
 

--- a/src/views/insights/Home/index.vue
+++ b/src/views/insights/Home/index.vue
@@ -62,9 +62,6 @@ export default {
     goToDashboards() {
       this.$router.replace({ name: 'dashboards' });
     },
-    getTime(date) {
-      return moment(date).format('HH:mm');
-    },
   },
 };
 </script>

--- a/src/views/insights/Home/index.vue
+++ b/src/views/insights/Home/index.vue
@@ -9,6 +9,7 @@
         size="small"
         @click="goToDashboards"
       />
+      <unnnic-input-date-picker v-model="filterDate" size="sm" />
     </div>
     <div class="cards">
       <div class="card">
@@ -40,6 +41,7 @@
 </template>
 
 <script>
+import moment from 'moment';
 import InsightsLayout from '@/layouts/InsightsLayout/index.vue';
 
 export default {
@@ -49,9 +51,19 @@ export default {
     InsightsLayout,
   },
 
+  data: () => ({
+    filterDate: {
+      start: moment().subtract(1, 'day').format('YYYY-MM-DD'),
+      end: moment().format('YYYY-MM-DD'),
+    },
+  }),
+
   methods: {
     goToDashboards() {
       this.$router.replace({ name: 'dashboards' });
+    },
+    getTime(date) {
+      return moment(date).format('HH:mm');
     },
   },
 };


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
Some buttons on the insights home page needed an anchor to go to another page. And made more sense to use the date picker from the unnnic library.

### Summary of Changes
The functionality of clicking to go to a page was added to some buttons. And a button was changed, using the date picker button from the unnnic library.

### Design Files <!--- (If not appropriate, remove this topic) -->
<!--- Links to the design files used for reference during implementation. -->

- [Design File 1](https://www.figma.com/proto/P9yyN4D0wGMlzYMjOtHvv3/Insights?page-id=2%3A3&type=design&node-id=1658-4144&viewport=-3853%2C-3705%2C0.41&t=FQrLvKq0xuPtJ5nS-1&scaling=scale-down&starting-point-node-id=1658%3A4144)

### Demonstration <!--- (If not appropriate, remove this topic) -->
![image](https://github.com/weni-ai/insights-webapp/assets/30897764/1bedf13c-d781-40de-b76e-6ce18001f20a)
![image](https://github.com/weni-ai/insights-webapp/assets/30897764/fae57887-7366-43fa-81e7-67937f9f3ca8)

