### PR TITLE
[ENGAGE-1415] - Fix treat new widget to config card data crossing

### DIFF
--- a/src/components/insights/drawers/DrawerConfigWidgetDynamic.vue
+++ b/src/components/insights/drawers/DrawerConfigWidgetDynamic.vue
@@ -206,14 +206,14 @@ export default {
     createCardWidget() {
       const { widget } = this;
       const selectedFlowLabel = this.projectFlows.find(
-        (flow) => flow.value === widget.config.flow.uuid,
+        (flow) => flow.value === widget.config?.flow?.uuid,
       )?.label;
       const hasReportName =
         this.configType === 'flow_result' &&
-        widget.config.operation === 'recurrence';
+        widget.config?.operation === 'recurrence';
 
       return {
-        name: widget.config.name,
+        name: widget.config?.name,
         ...(hasReportName
           ? {
               report_name: `${this.$t('drawers.config_card.total_flow_executions')} ${selectedFlowLabel}`,


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
It was not possible to configure new cards with data crossing.

### Summary of Changes
- Added optional chaining at objects in createCardWidget variable.

