### PR TITLE
 [ENGAGE-998] - (Insights MVP) Design patch default dashboard

### DIFF
--- a/src/components/insights/Layout/Header.vue
+++ b/src/components/insights/Layout/Header.vue
@@ -53,23 +53,14 @@ export default {
     }),
 
     breadcrumbs() {
-      const { currentDashboard, dashboardDefault } = this;
+      const { currentDashboard } = this;
       const { dashboardUuid } = this.$route.params;
 
       const crumbBase = [
-        { path: dashboardDefault.uuid, name: dashboardDefault.name },
+        { path: currentDashboard.uuid, name: currentDashboard.name },
       ];
 
-      const routeCrumbs = [
-        {
-          path: currentDashboard.uuid,
-          name: currentDashboard.name,
-        },
-      ];
-
-      return dashboardUuid === dashboardDefault.uuid
-        ? crumbBase
-        : crumbBase.concat(routeCrumbs);
+      return dashboardUuid === currentDashboard.uuid ? crumbBase : [];
     },
 
     showTagLive() {

--- a/src/components/insights/Layout/HeaderSelectDashboard.vue
+++ b/src/components/insights/Layout/HeaderSelectDashboard.vue
@@ -5,16 +5,8 @@
   >
     <template #trigger>
       <UnnnicAvatarIcon
-        v-if="isSelectedDefaultDashboard"
         icon="monitoring"
         scheme="aux-purple-500"
-        @click.stop
-      />
-      <UnnnicIcon
-        v-else
-        class="clickable"
-        icon="arrow_back"
-        @click.stop="$router.back"
       />
       <section class="dropdown__trigger">
         <h1 class="trigger__title">
@@ -30,6 +22,14 @@
       :key="dashboard"
       @click="setCurrentDashboard(dashboard)"
     >
+      <UnnnicIcon
+        icon="star_rate"
+        :scheme="
+          getIsDefaultDashboard(dashboard) ? 'weni-600' : 'neutral-clean'
+        "
+        :filled="getIsDefaultDashboard(dashboard)"
+        @click.stop
+      />
       {{ dashboard.name }}
     </UnnnicDropdownItem>
   </UnnnicDropdown>
@@ -49,16 +49,16 @@ export default {
     ...mapGetters({
       dashboardDefault: 'dashboards/dashboardDefault',
     }),
-
-    isSelectedDefaultDashboard() {
-      return this.currentDashboard.uuid === this.dashboardDefault.uuid;
-    },
   },
 
   methods: {
     ...mapActions({
       setCurrentDashboard: 'dashboards/setCurrentDashboard',
     }),
+
+    getIsDefaultDashboard(dashboard) {
+      return this.dashboardDefault.uuid === dashboard.uuid;
+    },
   },
 };
 </script>
@@ -103,12 +103,18 @@ $dropdownFixedWidth: 314px;
       gap: $unnnic-spacing-nano;
 
       .unnnic-dropdown-item {
+        border-radius: $unnnic-border-radius-sm;
+
+        padding: $unnnic-spacing-xs;
+
+        display: flex;
+        align-items: center;
+        gap: $unnnic-spacing-nano;
+
         color: $unnnic-color-neutral-darkest;
         font-family: $unnnic-font-family-secondary;
         font-size: $unnnic-font-size-body-gt;
         font-weight: $unnnic-font-weight-bold;
-        padding: $unnnic-spacing-xs;
-        border-radius: $unnnic-border-radius-sm;
 
         &:hover {
           background-color: $unnnic-color-neutral-lightest;

--- a/src/components/insights/Layout/HeaderSelectDashboard.vue
+++ b/src/components/insights/Layout/HeaderSelectDashboard.vue
@@ -20,14 +20,22 @@
     <UnnnicDropdownItem
       v-for="dashboard of dashboards"
       :key="dashboard"
+      class="header-select-dashboard__item"
       @click="setCurrentDashboard(dashboard)"
+      @mouseenter="setDashboardHovered(dashboard.uuid)"
+      @mouseleave="setDashboardHovered('')"
     >
       <UnnnicIcon
+        class="item__star-icon"
+        :class="{
+          'item__star-icon--selected': getIsDefaultDashboard(dashboard.uuid),
+        }"
         icon="star_rate"
-        :scheme="
-          getIsDefaultDashboard(dashboard) ? 'weni-600' : 'neutral-clean'
+        scheme="neutral-clean"
+        :filled="
+          getIsDefaultDashboard(dashboard.uuid) ||
+          dashboardHovered === dashboard.uuid
         "
-        :filled="getIsDefaultDashboard(dashboard)"
         @click.stop
       />
       {{ dashboard.name }}
@@ -40,6 +48,12 @@ import { mapActions, mapGetters, mapState } from 'vuex';
 
 export default {
   name: 'HeaderSelectDashboard',
+
+  data() {
+    return {
+      dashboardHovered: '',
+    };
+  },
 
   computed: {
     ...mapState({
@@ -56,8 +70,11 @@ export default {
       setCurrentDashboard: 'dashboards/setCurrentDashboard',
     }),
 
-    getIsDefaultDashboard(dashboard) {
-      return this.dashboardDefault.uuid === dashboard.uuid;
+    getIsDefaultDashboard(uuid) {
+      return this.dashboardDefault.uuid === uuid;
+    },
+    setDashboardHovered(uuid) {
+      this.dashboardHovered = uuid;
     },
   },
 };
@@ -118,10 +135,18 @@ $dropdownFixedWidth: 314px;
 
         &:hover {
           background-color: $unnnic-color-neutral-lightest;
+
+          .item__star-icon:not(.item__star-icon--selected) {
+            color: $unnnic-color-weni-500;
+          }
         }
 
         &::before {
           content: none;
+        }
+
+        .item__star-icon--selected {
+          color: $unnnic-color-weni-600;
         }
       }
     }


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
Insights MVP

### Summary of Changes
- Added star icon at select dashboard item and removed back icon;
- Defined any dashboard as crumb base.

### Design Files <!--- (If not appropriate, remove this topic) -->
<!--- Links to the design files used for reference during implementation. -->

- [Dropdown with select dash default](https://www.figma.com/design/P9yyN4D0wGMlzYMjOtHvv3/Insights?node-id=4267-8087&t=tOu3IZC7Hdh3Z7XR-1)

### Demonstration <!--- (If not appropriate, remove this topic) -->
![image](https://github.com/weni-ai/insights-webapp/assets/69015179/e27286d2-bc12-4260-9e13-119f66db5fe9)
