### PR TITLE
[ENGAGE-2731] - Add 2 width compensation map value

### DIFF
--- a/src/components/insights/charts/HorizontalBarChart.vue
+++ b/src/components/insights/charts/HorizontalBarChart.vue
@@ -243,6 +243,7 @@ export default {
 
             const widthCompensationMap = {
               1: 30,
+              2: 38,
               3: 40,
               4: 50,
               5: 60,
@@ -253,7 +254,7 @@ export default {
 
             ctx.fillText(
               `| ${fullValues[index]}`,
-              startTextPosition + widthCompensationMap[valueCharCount] || 0,
+              startTextPosition + (widthCompensationMap[valueCharCount] || 0),
               dataPoint.y,
             );
           });


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [xt] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Due to the lack of horizontal compensation map for size 2, the number of times the answer was displayed in the incorrect place

### Summary of Changes
<!--- Describe your changes in detail -->
- Add 2 width compensation map value
