### PR TITLE
fix: Adjust click functionality to redirect to another page on breadcrumb

### DIFF
--- a/src/views/dashboards/Dashboard/index.vue
+++ b/src/views/dashboards/Dashboard/index.vue
@@ -50,15 +50,23 @@ export default {
     breadcrumb: [
       {
         name: 'Insights',
+        path: '/insights',
       },
       {
         name: 'Dashboards',
+        path: '/dashboards',
       },
       {
         name: 'Atendimento Humano',
+        path: 'dashboard',
       },
     ],
   }),
+  methods: {
+    handleCrumbClick(crumb) {
+      this.$router.push(crumb.path);
+    },
+  },
 };
 </script>
 

--- a/src/views/dashboards/Dashboard/index.vue
+++ b/src/views/dashboards/Dashboard/index.vue
@@ -58,7 +58,7 @@ export default {
       },
       {
         name: 'Atendimento Humano',
-        path: 'dashboard',
+        path: '/dashboard',
       },
     ],
   }),

--- a/src/views/dashboards/Home/index.vue
+++ b/src/views/dashboards/Home/index.vue
@@ -46,9 +46,11 @@ export default {
     breadcrumb: [
       {
         name: 'Insights',
+        path: '/insights',
       },
       {
         name: 'Dashboards',
+        path: '/dashboards',
       },
     ],
   }),
@@ -56,6 +58,9 @@ export default {
   methods: {
     goToInsights() {
       this.$router.push({ name: 'home' });
+    },
+    handleCrumbClick(crumb) {
+      this.$router.push(crumb.path);
     },
   },
 };


### PR DESCRIPTION

## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
It was not possible to click on a breadcrumb item and go to another page.

### Summary of Changes
Route paths were added to each breadcrumb object and a function so that redirection can be done.

### Design Files <!--- (If not appropriate, remove this topic) -->
<!--- Links to the design files used for reference during implementation. -->

- [Design File 1](https://www.figma.com/file/P9yyN4D0wGMlzYMjOtHvv3/Insights?type=design&node-id=1658-4144&mode=design&t=2yLMIP6QNWXRZk7o-0)
