### PR TITLE
[ENGAGE-1287] - Add chart tooltips and truncate labels

### DIFF
--- a/src/components/insights/charts/BarChart.vue
+++ b/src/components/insights/charts/BarChart.vue
@@ -67,6 +67,7 @@ export default {
         backgroundColor: '#00A49F',
         hoverBackgroundColor: '#00DED2',
         plugins: {
+          tooltip: false,
           datalabels: {
             color: function (context) {
               return context.active ? '#003234' : '#fff';

--- a/src/components/insights/charts/HorizontalBarChart.vue
+++ b/src/components/insights/charts/HorizontalBarChart.vue
@@ -39,7 +39,7 @@
 import IconLoading from '@/components/IconLoading.vue';
 import BaseChart from './BaseChart.vue';
 import ChartDataLabels from 'chartjs-plugin-datalabels';
-
+import { Tooltip } from 'chart.js';
 import { deepMerge } from '@/utils/object';
 
 export default {
@@ -74,7 +74,7 @@ export default {
             {
               axis: 'y',
               borderSkipped: false,
-              minBarLength: 36,
+              minBarLength: 56,
             },
           ],
         },
@@ -95,6 +95,12 @@ export default {
             autoSkip: false,
             maxRotation: 0,
             ticks: {
+              callback: (value, index) => {
+                const label = String(this.chartData.labels[index]);
+                return label.length > 15
+                  ? `${label.substring(0, 15)}...`
+                  : label;
+              },
               padding: 0,
               font: { lineHeight: 1.66, size: 12, weight: 400 },
             },
@@ -106,6 +112,13 @@ export default {
         backgroundColor: '#00A49F',
         hoverBackgroundColor: '#00DED2',
         plugins: {
+          tooltip: {
+            enabled: true,
+            mode: 'index',
+            callbacks: {
+              label: () => false,
+            },
+          },
           datalabels: {
             formatter: (value) => {
               return value + this.datalabelsSuffix;
@@ -124,7 +137,7 @@ export default {
       };
     },
     chartPlugins() {
-      return [ChartDataLabels];
+      return [ChartDataLabels, Tooltip];
     },
     graphContainerHeight() {
       const barSpacingY = 4;


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
In the horizontal bar chart, the labels will now be truncated at 15 characters and a tooltip of the complete label will be displayed in order to avoid unwanted visual scenarios

### Summary of Changes
<!--- Describe your changes in detail -->
- Truncate labels in 15 characters
- Add chart.js tooltip


### Demonstration <!--- (If not appropriate, remove this topic) -->
<!--- Include a screenshot or video showcasing a feature or fix implemented in this pull request. -->
![image](https://github.com/user-attachments/assets/a63bb370-a760-44c1-96b1-02194baba5d6)
