### PR TITLE
[ENGAGE-1211] - Fix First Loading

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -20,6 +20,7 @@ export default {
     ...mapState({
       dashboards: (state) => state.dashboards.dashboards,
       currentDashboard: (state) => state.dashboards.currentDashboard,
+      token: (state) => state.config.token,
     }),
   },
 
@@ -32,13 +33,13 @@ export default {
   },
 
   created() {
-    this.setToken(localStorage.getItem('token'));
-    this.setProject({ uuid: localStorage.getItem('projectUuid') });
+    this.listenConnect();
   },
 
   mounted() {
-    this.listenConnect();
-    this.getDashboards();
+    this.setToken(localStorage.getItem('token'));
+    this.setProject({ uuid: localStorage.getItem('projectUuid') });
+    if (this.token) this.getDashboards();
   },
 
   methods: {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -25,7 +25,7 @@ const router = createRouter({
       path: '/loginexternal/:token',
       name: 'external.login',
       component: null,
-      beforeEnter: async (to, from, next) => {
+      beforeEnter: async (to) => {
         let { token = '' } = to.params;
         token = token.replace('+', ' ').replace('Bearer ', '');
         const { projectUuid = '' } = to.query;
@@ -33,10 +33,10 @@ const router = createRouter({
         localStorage.setItem('projectUuid', projectUuid);
         await store.dispatch('config/setToken', token);
         await store.dispatch('config/setProject', { uuid: projectUuid });
-        next({
-          path: '/:dashboardUuid',
-          query: { ...to.query, projectUuid: undefined },
-        });
+        const { isLoadingDashboards } = store.state.dashboards;
+        if (!isLoadingDashboards) {
+          await store.dispatch('dashboards/getDashboards');
+        }
       },
     },
   ],

--- a/src/store/modules/dashboards.js
+++ b/src/store/modules/dashboards.js
@@ -14,6 +14,7 @@ function treatFilters(filters, valueHandler, currentDashboardFilters) {
 
 const mutations = {
   SET_DASHBOARDS: 'SET_DASHBOARDS',
+  SET_LOADING_DASHBOARDS: 'SET_LOADING_DASHBOARDS',
   SET_CURRENT_DASHBOARD: 'SET_CURRENT_DASHBOARD',
   SET_CURRENT_DASHBOARD_WIDGETS: 'SET_CURRENT_DASHBOARD_WIDGETS',
   RESET_CURRENT_DASHBOARD_WIDGETS: 'RESET_CURRENT_DASHBOARD_WIDGETS',
@@ -28,6 +29,7 @@ export default {
   namespaced: true,
   state: {
     dashboards: [],
+    isLoadingDashboards: false,
     currentDashboard: {},
     currentDashboardWidgets: [],
     currentDashboardFilters: [],
@@ -36,6 +38,9 @@ export default {
   mutations: {
     [mutations.SET_DASHBOARDS](state, dashboards) {
       state.dashboards = dashboards;
+    },
+    [mutations.SET_LOADING_DASHBOARDS](state, loading) {
+      state.isLoadingDashboards = loading;
     },
     [mutations.SET_CURRENT_DASHBOARD](state, dashboard) {
       state.currentDashboard = dashboard;
@@ -83,11 +88,13 @@ export default {
   },
   actions: {
     async getDashboards({ commit }) {
+      commit(mutations.SET_LOADING_DASHBOARDS, true);
       const dashboards = await Dashboards.getAll();
       commit(
         mutations.SET_DASHBOARDS,
         sortByKey(dashboards, 'is_default', 'desc'),
       );
+      commit(mutations.SET_LOADING_DASHBOARDS, false);
     },
     async setCurrentDashboard({ commit }, dashboard) {
       commit(mutations.SET_CURRENT_DASHBOARD, dashboard);


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
A problem meant that insights did not render on its first load, making it necessary to always refresh the navigation to force a second load
