### PR TITLE
[ENGAGE-3881] Adjust datalabels positioning

### DIFF
--- a/src/components/insights/charts/HorizontalBarChart.vue
+++ b/src/components/insights/charts/HorizontalBarChart.vue
@@ -219,7 +219,7 @@ export default {
           const {
             ctx,
             data: { datasets },
-            chartArea: { width },
+            chartArea: { width, left: chartLeftMargin },
           } = chart;
 
           ctx.save();
@@ -231,7 +231,9 @@ export default {
             ctx.font = 'bold 16px Lato';
             ctx.fillStyle = '#4E5666';
 
-            const startTextPosition = width + 100;
+            // chartLeftMargin is the margin between the chart and the left edge of the chart area (labels space)
+            // 4px is the margin between the chart and the text
+            const startTextPosition = width + chartLeftMargin + 4;
 
             ctx.fillText(
               `${data[index]} ${plugins.datalabelsSuffix}`,

--- a/src/components/insights/charts/__tests__/HorizontalBarChart.spec.js
+++ b/src/components/insights/charts/__tests__/HorizontalBarChart.spec.js
@@ -151,7 +151,7 @@ describe('HorizontalBarChart', () => {
     const mockChart = {
       ctx: mockCtx,
       data: { datasets: chartData.datasets },
-      chartArea: { width: 300 },
+      chartArea: { width: 300, left: 0 },
       getDatasetMeta: () => ({
         data: [{ y: 50 }, { y: 100 }],
       }),
@@ -165,11 +165,11 @@ describe('HorizontalBarChart', () => {
 
     expect(mockCtx.fillText).toHaveBeenCalledTimes(4);
 
-    expect(mockCtx.fillText).toHaveBeenCalledWith('75 %', 400, 50);
-    expect(mockCtx.fillText).toHaveBeenCalledWith('| 75', 438, 50);
+    expect(mockCtx.fillText).toHaveBeenCalledWith('75 %', 304, 50);
+    expect(mockCtx.fillText).toHaveBeenCalledWith('| 75', 342, 50);
 
-    expect(mockCtx.fillText).toHaveBeenCalledWith('25 %', 400, 100);
-    expect(mockCtx.fillText).toHaveBeenCalledWith('| 25', 438, 100);
+    expect(mockCtx.fillText).toHaveBeenCalledWith('25 %', 304, 100);
+    expect(mockCtx.fillText).toHaveBeenCalledWith('| 25', 342, 100);
   });
 
   it('should draw background rectangles correctly using horizontalBackgroundColorPlugin', async () => {


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Due to a problem in calculating the position of the labels, in some cases, their values ​​overlapped the quantity bar on the graph.

### Summary of Changes
<!--- Describe your changes in detail -->
- Fix datalabels position