### PR TITLE
[ENGAGE-1513] - Adjusts at config cards UX

### DIFF
--- a/__tests__/components/__snapshots__/CheckboxList.spec.js.snap
+++ b/__tests__/components/__snapshots__/CheckboxList.spec.js.snap
@@ -24,12 +24,12 @@ exports[`CheckboxList > should render label and list 1`] = `
         class="unnnic-checkbox-wrapper"
         data-testid="checkbox"
         data-v-2e73b81b=""
-        data-v-7fb32042=""
+        data-v-dd1b9fa3=""
       >
         <svg
           class="unnnic-icon unnnic-icon__size--md unnnic-icon-scheme--neutral-clean unnnic-checkbox disabled"
-          data-v-7fb32042=""
           data-v-930380cc=""
+          data-v-dd1b9fa3=""
           fill="none"
           height="40"
           viewBox="0 0 40 40"
@@ -49,7 +49,7 @@ exports[`CheckboxList > should render label and list 1`] = `
         <div
           class="unnnic-checkbox__label unnnic-checkbox__label__right unnnic-checkbox__label__md"
           data-testid="checkbox-text-right"
-          data-v-7fb32042=""
+          data-v-dd1b9fa3=""
         >
           Check 1
         </div>
@@ -63,12 +63,12 @@ exports[`CheckboxList > should render label and list 1`] = `
         class="unnnic-checkbox-wrapper"
         data-testid="checkbox"
         data-v-2e73b81b=""
-        data-v-7fb32042=""
+        data-v-dd1b9fa3=""
       >
         <svg
           class="unnnic-icon unnnic-icon__size--md unnnic--clickable unnnic-icon-scheme--neutral-clean unnnic-checkbox"
-          data-v-7fb32042=""
           data-v-930380cc=""
+          data-v-dd1b9fa3=""
           fill="none"
           height="40"
           viewBox="0 0 40 40"
@@ -88,7 +88,7 @@ exports[`CheckboxList > should render label and list 1`] = `
         <div
           class="unnnic-checkbox__label unnnic-checkbox__label__right unnnic-checkbox__label__md"
           data-testid="checkbox-text-right"
-          data-v-7fb32042=""
+          data-v-dd1b9fa3=""
         >
           Check 2
         </div>
@@ -102,12 +102,12 @@ exports[`CheckboxList > should render label and list 1`] = `
         class="unnnic-checkbox-wrapper"
         data-testid="checkbox"
         data-v-2e73b81b=""
-        data-v-7fb32042=""
+        data-v-dd1b9fa3=""
       >
         <svg
           class="unnnic-icon unnnic-icon__size--md unnnic--clickable unnnic-icon-scheme--brand-weni unnnic-checkbox"
-          data-v-7fb32042=""
           data-v-930380cc=""
+          data-v-dd1b9fa3=""
           fill="none"
           height="40"
           viewBox="0 0 40 40"
@@ -133,7 +133,7 @@ exports[`CheckboxList > should render label and list 1`] = `
         <div
           class="unnnic-checkbox__label unnnic-checkbox__label__right unnnic-checkbox__label__md"
           data-testid="checkbox-text-right"
-          data-v-7fb32042=""
+          data-v-dd1b9fa3=""
         >
           Check 3
         </div>

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@vueuse/core": "^10.11.0",
-    "@weni/unnnic-system": "^2.6.2",
+    "@weni/unnnic-system": "2.9.0",
     "axios": "^1.7.2",
     "chart.js": "^4.4.2",
     "chartjs-plugin-datalabels": "^2.2.0",

--- a/src/components/SelectEmojiButton.vue
+++ b/src/components/SelectEmojiButton.vue
@@ -22,6 +22,7 @@
     <UnnnicEmojiPicker
       v-show="isEmojiPickerOpen"
       returnName
+      :position="pickerPosition"
       @emoji-selected="handleInput"
       @close="closeEmojiPicker"
     />
@@ -37,6 +38,11 @@ export default {
     modelValue: {
       type: String,
       default: '',
+    },
+    pickerPosition: {
+      type: String,
+      default: 'top',
+      validator: (position) => ['top', 'bottom'].includes(position),
     },
   },
 

--- a/src/components/SelectEmojiButton.vue
+++ b/src/components/SelectEmojiButton.vue
@@ -4,7 +4,7 @@
       'select-emoji-button',
       { 'select-emoji-button--selected': !!modelValue },
     ]"
