### PR TITLE
[ENGAGE-3258] Add status agent online to match figma

### DIFF
--- a/src/components/insights/widgets/HumanServiceAgentsTable/AgentStatus.vue
+++ b/src/components/insights/widgets/HumanServiceAgentsTable/AgentStatus.vue
@@ -5,6 +5,12 @@
       size="avatar-nano"
       :class="statusClass"
     />
+    <span
+      v-if="label"
+      class="agent-status-label"
+    >
+      {{ label }}
+    </span>
   </section>
 </template>
 
@@ -16,6 +22,10 @@ const props = defineProps({
     type: String,
     required: true,
     validator: (value) => ['green', 'gray', 'orange'].includes(value),
+  },
+  label: {
+    type: String,
+    default: '',
   },
 });
 
@@ -31,7 +41,19 @@ const statusClass = computed(() => {
 .agent-status-container {
   display: flex;
   gap: $unnnic-spacing-nano;
-  align-items: end;
+  align-items: center;
+}
+
+.agent-status-label {
+  font-family: $unnnic-font-family-secondary;
+  color: $unnnic-color-neutral-dark;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  font-size: $unnnic-font-size-body-gt;
+  font-style: normal;
+  font-weight: $unnnic-font-weight-regular;
+  line-height: $unnnic-font-size-body-gt + $unnnic-line-height-md;
 }
 
 .agent-status {

--- a/src/components/insights/widgets/HumanServiceAgentsTable/AgentStatus.vue
+++ b/src/components/insights/widgets/HumanServiceAgentsTable/AgentStatus.vue
@@ -3,17 +3,27 @@
     <UnnnicIcon
       icon="indicator"
       size="avatar-nano"
-      :scheme="`feedback-${props.status?.toLowerCase() === 'green' ? 'green' : 'grey'}`"
+      :class="statusClass"
     />
   </section>
 </template>
 
 <script setup>
+import { computed } from 'vue';
+
 const props = defineProps({
   status: {
     type: String,
     required: true,
+    validator: (value) => ['green', 'gray', 'orange'].includes(value),
   },
+});
+
+const statusClass = computed(() => {
+  return {
+    'agent-status': true,
+    [`agent-status--${props.status}`]: true,
+  };
 });
 </script>
 
@@ -22,5 +32,25 @@ const props = defineProps({
   display: flex;
   gap: $unnnic-spacing-nano;
   align-items: end;
+}
+
+.agent-status {
+  &.agent-status--green {
+    :deep(.primary) {
+      fill: $unnnic-color-aux-green-300;
+    }
+  }
+
+  &.agent-status--gray {
+    :deep(.primary) {
+      fill: $unnnic-color-neutral-cleanest;
+    }
+  }
+
+  &.agent-status--orange {
+    :deep(.primary) {
+      fill: $unnnic-color-aux-orange-500;
+    }
+  }
 }
 </style>

--- a/src/components/insights/widgets/HumanServiceAgentsTable/index.vue
+++ b/src/components/insights/widgets/HumanServiceAgentsTable/index.vue
@@ -91,10 +91,15 @@ export default {
       if (!this.formattedHeaders?.length || !this.items?.length) return [];
 
       const formattedItems = this.items.map((item) => {
+        let label = null;
+        if (item.label && this.isExpansive) {
+          label = item.label;
+        }
+
         const baseContent = [
           {
             component: markRaw(AgentStatus),
-            props: { status: item.status },
+            props: { status: item.status, label },
             events: {},
           },
           String(item.agent),


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

- add logic to correct render status in widget mode and expansive mode

### Summary of Changes
<!--- Describe your changes in detail -->

- adjust status component
- adjust logic to render label

### Design Files <!--- (If not appropriate, remove this topic) -->
<!--- Links to the design files used for reference during implementation. -->

- [Design File 1](https://www.figma.com/design/q3ze1CoLGa8Att0fownmcj/Infracommerce?node-id=4384-1664&m=dev)

