### PR TITLE
[ENGAGE-1340] - Widget gallery

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@vueuse/core": "^10.11.0",
-    "@weni/unnnic-system": "^2.1.1",
+    "@weni/unnnic-system": "^2.5.0",
     "axios": "^1.7.2",
     "chart.js": "^4.4.2",
     "chartjs-plugin-datalabels": "^2.2.0",

--- a/src/components/ModalResetWidget.vue
+++ b/src/components/ModalResetWidget.vue
@@ -16,6 +16,8 @@
 import { mapActions } from 'vuex';
 import Unnnic from '@weni/unnnic-system';
 
+import { clearDeepValues } from '@/utils/object';
+
 export default {
   name: 'ModalResetWidget',
 
@@ -60,7 +62,11 @@ export default {
       this.isLoading = true;
 
       try {
-        await this.updateWidget({ ...this.widget, config: {}, name: '' });
+        await this.updateWidget({
+          ...this.widget,
+          config: clearDeepValues(this.widget.config),
+          name: '',
+        });
 
         this.callSuccessAlert();
       } catch (error) {

--- a/src/components/ModalResetWidget.vue
+++ b/src/components/ModalResetWidget.vue
@@ -1,0 +1,96 @@
+<template>
+  <UnnnicModalDialog
+    :modelValue="modelValue"
+    :title="$t('widgets.reset')"
+    showCloseIcon
+    :primaryButtonProps="primaryButtonProps"
+    @primary-button-click="resetWidget"
+    @secondary-button-click="updateModelValue"
+    @update:model-value="updateModelValue"
+  >
+    <p>{{ $t('widgets.info_reset') }}</p>
+  </UnnnicModalDialog>
+</template>
+
+<script>
+import { mapActions } from 'vuex';
+import Unnnic from '@weni/unnnic-system';
+
+export default {
+  name: 'ModalResetWidget',
+
+  props: {
+    modelValue: {
+      type: Boolean,
+      required: true,
+    },
+    widget: {
+      type: Object,
+      default: () => ({}),
+    },
+  },
+
+  emits: ['update:model-value', 'finish-reset'],
+
+  data() {
+    return {
+      isLoading: false,
+    };
+  },
+
+  computed: {
+    primaryButtonProps() {
+      return {
+        text: this.$t('reset'),
+        loading: this.isLoading,
+      };
+    },
+  },
+
+  methods: {
+    ...mapActions({
+      updateWidget: 'dashboards/updateWidget',
+    }),
+
+    updateModelValue(value) {
+      this.$emit('update:model-value', value);
+    },
+
+    async resetWidget() {
+      this.isLoading = true;
+
+      try {
+        await this.updateWidget({ ...this.widget, config: {}, name: '' });
+
+        this.callSuccessAlert();
+      } catch (error) {
+        this.callErrorAlert();
+        console.error(error);
+      } finally {
+        this.$emit('finish-reset');
+        this.isLoading = false;
+      }
+    },
+
+    callSuccessAlert() {
+      Unnnic.unnnicCallAlert({
+        props: {
+          text: this.$t('widgets.success_reset'),
+          type: 'success',
+        },
+        seconds: 5,
+      });
+    },
+
+    callErrorAlert() {
+      Unnnic.unnnicCallAlert({
+        props: {
+          text: this.$t('widgets.error_reset'),
+          type: 'error',
+        },
+        seconds: 5,
+      });
+    },
+  },
+};
+</script>

--- a/src/components/insights/Layout/HeaderFilters/FilterSelect.vue
+++ b/src/components/insights/Layout/HeaderFilters/FilterSelect.vue
@@ -72,9 +72,10 @@ export default {
 
   watch: {
     dependsOnValue: {
+      immediate: true,
       handler(newDependsOnValue, oldDependsOnValue) {
-        const newValues = Object.values(newDependsOnValue);
-        const oldValues = Object.values(oldDependsOnValue);
+        const newValues = Object.values(newDependsOnValue || {});
+        const oldValues = Object.values(oldDependsOnValue || {});
         if (!compareEquals(newValues, oldValues)) {
           const filledDependsOnValue = newValues.every((value) => value);
 

--- a/src/components/insights/drawers/DrawerConfigContentFunnel.vue
+++ b/src/components/insights/drawers/DrawerConfigContentFunnel.vue
@@ -81,6 +81,11 @@ export default {
         delete metric.active;
         return metric;
       });
+
+      if (metricsToCompare.some((metric) => !metric.flow[0].value)) {
+        return false;
+      }
+
       if (this.initialMetricsStringfy === JSON.stringify(metricsToCompare)) {
         return false;
       }

--- a/src/components/insights/drawers/DrawerConfigGallery/GalleryOption.vue
+++ b/src/components/insights/drawers/DrawerConfigGallery/GalleryOption.vue
@@ -1,0 +1,61 @@
+<template>
+  <button class="gallery-option">
+    <p class="gallery-option__title">{{ title }}</p>
+    <p class="gallery-option__description">{{ description }}</p>
+  </button>
+</template>
+
+<script>
+export default {
+  name: 'GalleryOption',
+
+  props: {
+    title: {
+      type: String,
+      default: '',
+    },
+    description: {
+      type: String,
+      default: '',
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.gallery-option {
+  display: flex;
+  padding: $unnnic-spacing-md;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  gap: $unnnic-spacing-nano;
+
+  width: 100%;
+
+  border-radius: $unnnic-border-radius-md;
+  border: $unnnic-border-width-thinner solid $unnnic-color-neutral-soft;
+  background-color: $unnnic-color-neutral-snow;
+
+  cursor: pointer;
+
+  font-family: $unnnic-font-family-secondary;
+
+  &:hover {
+    border-color: $unnnic-color-weni-500;
+    background-color: $unnnic-color-weni-50;
+  }
+
+  &__title {
+    color: $unnnic-color-neutral-darkest;
+    font-size: $unnnic-font-size-body-lg;
+    font-weight: $unnnic-font-weight-bold;
+    line-height: $unnnic-line-height-small * 6;
+  }
+  &__description {
+    color: $unnnic-color-neutral-cloudy;
+    font-size: $unnnic-font-size-body-gt;
+    line-height: $unnnic-line-height-small * 5.5;
+  }
+}
+</style>

--- a/src/components/insights/drawers/DrawerConfigGallery/index.vue
+++ b/src/components/insights/drawers/DrawerConfigGallery/index.vue
@@ -1,0 +1,118 @@
+<template>
+  <UnnnicDrawer
+    v-if="galleryOptions.length && !showDrawerConfigWidget"
+    class="drawer-config-gallery"
+    wide
+    :title="$t('drawers.config_gallery.title')"
+    :description="$t('drawers.config_gallery.description')"
+    :modelValue="modelValue"
+    @close="closeAllDrawers"
+  >
+    <template #content>
+      <ol class="drawer-config-gallery__options">
+        <li
+          v-for="{ title, description, value } of galleryOptions"
+          :key="title"
+        >
+          <GalleryOption
+            :title="title"
+            :description="description"
+            @click="setDrawerConfigType(value)"
+          />
+        </li>
+      </ol>
+    </template>
+  </UnnnicDrawer>
+  <DrawerConfigWidgetDynamic
+    v-if="showDrawerConfigWidget"
+    :modelValue="showDrawerConfigWidget"
+    :widget="widget"
+    :configType="drawerConfigType"
+    @close="closeAllDrawers"
+  />
+</template>
+
+<script>
+import GalleryOption from './GalleryOption.vue';
+import DrawerConfigWidgetDynamic from '../DrawerConfigWidgetDynamic.vue';
+
+export default {
+  name: 'DrawerConfigGallery',
+
+  components: {
+    GalleryOption,
+    DrawerConfigWidgetDynamic,
+  },
+
+  props: {
+    modelValue: {
+      type: Boolean,
+      default: false,
+    },
+    widget: {
+      type: Object,
+      default: () => ({}),
+    },
+  },
+
+  emits: ['close'],
+
+  data() {
+    return { showDrawerConfigWidget: false, drawerConfigType: '' };
+  },
+
+  computed: {
+    galleryOptions() {
+      const { $t } = this;
+      function createOptions(optionKeys) {
+        return optionKeys.map((option) => ({
+          title: $t(`drawers.config_gallery.options.${option}.title`),
+          description: $t(
+            `drawers.config_gallery.options.${option}.description`,
+          ),
+          value: option,
+        }));
+      }
+
+      const optionsMap = {
+        card: createOptions(['executions', 'flow_result']),
+      };
+
+      return optionsMap[this.widget?.type] || [];
+    },
+  },
+
+  watch: {
+    modelValue: {
+      immediate: true,
+      handler() {
+        if (!this.galleryOptions.length) {
+          this.showDrawerConfigWidget = true;
+        }
+      },
+    },
+  },
+
+  methods: {
+    closeAllDrawers() {
+      this.$emit('close');
+      this.showDrawerConfigWidget = false;
+      this.drawerConfigType = '';
+    },
+
+    setDrawerConfigType(value) {
+      this.drawerConfigType = value;
+      this.showDrawerConfigWidget = true;
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.drawer-config-gallery {
+  &__options {
+    display: grid;
+    gap: $unnnic-spacing-ant;
+  }
+}
+</style>

--- a/src/components/insights/drawers/DrawerConfigGallery/index.vue
+++ b/src/components/insights/drawers/DrawerConfigGallery/index.vue
@@ -6,6 +6,7 @@
     :title="$t('drawers.config_gallery.title')"
     :description="$t('drawers.config_gallery.description')"
     :modelValue="modelValue"
+    closeIcon="close"
     @close="closeAllDrawers"
   >
     <template #content>
@@ -29,6 +30,7 @@
     :widget="widget"
     :configType="drawerConfigType"
     @close="closeAllDrawers"
+    @back="goToGallery"
   />
 </template>
 
@@ -95,14 +97,18 @@ export default {
 
   methods: {
     closeAllDrawers() {
+      this.goToGallery();
       this.$emit('close');
-      this.showDrawerConfigWidget = false;
-      this.drawerConfigType = '';
     },
 
     setDrawerConfigType(value) {
       this.drawerConfigType = value;
       this.showDrawerConfigWidget = true;
+    },
+
+    goToGallery() {
+      this.showDrawerConfigWidget = false;
+      this.drawerConfigType = '';
     },
   },
 };

--- a/src/components/insights/drawers/DrawerConfigWidgetDynamic.vue
+++ b/src/components/insights/drawers/DrawerConfigWidgetDynamic.vue
@@ -2,6 +2,7 @@
   <UnnnicDrawer
     ref="unnnicDrawer"
     class="drawer-config-widget-dynamic"
+    wide
     :modelValue="modelValue"
     :title="drawerProps?.title"
     :description="drawerProps?.description"

--- a/src/components/insights/drawers/DrawerConfigWidgetDynamic.vue
+++ b/src/components/insights/drawers/DrawerConfigWidgetDynamic.vue
@@ -1,38 +1,40 @@
 <template>
-  <UnnnicDrawer
-    ref="unnnicDrawer"
-    class="drawer-config-widget-dynamic"
-    wide
-    :modelValue="modelValue"
-    :title="drawerProps?.title"
-    :description="drawerProps?.description"
-    :primaryButtonText="$t('save')"
-    :secondaryButtonText="$t('cancel')"
-    :disabledPrimaryButton="disablePrimaryButton || isLoadingFlowOptions"
-    :loadingPrimaryButton="isLoadingUpdateConfig"
-    :withoutOverlay="showModalResetWidget"
-    @primary-button-click="updateWidgetConfig"
-    @secondary-button-click="internalClose"
-    @close="configType ? $emit('back') : $emit('close')"
+  <form
+    @submit.prevent
+    @keydown.enter.prevent
   >
-    <template #content>
-      <form
-        class="drawer-config-widget-dynamic__content"
-        @submit.prevent
-      >
-        <component
-          :is="isLoadingFlowOptions ? content.loading : content.component"
-          v-bind="contentProps"
-          v-on="contentEvents"
-        />
-      </form>
-    </template>
-  </UnnnicDrawer>
-  <ModalResetWidget
-    v-model="showModalResetWidget"
-    :widget="widget"
-    @finish-reset="$emit('close')"
-  />
+    <UnnnicDrawer
+      ref="unnnicDrawer"
+      class="drawer-config-widget-dynamic"
+      wide
+      :modelValue="modelValue"
+      :title="drawerProps?.title"
+      :description="drawerProps?.description"
+      :primaryButtonText="$t('save')"
+      :secondaryButtonText="$t('cancel')"
+      :disabledPrimaryButton="disablePrimaryButton || isLoadingFlowOptions"
+      :loadingPrimaryButton="isLoadingUpdateConfig"
+      :withoutOverlay="showModalResetWidget"
+      @primary-button-click="updateWidgetConfig"
+      @secondary-button-click="internalClose"
+      @close="configType ? $emit('back') : $emit('close')"
+    >
+      <template #content>
+        <section class="drawer-config-widget-dynamic__content">
+          <component
+            :is="isLoadingFlowOptions ? content.loading : content.component"
+            v-bind="contentProps"
+            v-on="contentEvents"
+          />
+        </section>
+      </template>
+    </UnnnicDrawer>
+    <ModalResetWidget
+      v-model="showModalResetWidget"
+      :widget="widget"
+      @finish-reset="$emit('close')"
+    />
+  </form>
 </template>
 
 <script>

--- a/src/components/insights/drawers/DrawerConfigWidgetDynamic.vue
+++ b/src/components/insights/drawers/DrawerConfigWidgetDynamic.vue
@@ -27,6 +27,11 @@
       </form>
     </template>
   </UnnnicDrawer>
+  <ModalResetWidget
+    v-model="showModalResetWidget"
+    :widget="widget"
+    @finish-reset="$emit('close')"
+  />
 </template>
 
 <script>
@@ -39,6 +44,8 @@ import DrawerConfigContentCard from './DrawerConfigContentCard.vue';
 import SkeletonConfigContentCard from './loadings/SkeletonConfigContentCard.vue';
 import SkeletonConfigContentFunnel from './loadings/SkeletonConfigContentFunnel.vue';
 
+import ModalResetWidget from '@/components/ModalResetWidget.vue';
+
 export default {
   name: 'DrawerConfigWidgetDynamic',
 
@@ -47,6 +54,7 @@ export default {
     DrawerConfigContentCard,
     SkeletonConfigContentCard,
     SkeletonConfigContentFunnel,
+    ModalResetWidget,
   },
 
   props: {
@@ -57,6 +65,10 @@ export default {
     widget: {
       type: Object,
       default: () => ({}),
+    },
+    configType: {
+      type: String,
+      default: '',
     },
   },
 
@@ -72,6 +84,7 @@ export default {
       disablePrimaryButton: false,
       isLoadingUpdateConfig: false,
       isLoadingFlowOptions: false,
+      showModalResetWidget: false,
     };
   },
   computed: {
@@ -111,7 +124,7 @@ export default {
       };
 
       const mappingProps = {
-        card: { flows },
+        card: { flows, type: this.configType },
       };
 
       return { ...defaultProps, ...mappingProps[this.widget?.type] };
@@ -119,8 +132,9 @@ export default {
     contentEvents() {
       const defaultEvents = {
         'update:model-value': (config) => (this.config = config),
-        updateDisablePrimaryButton: (boolean) =>
+        'update-disable-primary-button': (boolean) =>
           (this.disablePrimaryButton = boolean),
+        'reset-widget': () => (this.showModalResetWidget = true),
       };
 
       const mappingEvents = {};
@@ -176,7 +190,7 @@ export default {
         report_name: `${this.$t('drawers.config_card.total_flow_executions')} ${configuredFlow?.label}`,
         config: {
           operation:
-            config.resultType === 'executions'
+            this.configType === 'executions'
               ? 'count'
               : config.result?.operation,
           filter: { flow: configuredFlow?.value },

--- a/src/components/insights/drawers/DrawerConfigWidgetDynamic.vue
+++ b/src/components/insights/drawers/DrawerConfigWidgetDynamic.vue
@@ -286,6 +286,8 @@ export default {
           },
           seconds: 5,
         });
+      } finally {
+        this.$emit('close');
       }
 
       this.isLoadingUpdateConfig = false;

--- a/src/components/insights/drawers/DrawerConfigWidgetDynamic.vue
+++ b/src/components/insights/drawers/DrawerConfigWidgetDynamic.vue
@@ -90,17 +90,34 @@ export default {
   },
   computed: {
     drawerProps() {
+      const { $t } = this;
       const configMap = {
         graph_funnel: {
-          title: this.$t('drawers.config_funnel.title'),
-          description: this.$t('drawers.config_funnel.description'),
+          default: {
+            title: $t('drawers.config_funnel.title'),
+            description: $t('drawers.config_funnel.description'),
+          },
         },
         card: {
-          title: this.$t('drawers.config_card.title'),
+          default: {
+            title: $t('drawers.config_card.title'),
+          },
+          executions: {
+            title: $t(`drawers.config_gallery.options.executions.title`),
+            description: $t(
+              `drawers.config_gallery.options.executions.description`,
+            ),
+          },
+          flow_result: {
+            title: $t(`drawers.config_gallery.options.flow_result.title`),
+            description: $t(
+              `drawers.config_gallery.options.flow_result.description`,
+            ),
+          },
         },
       };
 
-      return configMap[this.widget?.type] || {};
+      return configMap[this.widget?.type][this.configType || 'default'] || {};
     },
     content() {
       const componentMap = {

--- a/src/components/insights/drawers/DrawerConfigWidgetDynamic.vue
+++ b/src/components/insights/drawers/DrawerConfigWidgetDynamic.vue
@@ -10,9 +10,10 @@
     :secondaryButtonText="$t('cancel')"
     :disabledPrimaryButton="disablePrimaryButton || isLoadingFlowOptions"
     :loadingPrimaryButton="isLoadingUpdateConfig"
+    :withoutOverlay="showModalResetWidget"
     @primary-button-click="updateWidgetConfig"
     @secondary-button-click="internalClose"
-    @close="$emit('close')"
+    @close="configType ? $emit('back') : $emit('close')"
   >
     <template #content>
       <form
@@ -72,7 +73,7 @@ export default {
     },
   },
 
-  emits: ['close'],
+  emits: ['close', 'back'],
 
   data() {
     return {

--- a/src/components/insights/widgets/DynamicWidget.vue
+++ b/src/components/insights/widgets/DynamicWidget.vue
@@ -91,7 +91,7 @@ export default {
             mappingMetricDataTypesFormat[config.data_type]?.(data?.value) ||
             JSON.stringify(data?.value),
           description: name,
-          configured: config && !!Object.keys(config).length,
+          configured: !!name,
           clickable: !!report,
           configurable: is_configurable,
         },

--- a/src/components/insights/widgets/DynamicWidget.vue
+++ b/src/components/insights/widgets/DynamicWidget.vue
@@ -92,6 +92,8 @@ export default {
             JSON.stringify(data?.value),
           description: name,
           configured: !!name,
+          /* The "configured" field is only checking if the name is defined, since the widget may be unconfigured,
+          but still have empty fields in the "config" object. */
           clickable: !!report,
           configurable: is_configurable,
         },

--- a/src/locales/translations.json
+++ b/src/locales/translations.json
@@ -69,7 +69,32 @@
     "en": "Error saving, please try again",
     "es": "Error al guardar, por favor inténtalo de nuevo"
   },
+  "reset": {
+    "pt-br": "Resetar",
+    "en": "Reset",
+    "es": "Reiniciar"
+  },
   "widgets": {
+    "reset": {
+      "pt-br": "Resetar widget",
+      "en": "Reset widget",
+      "es": "Restablecer widget"
+    },
+    "info_reset": {
+      "pt-br": "Ao resetar, os dados configurados serão perdidos.",
+      "en": "When reset, the configured data will be lost.",
+      "es": "Cuando se reinicie, los datos configurados se perderán."
+    },
+    "success_reset": {
+      "pt-br": "O widget foi resetado com sucesso",
+      "en": "The widget was successfully reset",
+      "es": "El widget se restableció con éxito"
+    },
+    "error_reset": {
+      "pt-br": "Não foi possível resetar o widget. Por favor, tente novamente",
+      "en": "It was not possible to reset the widget. Please try again",
+      "es": "No fue posible restablecer el widget. Inténtalo de nuevo"
+    },
     "metric_error": {
       "pt-br": "Erro ao buscar @.lower:metric",
       "en": "Error when seeking @.lower:metric",
@@ -120,6 +145,49 @@
       "pt-br": "@:metric salva com sucesso",
       "en": "@:metric saved successfully",
       "es": "@:metric guardada correctamente"
+    },
+    "reset_widget": {
+      "pt-br": "Resetar widget",
+      "en": "Reset widget",
+      "es": "Restablecer widget"
+    },
+    "config_gallery": {
+      "title": {
+        "pt-br": "Galeria de widgets",
+        "en": "Widget gallery",
+        "es": "Galería de widgets"
+      },
+      "description": {
+        "pt-br": "Escolha o tipo de widget que deseja configurar:",
+        "en": "Choose the type of widget you want to configure:",
+        "es": "Elija el tipo de widget que desea configurar:"
+      },
+      "options": {
+        "executions": {
+          "title": {
+            "pt-br": "Execuções",
+            "en": "Execution",
+            "es": "Ejecución"
+          },
+          "description": {
+            "pt-br": "Visualize o total de execuções de um @.lower:flow",
+            "en": "Visualize the total executions of a @.lower:flow",
+            "es": "Visualizar las ejecuciones totales de un @.lower:flow"
+          }
+        },
+        "flow_result": {
+          "title": {
+            "pt-br": "Resultado de @.lower:flow",
+            "en": "@:flow result",
+            "es": "Resultado de @.lower:flow"
+          },
+          "description": {
+            "pt-br": "Traz um resultado de @.lower:flow e permite operações básicas",
+            "en": "Brings a @.lower:flow result and allows basic operations",
+            "es": "Trae un resultado de @.lower:flow y permite operaciones básicas"
+          }
+        }
+      }
     },
     "config_card": {
       "title": {

--- a/src/utils/object.js
+++ b/src/utils/object.js
@@ -21,3 +21,24 @@ export function stringifyValue(value) {
   }
   return value;
 }
+
+export function clearDeepValues(obj) {
+  function clearValue(value) {
+    const clearValuesByTypeMap = {
+      string: '',
+      number: 0,
+    };
+
+    const haveValueTypeAtMap =
+      Object.keys(clearValuesByTypeMap).includes(typeof value);
+
+    return haveValueTypeAtMap
+      ? clearValuesByTypeMap[typeof value]
+      : clearDeepValues(value) || value;
+  }
+
+  return Object.entries(obj).reduce((acc, [key, value]) => {
+    acc[key] = clearValue(value);
+    return acc;
+  }, {});
+}

--- a/src/views/insights/Dashboard.vue
+++ b/src/views/insights/Dashboard.vue
@@ -20,7 +20,7 @@
         @open-config="openDrawerConfigWidget(widget)"
       />
     </template>
-    <DrawerConfigWidgetDynamic
+    <DrawerConfigGallery
       v-if="!!widgetConfigurating"
       :modelValue="showDrawerConfigWidget"
       :widget="widgetConfigurating"
@@ -33,7 +33,7 @@
 import { mapActions, mapState, mapMutations } from 'vuex';
 
 import DynamicWidget from '@/components/insights/widgets/DynamicWidget.vue';
-import DrawerConfigWidgetDynamic from '@/components/insights/drawers/DrawerConfigWidgetDynamic.vue';
+import DrawerConfigGallery from '@/components/insights/drawers/DrawerConfigGallery/index.vue';
 import IconLoading from '@/components/IconLoading.vue';
 
 export default {
@@ -41,7 +41,7 @@ export default {
 
   components: {
     DynamicWidget,
-    DrawerConfigWidgetDynamic,
+    DrawerConfigGallery,
     IconLoading,
   },
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -964,10 +964,10 @@
   resolved "https://registry.yarnpkg.com/@weni/eslint-config/-/eslint-config-1.0.3.tgz#ddd6420b3215218107ca26e3795251849a3c80be"
   integrity sha512-Te4vJZpwlR6cgwbkIKAKuUKhfcDuwgXPAZCoTu+/Tkhy2lo4/neo4j1fljv0yDAxvgLdHL6JvfGGaalUEJB38g==
 
-"@weni/unnnic-system@^2.1.1":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@weni/unnnic-system/-/unnnic-system-2.1.1.tgz#97069d6d44f2161f5a4c6267929211eef9712e24"
-  integrity sha512-U0HQw/xxWQxY54W22NdqjqLWyV/F3loF68T3XsJXly53ho2B4qV4PuhvcYFW/JUhI5n7wKAcQPStrJb+ARi6FA==
+"@weni/unnnic-system@^2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@weni/unnnic-system/-/unnnic-system-2.5.0.tgz#4fd59b6ec269551c15c160b14f2d8d42f0bf8670"
+  integrity sha512-qrPu94JHjqU7N8Yh5pP5zytDK9vZMB2peEugpa+LElrsycmKOnyAgJXtSHrKDMc5gYjvEhYgPE+eGx1dVI2UaQ==
   dependencies:
     "@emoji-mart/data" "^1.1.2"
     "@vueuse/components" "^10.4.1"


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
This improvement will add to the UX in card configuration and increase scalability in configuring widget types.

### Summary of Changes
- Changed validation for any widget configuration to open or not the gallery;
- Added button and modal to reset the widget;
- Added gallery option component;
- Changed logic in the card configuration form to adapt to the widget gallery;
- Changed titles and descriptions of card configuration drawers;
- Changed default size of configuration drawers to wide;

### Design Files <!--- (If not appropriate, remove this topic) -->
<!--- Links to the design files used for reference during implementation. -->

- [Widget gallery](https://www.figma.com/design/P9yyN4D0wGMlzYMjOtHvv3/Insights?node-id=5759-7662&t=SsGyfCvyZczvczk0-0)

### Demonstration <!--- (If not appropriate, remove this topic) -->
<!--- Include a screenshot or video showcasing a feature or fix implemented in this pull request. -->
