### PR TITLE
[ENGAGE-2879] - Fix dashboard view broken on delete favorite dashboard

### DIFF
--- a/src/components/insights/dashboards/ModalDeleteDashboard.vue
+++ b/src/components/insights/dashboards/ModalDeleteDashboard.vue
@@ -71,11 +71,18 @@ export default {
     },
     deleteDashboard() {
       this.loadingRequest = true;
+
       Dashboards.deleteDashboard(this.dashboard.uuid)
         .then(() => {
+          const hasDeletedDefaultDashboard = this.dashboard.is_default;
+
           this.setDashboards(
             this.dashboards.filter((item) => item.uuid !== this.dashboard.uuid),
           );
+
+          if (hasDeletedDefaultDashboard) {
+            this.dashboardDefault.is_default = true;
+          }
 
           unnnic.unnnicCallAlert({
             props: {

--- a/src/store/modules/dashboards.js
+++ b/src/store/modules/dashboards.js
@@ -170,7 +170,12 @@ export default {
   },
   getters: {
     dashboardDefault(state) {
-      return state.dashboards.find((dashboard) => dashboard.is_default);
+      return (
+        state.dashboards.find((dashboard) => dashboard.is_default) ||
+        state.dashboards.find(
+          (dashboard) => dashboard.name === 'human_service_dashboard.title',
+        )
+      );
     },
   },
 };


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When deleting a favorited dashboard, a problem occurred where no dashboard was found as a default for redirection, which caused an error on the screen that prevented any dashboard from being viewed.

### Summary of Changes
<!--- Describe your changes in detail -->
- Fix action to delete favorite dashboard, now, if this happens, the human service dashboard will be marked as favorite automatically