### PR TITLE
[ENGAGE-1013] - Fix home router replace to default dashboard

### DIFF
--- a/src/components/insights/Layout/Header.vue
+++ b/src/components/insights/Layout/Header.vue
@@ -40,11 +40,6 @@ export default {
     HeaderTagLive,
     InsightsLayoutHeaderFilters,
   },
-
-  created() {
-    this.routeUpdateCurrentDashboard();
-  },
-
   computed: {
     ...mapState({
       dashboards: (state) => state.dashboards.dashboards,
@@ -89,6 +84,26 @@ export default {
     },
   },
 
+  watch: {
+    currentDashboard(newCurrentDashboard, oldCurrentDashboard) {
+      if (oldCurrentDashboard?.uuid) {
+        this.navigateToDashboard(this.currentDashboard.uuid);
+      }
+    },
+    $route(newRoute, oldRoute) {
+      const { dashboardUuid: newUuid } = newRoute.params;
+      const { dashboardUuid: oldUuid } = oldRoute.params;
+
+      if (newUuid !== oldUuid) {
+        this.routeUpdateCurrentDashboard();
+      }
+    },
+  },
+
+  mounted() {
+    this.routeUpdateCurrentDashboard();
+  },
+
   methods: {
     ...mapActions({
       setCurrentDashboard: 'dashboards/setCurrentDashboard',
@@ -120,22 +135,6 @@ export default {
       this.setCurrentDashboard(
         dashboardRelativeToPath || this.dashboardDefault,
       );
-    },
-  },
-
-  watch: {
-    currentDashboard(newCurrentDashboard, oldCurrentDashboard) {
-      if (oldCurrentDashboard?.uuid) {
-        this.navigateToDashboard(this.currentDashboard.uuid);
-      }
-    },
-    $route(newRoute, oldRoute) {
-      const { dashboardUuid: newUuid } = newRoute.params;
-      const { dashboardUuid: oldUuid } = oldRoute.params;
-
-      if (newUuid !== oldUuid) {
-        this.routeUpdateCurrentDashboard();
-      }
     },
   },
 };

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -31,7 +31,7 @@ const router = createRouter({
         const { projectUuid = '' } = to.query;
         await store.dispatch('config/setToken', token);
         await store.dispatch('config/setProject', { uuid: projectUuid });
-        next({ name: 'dashboards' });
+        next({ name: 'dashboard' });
       },
     },
   ],


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
Breadcrumbs not displayed on the '/' route

### Summary of Changes
* Change from the 'created' method to the 'mounted' method for the $router.replace to function as expected