-    @click.stop="handleEmojiPicker"
+    @click.stop="handleEmoji"
   >
     <section
       v-if="modelValue"
@@ -61,12 +61,15 @@ export default {
     closeEmojiPicker() {
       this.isEmojiPickerOpen = false;
     },
-    handleEmojiPicker() {
-      if (this.isEmojiPickerOpen) {
-        this.closeEmojiPicker();
+    handleEmoji() {
+      if (this.selectedEmoji) {
+        this.$emit('update:model-value', '');
       } else {
-        this.openEmojiPicker();
+        this.toggleEmojiPicker();
       }
+    },
+    toggleEmojiPicker() {
+      this.isEmojiPickerOpen ? this.closeEmojiPicker() : this.openEmojiPicker();
     },
     handleInput(event) {
       this.$emit('update:model-value', event);

--- a/src/components/insights/drawers/DrawerConfigContentCard.vue
+++ b/src/components/insights/drawers/DrawerConfigContentCard.vue
@@ -12,7 +12,10 @@
     v-on="currentFormEvents"
   />
 
-  <SelectEmojiButton v-model="config.friendly_id" />
+  <SelectEmojiButton
+    v-model="config.friendly_id"
+    :pickerPosition="type === 'executions' ? 'bottom' : 'top'"
+  />
 
   <UnnnicButton
     :text="$t('drawers.reset_widget')"

--- a/src/components/insights/drawers/DrawerConfigGallery/index.vue
+++ b/src/components/insights/drawers/DrawerConfigGallery/index.vue
@@ -39,6 +39,8 @@ import { mapActions, mapState } from 'vuex';
 import GalleryOption from './GalleryOption.vue';
 import DrawerConfigWidgetDynamic from '../DrawerConfigWidgetDynamic.vue';
 
+import { clearDeepValues } from '@/utils/object.js';
+
 export default {
   name: 'DrawerConfigGallery',
 
@@ -112,6 +114,7 @@ export default {
   methods: {
     ...mapActions({
       getProjectFlows: 'project/getProjectFlows',
+      updateCurrentWidgetEditing: 'widgets/updateCurrentWidgetEditing',
     }),
 
     closeAllDrawers() {
@@ -124,6 +127,16 @@ export default {
 
       if (value) {
         this.showDrawerConfigWidget = true;
+      }
+
+      if (value !== this.widgetConfigType) {
+        const cleanWidget = {
+          ...this.widget,
+          name: '',
+          config: clearDeepValues(this.widget.config),
+        };
+
+        this.updateCurrentWidgetEditing(cleanWidget);
       }
     },
 

--- a/src/components/insights/drawers/DrawerConfigGallery/index.vue
+++ b/src/components/insights/drawers/DrawerConfigGallery/index.vue
@@ -1,6 +1,7 @@
 <template>
   <UnnnicDrawer
     v-if="galleryOptions.length && !showDrawerConfigWidget"
+    ref="unnnicDrawer"
     class="drawer-config-gallery"
     wide
     :title="$t('drawers.config_gallery.title')"
@@ -122,22 +123,36 @@ export default {
       this.$emit('close');
     },
 
-    setDrawerConfigType(value) {
-      this.drawerConfigType = value;
+    setDrawerConfigType(configType) {
+      this.drawerConfigType = configType;
 
-      if (value) {
+      if (configType) {
+        this.handleShowDrawerConfigWidget();
+      }
+
+      if (configType !== this.widgetConfigType) {
+        this.cleanCurrentWidget();
+      }
+    },
+
+    handleShowDrawerConfigWidget() {
+      if (this.$refs.unnnicDrawer) {
+        this.$refs.unnnicDrawer.transitionClose(() => {
+          this.showDrawerConfigWidget = true;
+        });
+      } else {
         this.showDrawerConfigWidget = true;
       }
+    },
 
-      if (value !== this.widgetConfigType) {
-        const cleanWidget = {
-          ...this.widget,
-          name: '',
-          config: clearDeepValues(this.widget.config),
-        };
+    cleanCurrentWidget() {
+      const cleanWidget = {
+        ...this.widget,
+        name: '',
+        config: clearDeepValues(this.widget.config),
+      };
 
-        this.updateCurrentWidgetEditing(cleanWidget);
-      }
+      this.updateCurrentWidgetEditing(cleanWidget);
     },
 
     goToGallery() {

--- a/src/components/insights/drawers/DrawerConfigWidgetDynamic.vue
+++ b/src/components/insights/drawers/DrawerConfigWidgetDynamic.vue
@@ -8,6 +8,7 @@
       ref="unnnicDrawer"
       class="drawer-config-widget-dynamic"
       wide
+      distinctCloseBack
       :modelValue="modelValue"
       :title="drawerProps?.title"
       :description="drawerProps?.description"
@@ -18,7 +19,8 @@
       :withoutOverlay="showModalResetWidget"
       @primary-button-click="updateWidgetConfig"
       @secondary-button-click="internalClose"
-      @close="configType ? $emit('back') : $emit('close')"
+      @close="$emit('close')"
+      @back="$emit('back')"
     >
       <template #content>
         <section class="drawer-config-widget-dynamic__content">

--- a/src/components/insights/drawers/DrawerForms/Card/FormDataCrossing/index.vue
+++ b/src/components/insights/drawers/DrawerForms/Card/FormDataCrossing/index.vue
@@ -84,6 +84,7 @@ export default {
           value: 'currency',
           selected: this.config?.currency,
           label: this.$t('drawers.config_card.checkbox.currency'),
+          disabled: this.config.operation === 'min',
         },
       ];
     },
@@ -107,6 +108,8 @@ export default {
           ...this.widgetConfig,
           ...newConfig,
         });
+
+        if (newConfig?.operation === 'min') this.config.currency = false;
       },
     },
 
@@ -114,10 +117,6 @@ export default {
       if (typeof oldFlow === 'object') {
         this.config.flow.result = '';
       }
-    },
-
-    'config?.operation'(newOperation) {
-      if (newOperation === 'recurrence') this.config.currency = false;
     },
 
     isValidForm: {

--- a/src/components/insights/drawers/DrawerForms/Card/FormFlowResult.vue
+++ b/src/components/insights/drawers/DrawerForms/Card/FormFlowResult.vue
@@ -91,17 +91,15 @@ export default {
           ...this.widgetConfig,
           ...newConfig,
         });
+
+        if (newConfig?.operation === 'recurrence') this.config.currency = false;
       },
     },
 
-    'config?.flow.uuid'(_newFlow, oldFlow) {
+    'config.flow?.uuid'(_newFlow, oldFlow) {
       if (typeof oldFlow === 'object') {
         this.config.flow.result = '';
       }
-    },
-
-    'config?.operation'(newOperation) {
-      if (newOperation === 'recurrence') this.config.currency = false;
     },
 
     isValidForm: {

--- a/src/utils/object.js
+++ b/src/utils/object.js
@@ -29,6 +29,7 @@ export function clearDeepValues(obj) {
     const clearValuesByTypeMap = {
       string: '',
       number: 0,
+      boolean: false,
     };
 
     const haveValueTypeAtMap =

--- a/yarn.lock
+++ b/yarn.lock
@@ -1356,10 +1356,10 @@
   resolved "https://registry.yarnpkg.com/@weni/eslint-config/-/eslint-config-1.0.3.tgz#ddd6420b3215218107ca26e3795251849a3c80be"
   integrity sha512-Te4vJZpwlR6cgwbkIKAKuUKhfcDuwgXPAZCoTu+/Tkhy2lo4/neo4j1fljv0yDAxvgLdHL6JvfGGaalUEJB38g==
 
-"@weni/unnnic-system@^2.6.2":
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/@weni/unnnic-system/-/unnnic-system-2.6.2.tgz#1e7177fe0524b28abb1bf85270fc9a6d00995416"
-  integrity sha512-gt5TohHZVfhkqLueS9UQquL02izDWvllMzb7fDbyk5ayjWW/bTErR/7KkBAdwTh2/Omo5SR/baEPxWgxqa1qjg==
+"@weni/unnnic-system@2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@weni/unnnic-system/-/unnnic-system-2.9.0.tgz#67234c8884ef960ec96943191aad34cc17c3373b"
+  integrity sha512-uNSLv87wMF2GwaF3j2W5ghhVK38gDesxCdo6C6eWNlcAjmpJOYIVXcsmBbjTtZmsxAlRBUCHiWut78pZX8As7w==
   dependencies:
     "@emoji-mart/data" "^1.1.2"
     "@vueuse/components" "^10.4.1"


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
The UX of config cards can be improved.

### Summary of Changes
- Clear card fields when change gallery widget config type;
- Disable currency field when data crossing operation is 'min';
- Clear selected emoji when click if if it already has emoji;
- Separate drawer config dynamic close and back actions;
- Open emoji picker at bottom when config is executions type.
