### PR TITLE
[ENGAGE-1737] - Blank selected flow result on edit widget config

### DIFF
--- a/src/components/insights/drawers/DrawerForms/Card/FormFlowResult.vue
+++ b/src/components/insights/drawers/DrawerForms/Card/FormFlowResult.vue
@@ -1,16 +1,14 @@
 <template>
   <SelectFlow
-    :modelValue="config.flow.uuid"
+    v-model="config.flow.uuid"
     data-test-id="select-flow"
-    @update:model-value="config.flow.uuid = $event"
   />
 
   <SelectFlowResult
-    :modelValue="config.flow.result"
+    v-model="config.flow.result"
     data-test-id="select-flow-result"
     :flow="config.flow?.uuid"
     :disabled="!config.flow?.uuid"
-    @update:model-value="config.flow.result = $event"
   />
 
   <RadioList

--- a/src/components/insights/drawers/DrawerForms/Card/__tests__/FormFlowResult.spec.js
+++ b/src/components/insights/drawers/DrawerForms/Card/__tests__/FormFlowResult.spec.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { flushPromises, mount } from '@vue/test-utils';
+import { mount } from '@vue/test-utils';
 import { createStore } from 'vuex';
 import FormFlowResult from '@/components/insights/drawers/DrawerForms/Card/FormFlowResult.vue';
 


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When opening a widget to edit its configuration, the result field was displayed blank, even if there was a previously selected value

### Summary of Changes
<!--- Describe your changes in detail -->
- Fix clean flow result logic
