### PR TITLE
[ENGAGE-1318] - Remove widget graph column reorder

### DIFF
--- a/src/components/insights/widgets/DynamicWidget.vue
+++ b/src/components/insights/widgets/DynamicWidget.vue
@@ -142,10 +142,6 @@ export default {
       const widgetData = this.widget.data;
       let data = widgetData.data || widgetData.results;
 
-      if (this.widget.type === 'graph_column') {
-        data = sortByKey(data, 'label');
-      }
-
       const labels = data.map((item) => item.label);
       const values = data.map((item) => item.value);
 

--- a/src/components/insights/widgets/DynamicWidget.vue
+++ b/src/components/insights/widgets/DynamicWidget.vue
@@ -16,7 +16,6 @@ import CardDashboard from '@/components/insights/cards/CardDashboard.vue';
 import TableDynamicByFilter from '@/components/insights/widgets/TableDynamicByFilter.vue';
 import TableGroup from '@/components/insights/widgets/TableGroup.vue';
 
-import { sortByKey } from '@/utils/array';
 import { formatSecondsToHumanString } from '@/utils/time';
 
 export default {

--- a/src/components/insights/widgets/DynamicWidget.vue
+++ b/src/components/insights/widgets/DynamicWidget.vue
@@ -139,7 +139,7 @@ export default {
       }
 
       const widgetData = this.widget.data;
-      let data = widgetData.data || widgetData.results;
+      const data = widgetData.data || widgetData.results;
 
       const labels = data.map((item) => item.label);
       const values = data.map((item) => item.value);


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
The frontend was unable to correctly order the labels due to the formatting that the backend returned. Now the backend is returning in the right order, so this ordering is not necessary.

### Summary of Changes
Removed widget graph column reorder.
