### PR TITLE
[ENGAGE-1392] - Fix widget gallery bugs

### DIFF
--- a/src/components/insights/drawers/DrawerConfigContentCard.vue
+++ b/src/components/insights/drawers/DrawerConfigContentCard.vue
@@ -220,6 +220,10 @@ export default {
         this.$emit('update-disable-primary-button', !newIsConfigValid);
       },
     },
+
+    'config.flow'() {
+      this.config.result.name = [this.flowResultsOptionsPlaceholder];
+    },
   },
 
   mounted() {

--- a/src/components/insights/drawers/DrawerConfigContentCard.vue
+++ b/src/components/insights/drawers/DrawerConfigContentCard.vue
@@ -221,7 +221,9 @@ export default {
       },
     },
 
-    'config.flow'() {
+    'config.flow'(_newFlow, oldFlow) {
+      if (!oldFlow.length) return;
+
       this.config.result.name = [this.flowResultsOptionsPlaceholder];
     },
   },

--- a/src/components/insights/drawers/DrawerConfigContentFunnel.vue
+++ b/src/components/insights/drawers/DrawerConfigContentFunnel.vue
@@ -82,7 +82,7 @@ export default {
         return metric;
       });
 
-      if (metricsToCompare.some((metric) => !metric.flow[0].value)) {
+      if (metricsToCompare.some((metric) => !metric.flow[0]?.value)) {
         return false;
       }
 

--- a/src/components/insights/drawers/DrawerConfigGallery/index.vue
+++ b/src/components/insights/drawers/DrawerConfigGallery/index.vue
@@ -64,6 +64,10 @@ export default {
   },
 
   computed: {
+    widgetConfigType() {
+      return this.widget.config?.type_result;
+    },
+
     galleryOptions() {
       const { $t } = this;
       function createOptions(optionKeys) {
@@ -88,6 +92,8 @@ export default {
     modelValue: {
       immediate: true,
       handler() {
+        this.setDrawerConfigType(this.widgetConfigType);
+
         if (!this.galleryOptions.length) {
           this.showDrawerConfigWidget = true;
         }
@@ -103,7 +109,10 @@ export default {
 
     setDrawerConfigType(value) {
       this.drawerConfigType = value;
-      this.showDrawerConfigWidget = true;
+
+      if (value) {
+        this.showDrawerConfigWidget = true;
+      }
     },
 
     goToGallery() {

--- a/src/components/insights/drawers/DrawerConfigWidgetDynamic.vue
+++ b/src/components/insights/drawers/DrawerConfigWidgetDynamic.vue
@@ -1,5 +1,6 @@
 <template>
   <form
+    class="drawer-config-widget-dynamic__form-container"
     @submit.prevent
     @keydown.enter.prevent
   >
@@ -301,6 +302,10 @@ export default {
 
 <style lang="scss" scoped>
 .drawer-config-widget-dynamic {
+  &__form-container {
+    position: absolute;
+  }
+
   &__content {
     display: grid;
     gap: $unnnic-spacing-sm;

--- a/src/components/insights/drawers/DrawerConfigWidgetDynamic.vue
+++ b/src/components/insights/drawers/DrawerConfigWidgetDynamic.vue
@@ -272,7 +272,7 @@ export default {
             widgetFunnelConfig: this.treatedWidget.config,
           });
         } else {
-          await this.getCurrentDashboardWidgetData(this.widget.uuid);
+          await this.getCurrentDashboardWidgetData(this.treatedWidget);
         }
 
         unnnic.unnnicCallAlert({

--- a/src/components/insights/drawers/DrawerConfigWidgetDynamic.vue
+++ b/src/components/insights/drawers/DrawerConfigWidgetDynamic.vue
@@ -209,6 +209,7 @@ export default {
         name: config.name,
         report_name: `${this.$t('drawers.config_card.total_flow_executions')} ${configuredFlow?.label}`,
         config: {
+          type_result: this.configType,
           operation:
             this.configType === 'executions'
               ? 'count'

--- a/src/components/insights/widgets/DynamicWidget.vue
+++ b/src/components/insights/widgets/DynamicWidget.vue
@@ -214,7 +214,7 @@ export default {
       if (this.$route.name === 'report') {
         await this.getWidgetReportData({ offset, limit, next });
       } else if (this.isConfigured) {
-        await this.getCurrentDashboardWidgetData(this.widget.uuid);
+        await this.getCurrentDashboardWidgetData(this.widget);
       }
 
       this.isRequestingData = false;


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
Some bugs were identified in the widget gallery that impacted the UX.

### Summary of Changes
- Added functionality of skip widget gallery if widget is configured;
- Only request widget data if it is configured;
- Clean card flow result when flow changes;
- Fix wrong gap in dashboard when opening widget configuration drawer.
