### PR TITLE
[ENGAGE-1271] - Fix horizontal bar chart spacings

### DIFF
--- a/src/components/insights/charts/HorizontalBarChart.vue
+++ b/src/components/insights/charts/HorizontalBarChart.vue
@@ -74,7 +74,7 @@ export default {
             {
               axis: 'y',
               borderSkipped: false,
-              minBarLength: 35,
+              minBarLength: 36,
             },
           ],
         },
@@ -84,7 +84,7 @@ export default {
     chartOptions() {
       return {
         indexAxis: 'y',
-        barThickness: 30,
+        barThickness: 32,
         maintainAspectRatio: false,
         scales: {
           x: {
@@ -92,6 +92,8 @@ export default {
           },
           y: {
             display: true,
+            autoSkip: false,
+            maxRotation: 0,
             ticks: {
               padding: 0,
               font: { lineHeight: 1.66, size: 12, weight: 400 },
@@ -125,7 +127,13 @@ export default {
       return [ChartDataLabels];
     },
     graphContainerHeight() {
-      return this.mergedData.datasets?.[0]?.data.length * 35;
+      const barSpacingY = 4;
+      const paddingY = 24;
+      const totalBars = this.mergedData.datasets?.[0]?.data.length;
+
+      return (
+        totalBars * (this.chartOptions.barThickness + barSpacingY) + paddingY
+      );
     },
   },
 };


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When there was little data on the graph, the space between the bars became smaller than they should have been. This was resolved by adding a spacing added to the bar size and padding the graph in relation to the parent container