### PR TITLE
[ENGAGE-4470] Widget csat and nps with loading

### DIFF
--- a/src/components/ProgressItem.vue
+++ b/src/components/ProgressItem.vue
@@ -1,15 +1,35 @@
 <template>
-  <section class="progress-item">
-    <section class="progress-item__container">
-      <p class="progress-item__text">{{ text }}</p>
+  <section
+    class="progress-item"
+    data-testid="progress-item"
+  >
+    <section
+      class="progress-item__container"
+      data-testid="progress-item-container"
+    >
+      <p
+        class="progress-item__text"
+        data-testid="progress-item-text"
+      >
+        {{ text }}
+      </p>
     </section>
-    <section class="progress-item__progress">
+    <section
+      class="progress-item__progress"
+      data-testid="progress-item-progress"
+    >
       <NativeProgress
         :progress="value"
         :backgroundColor="backgroundColor"
         :progressColor="progressColor"
+        data-testid="progress-item-native-progress"
       />
-      <p class="progress-item__progress__value">{{ value }}%</p>
+      <p
+        class="progress-item__progress__value"
+        data-testid="progress-item-value"
+      >
+        {{ value }}%
+      </p>
     </section>
   </section>
 </template>

--- a/src/components/ProgressItem.vue
+++ b/src/components/ProgressItem.vue
@@ -1,0 +1,81 @@
+<template>
+  <section class="progress-item">
+    <section class="progress-item__container">
+      <p class="progress-item__text">{{ text }}</p>
+    </section>
+    <section class="progress-item__progress">
+      <NativeProgress
+        :progress="value"
+        :backgroundColor="backgroundColor"
+        :progressColor="progressColor"
+      />
+      <p class="progress-item__progress__value">{{ value }}%</p>
+    </section>
+  </section>
+</template>
+
+<script setup lang="ts">
+import NativeProgress from './insights/charts/NativeProgress.vue';
+
+defineProps<{
+  text: string;
+  value: number;
+  progressColor?: string;
+  backgroundColor?: string;
+}>();
+</script>
+
+<style scoped lang="scss">
+.progress-item {
+  display: flex;
+  gap: $unnnic-spacing-xs;
+  justify-content: space-between;
+  padding: $unnnic-spacing-sm 0;
+  align-items: center;
+  align-self: stretch;
+
+  &__container {
+    display: flex;
+    align-items: center;
+    flex-direction: column;
+    justify-content: center;
+    height: 100%;
+  }
+
+  &__text {
+    flex: 2;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    flex-shrink: 0;
+    align-items: center;
+    color: $unnnic-color-neutral-darkest;
+    font-family: $unnnic-font-family-secondary;
+    font-size: $unnnic-font-size-body-lg;
+    font-style: normal;
+    font-weight: $unnnic-font-weight-regular;
+    line-height: $unnnic-font-size-body-lg + $unnnic-line-height-md;
+  }
+
+  &__progress {
+    flex: 8;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: $unnnic-spacing-xs;
+
+    &__value {
+      width: 50px;
+      flex-shrink: 0;
+      display: flex;
+      align-items: center;
+      color: $unnnic-color-neutral-dark;
+      font-family: $unnnic-font-family-secondary;
+      font-size: $unnnic-font-size-body-lg;
+      font-style: normal;
+      font-weight: $unnnic-font-weight-bold;
+      line-height: $unnnic-font-size-body-lg + $unnnic-line-height-md;
+    }
+  }
+}
+</style>

--- a/src/components/ProgressItem.vue
+++ b/src/components/ProgressItem.vue
@@ -3,17 +3,12 @@
     class="progress-item"
     data-testid="progress-item"
   >
-    <section
-      class="progress-item__container"
-      data-testid="progress-item-container"
+    <p
+      class="progress-item__text"
+      data-testid="progress-item-text"
     >
-      <p
-        class="progress-item__text"
-        data-testid="progress-item-text"
-      >
-        {{ text }}
-      </p>
-    </section>
+      {{ text }}
+    </p>
     <section
       class="progress-item__progress"
       data-testid="progress-item-progress"
@@ -54,21 +49,13 @@ defineProps<{
   align-items: center;
   align-self: stretch;
 
-  &__container {
-    display: flex;
-    align-items: center;
-    flex-direction: column;
-    justify-content: center;
-    height: 100%;
-  }
-
   &__text {
     flex: 2;
+    width: 180px;
     display: flex;
     flex-direction: column;
-    justify-content: center;
     flex-shrink: 0;
-    align-items: center;
+    align-items: flex-start;
     color: $unnnic-color-neutral-darkest;
     font-family: $unnnic-font-family-secondary;
     font-size: $unnnic-font-size-body-lg;

--- a/src/components/ShortTab.vue
+++ b/src/components/ShortTab.vue
@@ -1,0 +1,85 @@
+<template>
+  <section class="short-tab">
+    <div class="short-tab__tabs">
+      <button
+        v-for="(tab, index) in tabs"
+        :key="index"
+        :class="[
+          'short-tab__tab',
+          { 'short-tab__tab--active': activeTab === index },
+        ]"
+        @click="switchTab(index)"
+      >
+        {{ tab.name }}
+      </button>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { ref, defineEmits } from 'vue';
+interface Tab {
+  name: string;
+  key: string;
+}
+interface Props {
+  tabs: Tab[];
+  defaultTab?: number;
+}
+const props = withDefaults(defineProps<Props>(), {
+  defaultTab: 0,
+});
+const emit = defineEmits<{
+  (_e: 'tabChange', tab: string): void;
+}>();
+const activeTab = ref(props.defaultTab);
+const switchTab = (index: number) => {
+  if (index !== activeTab.value) {
+    activeTab.value = index;
+    emit('tabChange', props.tabs[index].key);
+  }
+};
+</script>
+
+<style lang="scss" scoped>
+.short-tab {
+  &__tabs {
+    display: flex;
+    gap: $unnnic-spacing-nano;
+    background-color: $unnnic-color-background-grass;
+    border-radius: $unnnic-border-radius-pill;
+    padding: $unnnic-spacing-nano;
+    align-items: center;
+  }
+  &__tab {
+    flex: 1;
+    padding: $unnnic-spacing-nano $unnnic-spacing-ant;
+    gap: 0.625rem;
+    justify-content: center;
+    align-items: center;
+    border: none;
+    border-radius: $unnnic-border-radius-pill;
+    background-color: $unnnic-color-background-grass;
+    color: $unnnic-color-neutral-cloudy;
+    font-family: $unnnic-font-family-secondary;
+    font-size: $unnnic-font-size-body-md;
+    font-weight: $unnnic-font-weight-regular;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    white-space: nowrap;
+    &:hover {
+      background-color: $unnnic-color-neutral-light;
+      color: $unnnic-color-neutral-dark;
+    }
+    &--active {
+      background-color: $unnnic-color-neutral-white;
+      color: $unnnic-color-neutral-dark;
+      transform: translateY(-1px);
+      &:hover {
+        background-color: $unnnic-color-neutral-white;
+        color: $unnnic-color-neutral-dark;
+      }
+    }
+  }
+}
+</style>

--- a/src/components/__tests__/ProgressItem.spec.js
+++ b/src/components/__tests__/ProgressItem.spec.js
@@ -1,0 +1,271 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mount, config } from '@vue/test-utils';
+
+import ProgressItem from '../ProgressItem.vue';
+
+config.global.plugins = [];
+
+const defaultProps = {
+  text: 'Test Progress',
+  value: 75,
+};
+
+const createWrapper = (props = {}) => {
+  return mount(ProgressItem, {
+    props: { ...defaultProps, ...props },
+  });
+};
+
+const expectElementExists = (wrapper, testId) => {
+  expect(wrapper.find(`[data-testid="${testId}"]`).exists()).toBe(true);
+};
+
+const expectElementText = (wrapper, testId, expectedText) => {
+  expect(wrapper.find(`[data-testid="${testId}"]`).text()).toBe(expectedText);
+};
+
+const expectElementClass = (wrapper, testId, expectedClass) => {
+  expect(wrapper.find(`[data-testid="${testId}"]`).classes()).toContain(
+    expectedClass,
+  );
+};
+
+describe('ProgressItem.vue', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = createWrapper();
+  });
+
+  describe('Component Structure', () => {
+    const requiredElements = [
+      'progress-item',
+      'progress-item-container',
+      'progress-item-text',
+      'progress-item-progress',
+      'progress-item-native-progress',
+      'progress-item-value',
+    ];
+
+    requiredElements.forEach((testId) => {
+      it(`should render ${testId} element`, () => {
+        expectElementExists(wrapper, testId);
+      });
+    });
+
+    it('should apply correct CSS classes', () => {
+      expectElementClass(wrapper, 'progress-item', 'progress-item');
+      expectElementClass(
+        wrapper,
+        'progress-item-container',
+        'progress-item__container',
+      );
+      expectElementClass(wrapper, 'progress-item-text', 'progress-item__text');
+      expectElementClass(
+        wrapper,
+        'progress-item-progress',
+        'progress-item__progress',
+      );
+      expectElementClass(
+        wrapper,
+        'progress-item-value',
+        'progress-item__progress__value',
+      );
+    });
+  });
+
+  describe('Content Rendering', () => {
+    it('should render text prop correctly', () => {
+      expectElementText(wrapper, 'progress-item-text', 'Test Progress');
+    });
+
+    it('should render value as percentage', () => {
+      expectElementText(wrapper, 'progress-item-value', '75%');
+    });
+
+    it('should render custom text when provided', async () => {
+      await wrapper.setProps({ text: 'Custom Progress Text' });
+      expectElementText(wrapper, 'progress-item-text', 'Custom Progress Text');
+    });
+
+    it('should render different value percentages', async () => {
+      const testValues = [0, 25, 50, 100];
+
+      for (const value of testValues) {
+        await wrapper.setProps({ value });
+        expectElementText(wrapper, 'progress-item-value', `${value}%`);
+      }
+    });
+  });
+
+  describe('NativeProgress Integration', () => {
+    it('should render NativeProgress component', () => {
+      const nativeProgress = wrapper.findComponent({
+        name: 'NativeProgress',
+      });
+      expect(nativeProgress.exists()).toBe(true);
+    });
+
+    it('should pass progress value to NativeProgress', () => {
+      const nativeProgress = wrapper.findComponent({
+        name: 'NativeProgress',
+      });
+      expect(nativeProgress.props('progress')).toBe(75);
+    });
+
+    it('should pass custom colors to NativeProgress when provided', async () => {
+      await wrapper.setProps({
+        progressColor: '#ff0000',
+        backgroundColor: '#00ff00',
+      });
+
+      const nativeProgress = wrapper.findComponent({
+        name: 'NativeProgress',
+      });
+      expect(nativeProgress.props('progressColor')).toBe('#ff0000');
+      expect(nativeProgress.props('backgroundColor')).toBe('#00ff00');
+    });
+
+    it('should handle undefined color props', () => {
+      const nativeProgress = wrapper.findComponent({
+        name: 'NativeProgress',
+      });
+
+      expect(nativeProgress.props('progressColor')).toBe('#007bff');
+      expect(nativeProgress.props('backgroundColor')).toBe('#e9ecef');
+    });
+  });
+
+  describe('Props Validation', () => {
+    const propsTests = [
+      { prop: 'text', value: 'New Text', expected: 'New Text' },
+      { prop: 'value', value: 90, expected: '90%' },
+      { prop: 'progressColor', value: '#blue' },
+      { prop: 'backgroundColor', value: '#gray' },
+    ];
+
+    propsTests.forEach(({ prop, value, expected }) => {
+      it(`should handle ${prop} prop correctly`, async () => {
+        await wrapper.setProps({ [prop]: value });
+
+        if (prop === 'text') {
+          expectElementText(wrapper, 'progress-item-text', expected);
+        } else if (prop === 'value') {
+          expectElementText(wrapper, 'progress-item-value', expected);
+          const nativeProgress = wrapper.findComponent({
+            name: 'NativeProgress',
+          });
+          expect(nativeProgress.props('progress')).toBe(value);
+        } else {
+          const nativeProgress = wrapper.findComponent({
+            name: 'NativeProgress',
+          });
+          expect(nativeProgress.props(prop)).toBe(value);
+        }
+      });
+    });
+  });
+
+  describe('Edge Cases', () => {
+    const edgeCaseTests = [
+      { value: 0, description: 'zero progress' },
+      { value: 100, description: 'full progress' },
+      { value: 0.5, description: 'decimal progress' },
+    ];
+
+    edgeCaseTests.forEach(({ value, description }) => {
+      it(`should handle ${description}`, async () => {
+        await wrapper.setProps({ value });
+        expectElementText(wrapper, 'progress-item-value', `${value}%`);
+
+        const nativeProgress = wrapper.findComponent({
+          name: 'NativeProgress',
+        });
+        expect(nativeProgress.props('progress')).toBe(value);
+      });
+    });
+
+    it('should handle long text', async () => {
+      const longText = 'Very long progress text that might overflow';
+      await wrapper.setProps({ text: longText });
+      expectElementText(wrapper, 'progress-item-text', longText);
+    });
+  });
+
+  describe('Component Integration', () => {
+    it('should render with all props provided', () => {
+      const fullPropsWrapper = createWrapper({
+        text: 'Complete Test',
+        value: 85,
+        progressColor: '#success',
+        backgroundColor: '#light',
+      });
+
+      expectElementText(
+        fullPropsWrapper,
+        'progress-item-text',
+        'Complete Test',
+      );
+      expectElementText(fullPropsWrapper, 'progress-item-value', '85%');
+
+      const nativeProgress = fullPropsWrapper.findComponent({
+        name: 'NativeProgress',
+      });
+      expect(nativeProgress.props('progress')).toBe(85);
+      expect(nativeProgress.props('progressColor')).toBe('#success');
+      expect(nativeProgress.props('backgroundColor')).toBe('#light');
+    });
+
+    it('should render with minimal props', () => {
+      const minimalWrapper = createWrapper({
+        text: 'Minimal',
+        value: 50,
+      });
+
+      expectElementExists(minimalWrapper, 'progress-item');
+      expectElementText(minimalWrapper, 'progress-item-text', 'Minimal');
+      expectElementText(minimalWrapper, 'progress-item-value', '50%');
+    });
+  });
+
+  describe('Reactivity', () => {
+    it('should update when props change', async () => {
+      expect(wrapper.vm.$props.text).toBe('Test Progress');
+      expect(wrapper.vm.$props.value).toBe(75);
+
+      await wrapper.setProps({
+        text: 'Updated Progress',
+        value: 90,
+        progressColor: '#updated',
+      });
+
+      expect(wrapper.vm.$props.text).toBe('Updated Progress');
+      expect(wrapper.vm.$props.value).toBe(90);
+      expect(wrapper.vm.$props.progressColor).toBe('#updated');
+
+      expectElementText(wrapper, 'progress-item-text', 'Updated Progress');
+      expectElementText(wrapper, 'progress-item-value', '90%');
+    });
+  });
+
+  describe('Component Lifecycle', () => {
+    it('should mount successfully', () => {
+      expect(wrapper.exists()).toBe(true);
+      expectElementExists(wrapper, 'progress-item');
+    });
+
+    it('should handle prop updates without errors', async () => {
+      const initialText = wrapper
+        .find('[data-testid="progress-item-text"]')
+        .text();
+
+      await wrapper.setProps({ text: 'Changed Text' });
+
+      const updatedText = wrapper
+        .find('[data-testid="progress-item-text"]')
+        .text();
+      expect(updatedText).not.toBe(initialText);
+      expect(updatedText).toBe('Changed Text');
+    });
+  });
+});

--- a/src/components/__tests__/ProgressItem.spec.js
+++ b/src/components/__tests__/ProgressItem.spec.js
@@ -40,7 +40,6 @@ describe('ProgressItem.vue', () => {
   describe('Component Structure', () => {
     const requiredElements = [
       'progress-item',
-      'progress-item-container',
       'progress-item-text',
       'progress-item-progress',
       'progress-item-native-progress',
@@ -55,11 +54,6 @@ describe('ProgressItem.vue', () => {
 
     it('should apply correct CSS classes', () => {
       expectElementClass(wrapper, 'progress-item', 'progress-item');
-      expectElementClass(
-        wrapper,
-        'progress-item-container',
-        'progress-item__container',
-      );
       expectElementClass(wrapper, 'progress-item-text', 'progress-item__text');
       expectElementClass(
         wrapper,

--- a/src/components/insights/cards/CardConversations.vue
+++ b/src/components/insights/cards/CardConversations.vue
@@ -9,7 +9,7 @@
   >
     <section class="card-conversations__title">
       <p
-        class="card-conversations__title-text"
+        class="card-conversations__text"
         data-testid="card-title"
       >
         {{ title }}
@@ -19,7 +19,7 @@
         enabled
         :text="tooltipInfo"
         side="left"
-        class="card-conversations__title-tooltip"
+        class="card-conversations__tooltip"
         data-testid="card-conversations-tooltip"
       >
         <UnnnicIcon
@@ -36,16 +36,16 @@
       class="card-conversations__content"
       data-testid="card-content"
     >
-      <section class="card-conversations__content-value">
+      <section class="card-conversations__value">
         <p
-          class="card-conversations__content-value-number"
+          class="card-conversations__number"
           data-testid="card-value"
         >
           {{ value }}
         </p>
         <p
           v-if="valueDescription"
-          class="card-conversations__content-value-description"
+          class="card-conversations__value-description"
           data-testid="card-value-description"
         >
           {{ valueDescription }}
@@ -53,7 +53,7 @@
       </section>
       <p
         v-if="description"
-        class="card-conversations__content-description"
+        class="card-conversations__description"
         data-testid="card-description"
       >
         {{ description }}
@@ -119,63 +119,63 @@ const props = defineProps<Props>();
     width: 100%;
     align-items: center;
     gap: $unnnic-spacing-sm;
+  }
 
-    &-text {
-      display: -webkit-box;
-      -webkit-box-orient: vertical;
-      -webkit-line-clamp: 1;
-      flex: 1 0 0;
-      overflow: hidden;
-      color: $unnnic-color-neutral-darkest;
-      text-overflow: ellipsis;
-      font-family: $unnnic-font-family-secondary;
-      font-size: $unnnic-font-size-body-lg;
-      font-style: normal;
-      font-weight: $unnnic-font-weight-regular;
-      line-height: $unnnic-font-size-body-lg + $unnnic-line-height-md;
-    }
+  &__text {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 1;
+    flex: 1 0 0;
+    overflow: hidden;
+    color: $unnnic-color-neutral-darkest;
+    text-overflow: ellipsis;
+    font-family: $unnnic-font-family-secondary;
+    font-size: $unnnic-font-size-body-lg;
+    font-style: normal;
+    font-weight: $unnnic-font-weight-regular;
+    line-height: $unnnic-font-size-body-lg + $unnnic-line-height-md;
+  }
 
-    &__info-icon {
-      cursor: help;
-    }
+  &__info-icon {
+    cursor: help;
   }
 
   &__content {
     display: flex;
     flex-direction: column;
+  }
 
-    &-value {
-      display: flex;
-      align-items: end;
-      gap: $unnnic-spacing-xs;
+  &__value {
+    display: flex;
+    align-items: end;
+    gap: $unnnic-spacing-xs;
+  }
 
-      &-number {
-        color: $unnnic-color-neutral-black;
-        font-family: $unnnic-font-family-secondary;
-        font-size: $unnnic-font-size-title-md;
-        font-style: normal;
-        font-weight: $unnnic-font-weight-bold;
-        line-height: $unnnic-font-size-title-md + $unnnic-line-height-md;
-      }
+  &__number {
+    color: $unnnic-color-neutral-black;
+    font-family: $unnnic-font-family-secondary;
+    font-size: $unnnic-font-size-title-md;
+    font-style: normal;
+    font-weight: $unnnic-font-weight-bold;
+    line-height: $unnnic-font-size-title-md + $unnnic-line-height-md;
+  }
 
-      &-description {
-        color: $unnnic-color-neutral-cloudy;
-        font-family: $unnnic-font-family-secondary;
-        font-size: $unnnic-font-size-body-lg;
-        font-style: normal;
-        font-weight: $unnnic-font-weight-bold;
-        line-height: $unnnic-font-size-body-lg + $unnnic-line-height-md;
-      }
-    }
+  &__value-description {
+    color: $unnnic-color-neutral-cloudy;
+    font-family: $unnnic-font-family-secondary;
+    font-size: $unnnic-font-size-body-lg;
+    font-style: normal;
+    font-weight: $unnnic-font-weight-bold;
+    line-height: $unnnic-font-size-body-lg + $unnnic-line-height-md;
+  }
 
-    &-description {
-      color: $unnnic-color-neutral-cloudy;
-      font-family: $unnnic-font-family-secondary;
-      font-size: $unnnic-font-size-body-md;
-      font-style: normal;
-      font-weight: $unnnic-font-weight-regular;
-      line-height: $unnnic-font-size-body-md + $unnnic-line-height-md;
-    }
+  &__description {
+    color: $unnnic-color-neutral-cloudy;
+    font-family: $unnnic-font-family-secondary;
+    font-size: $unnnic-font-size-body-md;
+    font-style: normal;
+    font-weight: $unnnic-font-weight-regular;
+    line-height: $unnnic-font-size-body-md + $unnnic-line-height-md;
   }
 
   &__skeleton {

--- a/src/components/insights/cards/CardConversations.vue
+++ b/src/components/insights/cards/CardConversations.vue
@@ -1,0 +1,171 @@
+<template>
+  <section
+    v-if="!isLoading"
+    :class="[
+      'card-conversations',
+      `card-conversations--border-${props.borderRadius || 'full'}`,
+    ]"
+  >
+    <section class="card-conversations__title">
+      <p class="card-conversations__title-text">{{ title }}</p>
+      <UnnnicToolTip
+        v-if="tooltipInfo"
+        enabled
+        :text="tooltipInfo"
+        side="right"
+        class="card-conversations__title-tooltip"
+        data-test-id="card-conversations-tooltip"
+      >
+        <UnnnicIcon
+          data-test-id="card-conversations-info-icon"
+          class="card-conversations__info-icon"
+          icon="info"
+          size="sm"
+          filled
+          scheme="neutral-cleanest"
+        />
+      </UnnnicToolTip>
+    </section>
+    <section class="card-conversations__content">
+      <section class="card-conversations__content-value">
+        <p class="card-conversations__content-value-number">
+          {{ value }}
+        </p>
+        <p
+          v-if="valueDescription"
+          class="card-conversations__content-value-description"
+        >
+          {{ valueDescription }}
+        </p>
+      </section>
+      <p
+        v-if="description"
+        class="card-conversations__content-description"
+      >
+        {{ description }}
+      </p>
+    </section>
+  </section>
+  <UnnnicSkeletonLoading
+    v-if="isLoading"
+    class="card-conversations__skeleton"
+    :width="`100%`"
+    height="134px"
+  />
+</template>
+
+<script setup lang="ts">
+interface Props {
+  title: string;
+  value: string;
+  borderRadius?: 'full' | 'left' | 'right' | 'none';
+  valueDescription?: string;
+  description?: string;
+  tooltipInfo?: string;
+  isLoading?: boolean;
+}
+
+const props = defineProps<Props>();
+</script>
+
+<style scoped lang="scss">
+.card-conversations {
+  display: flex;
+  padding: $unnnic-spacing-md;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: $unnnic-spacing-xs;
+  flex: 1 0 0;
+  align-self: stretch;
+
+  border: 1px solid $unnnic-color-neutral-soft;
+  background: #fff;
+
+  &--border-full {
+    border-radius: $unnnic-border-radius-md;
+  }
+
+  &--border-left {
+    border-radius: $unnnic-border-radius-md 0 0 $unnnic-border-radius-md;
+  }
+
+  &--border-right {
+    border-radius: 0 $unnnic-border-radius-md $unnnic-border-radius-md 0;
+    border-left: none;
+  }
+
+  &--border-none {
+    border-radius: 0;
+    border-left: none;
+  }
+
+  &__title {
+    display: flex;
+    width: 100%;
+    align-items: center;
+    gap: $unnnic-spacing-sm;
+
+    &-text {
+      display: -webkit-box;
+      -webkit-box-orient: vertical;
+      -webkit-line-clamp: 1;
+      flex: 1 0 0;
+      overflow: hidden;
+      color: $unnnic-color-neutral-darkest;
+      text-overflow: ellipsis;
+      font-family: $unnnic-font-family-secondary;
+      font-size: $unnnic-font-size-body-lg;
+      font-style: normal;
+      font-weight: $unnnic-font-weight-regular;
+      line-height: $unnnic-font-size-body-lg + $unnnic-line-height-md;
+    }
+
+    &__info-icon {
+      cursor: help;
+    }
+  }
+
+  &__content {
+    display: flex;
+    flex-direction: column;
+
+    &-value {
+      display: flex;
+      align-items: end;
+      gap: $unnnic-spacing-xs;
+
+      &-number {
+        color: $unnnic-color-neutral-black;
+        font-family: $unnnic-font-family-secondary;
+        font-size: $unnnic-font-size-title-md;
+        font-style: normal;
+        font-weight: $unnnic-font-weight-bold;
+        line-height: $unnnic-font-size-title-md + $unnnic-line-height-md;
+      }
+
+      &-description {
+        color: $unnnic-color-neutral-cloudy;
+        font-family: $unnnic-font-family-secondary;
+        font-size: $unnnic-font-size-body-lg;
+        font-style: normal;
+        font-weight: $unnnic-font-weight-bold;
+        line-height: $unnnic-font-size-body-lg + $unnnic-line-height-md;
+      }
+    }
+
+    &-description {
+      color: $unnnic-color-neutral-cloudy;
+      font-family: $unnnic-font-family-secondary;
+      font-size: $unnnic-font-size-body-md;
+      font-style: normal;
+      font-weight: $unnnic-font-weight-regular;
+      line-height: $unnnic-font-size-body-md + $unnnic-line-height-md;
+    }
+  }
+
+  &__skeleton {
+    flex: 1;
+    align-self: stretch;
+  }
+}
+</style>

--- a/src/components/insights/cards/CardConversations.vue
+++ b/src/components/insights/cards/CardConversations.vue
@@ -18,7 +18,7 @@
         v-if="tooltipInfo"
         enabled
         :text="tooltipInfo"
-        side="right"
+        side="left"
         class="card-conversations__title-tooltip"
         data-testid="card-conversations-tooltip"
       >

--- a/src/components/insights/cards/CardConversations.vue
+++ b/src/components/insights/cards/CardConversations.vue
@@ -5,19 +5,25 @@
       'card-conversations',
       `card-conversations--border-${props.borderRadius || 'full'}`,
     ]"
+    data-testid="card-conversations"
   >
     <section class="card-conversations__title">
-      <p class="card-conversations__title-text">{{ title }}</p>
+      <p
+        class="card-conversations__title-text"
+        data-testid="card-title"
+      >
+        {{ title }}
+      </p>
       <UnnnicToolTip
         v-if="tooltipInfo"
         enabled
         :text="tooltipInfo"
         side="right"
         class="card-conversations__title-tooltip"
-        data-test-id="card-conversations-tooltip"
+        data-testid="card-conversations-tooltip"
       >
         <UnnnicIcon
-          data-test-id="card-conversations-info-icon"
+          data-testid="card-conversations-info-icon"
           class="card-conversations__info-icon"
           icon="info"
           size="sm"
@@ -26,14 +32,21 @@
         />
       </UnnnicToolTip>
     </section>
-    <section class="card-conversations__content">
+    <section
+      class="card-conversations__content"
+      data-testid="card-content"
+    >
       <section class="card-conversations__content-value">
-        <p class="card-conversations__content-value-number">
+        <p
+          class="card-conversations__content-value-number"
+          data-testid="card-value"
+        >
           {{ value }}
         </p>
         <p
           v-if="valueDescription"
           class="card-conversations__content-value-description"
+          data-testid="card-value-description"
         >
           {{ valueDescription }}
         </p>
@@ -41,6 +54,7 @@
       <p
         v-if="description"
         class="card-conversations__content-description"
+        data-testid="card-description"
       >
         {{ description }}
       </p>
@@ -51,6 +65,7 @@
     class="card-conversations__skeleton"
     :width="`100%`"
     height="134px"
+    data-testid="card-skeleton"
   />
 </template>
 

--- a/src/components/insights/cards/__tests__/CardConversations.spec.js
+++ b/src/components/insights/cards/__tests__/CardConversations.spec.js
@@ -105,19 +105,19 @@ describe('CardConversations.vue', () => {
       await wrapper.setProps({ tooltipInfo: 'Test Tooltip' });
 
       expect(
-        wrapper.find('[data-test-id="card-conversations-tooltip"]').exists(),
+        wrapper.find('[data-testid="card-conversations-tooltip"]').exists(),
       ).toBe(true);
       expect(
-        wrapper.find('[data-test-id="card-conversations-info-icon"]').exists(),
+        wrapper.find('[data-testid="card-conversations-info-icon"]').exists(),
       ).toBe(true);
     });
 
     it('should not render tooltip when tooltipInfo is not provided', () => {
       expect(
-        wrapper.find('[data-test-id="card-conversations-tooltip"]').exists(),
+        wrapper.find('[data-testid="card-conversations-tooltip"]').exists(),
       ).toBe(false);
       expect(
-        wrapper.find('[data-test-id="card-conversations-info-icon"]').exists(),
+        wrapper.find('[data-testid="card-conversations-info-icon"]').exists(),
       ).toBe(false);
     });
   });
@@ -185,7 +185,7 @@ describe('CardConversations.vue', () => {
         wrapper.find('[data-testid="card-value-description"]').text(),
       ).toBe(props.valueDescription);
       expect(
-        wrapper.find('[data-test-id="card-conversations-tooltip"]').exists(),
+        wrapper.find('[data-testid="card-conversations-tooltip"]').exists(),
       ).toBe(true);
       expect(
         wrapper.find('[data-testid="card-conversations"]').classes(),

--- a/src/components/insights/cards/__tests__/CardConversations.spec.js
+++ b/src/components/insights/cards/__tests__/CardConversations.spec.js
@@ -1,0 +1,209 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mount, config } from '@vue/test-utils';
+
+import CardConversations from '../CardConversations.vue';
+
+import { createI18n } from 'vue-i18n';
+import UnnnicSystem from '@/utils/plugins/UnnnicSystem';
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {},
+  },
+  fallbackWarn: false,
+  missingWarn: false,
+});
+
+config.global.plugins = [i18n];
+
+const defaultProps = {
+  title: 'Test Title',
+  value: '123',
+};
+
+const createWrapper = (props = {}) => {
+  return mount(CardConversations, {
+    global: { plugins: [UnnnicSystem] },
+    props: { ...defaultProps, ...props },
+  });
+};
+
+describe('CardConversations.vue', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = createWrapper();
+  });
+
+  describe('Loading State', () => {
+    it('should show skeleton loading when isLoading is true', async () => {
+      await wrapper.setProps({ isLoading: true });
+
+      expect(wrapper.find('[data-testid="card-skeleton"]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid="card-conversations"]').exists()).toBe(
+        false,
+      );
+    });
+
+    it('should hide skeleton loading when isLoading is false', () => {
+      expect(wrapper.find('[data-testid="card-skeleton"]').exists()).toBe(
+        false,
+      );
+      expect(wrapper.find('[data-testid="card-conversations"]').exists()).toBe(
+        true,
+      );
+    });
+  });
+
+  describe('Content Rendering', () => {
+    it('should render title and value correctly', () => {
+      expect(wrapper.find('[data-testid="card-title"]').text()).toBe(
+        'Test Title',
+      );
+      expect(wrapper.find('[data-testid="card-value"]').text()).toBe('123');
+    });
+
+    it('should render description when provided', async () => {
+      await wrapper.setProps({ description: 'Test Description' });
+
+      expect(wrapper.find('[data-testid="card-description"]').exists()).toBe(
+        true,
+      );
+      expect(wrapper.find('[data-testid="card-description"]').text()).toBe(
+        'Test Description',
+      );
+    });
+
+    it('should not render description when not provided', () => {
+      expect(wrapper.find('[data-testid="card-description"]').exists()).toBe(
+        false,
+      );
+    });
+
+    it('should render valueDescription when provided', async () => {
+      await wrapper.setProps({ valueDescription: 'Low' });
+
+      expect(
+        wrapper.find('[data-testid="card-value-description"]').exists(),
+      ).toBe(true);
+      expect(
+        wrapper.find('[data-testid="card-value-description"]').text(),
+      ).toBe('Low');
+    });
+
+    it('should not render valueDescription when not provided', () => {
+      expect(
+        wrapper.find('[data-testid="card-value-description"]').exists(),
+      ).toBe(false);
+    });
+  });
+
+  describe('Tooltip Functionality', () => {
+    it('should render tooltip when tooltipInfo is provided', async () => {
+      await wrapper.setProps({ tooltipInfo: 'Test Tooltip' });
+
+      expect(
+        wrapper.find('[data-test-id="card-conversations-tooltip"]').exists(),
+      ).toBe(true);
+      expect(
+        wrapper.find('[data-test-id="card-conversations-info-icon"]').exists(),
+      ).toBe(true);
+    });
+
+    it('should not render tooltip when tooltipInfo is not provided', () => {
+      expect(
+        wrapper.find('[data-test-id="card-conversations-tooltip"]').exists(),
+      ).toBe(false);
+      expect(
+        wrapper.find('[data-test-id="card-conversations-info-icon"]').exists(),
+      ).toBe(false);
+    });
+  });
+
+  describe('Border Radius Classes', () => {
+    const borderRadiusTests = [
+      {
+        borderRadius: 'full',
+        expectedClass: 'card-conversations--border-full',
+      },
+      {
+        borderRadius: 'left',
+        expectedClass: 'card-conversations--border-left',
+      },
+      {
+        borderRadius: 'right',
+        expectedClass: 'card-conversations--border-right',
+      },
+      {
+        borderRadius: 'none',
+        expectedClass: 'card-conversations--border-none',
+      },
+    ];
+
+    borderRadiusTests.forEach(({ borderRadius, expectedClass }) => {
+      it(`should apply ${expectedClass} class when borderRadius is ${borderRadius}`, async () => {
+        await wrapper.setProps({ borderRadius });
+
+        expect(
+          wrapper.find('[data-testid="card-conversations"]').classes(),
+        ).toContain(expectedClass);
+      });
+    });
+
+    it('should default to full border radius when not specified', () => {
+      expect(
+        wrapper.find('[data-testid="card-conversations"]').classes(),
+      ).toContain('card-conversations--border-full');
+    });
+  });
+
+  describe('Complete Integration', () => {
+    it('should render all elements when all props are provided', async () => {
+      const props = {
+        title: 'Complete Test',
+        value: '456',
+        description: 'Complete Description',
+        valueDescription: 'High',
+        tooltipInfo: 'Complete Tooltip',
+        borderRadius: 'left',
+      };
+
+      await wrapper.setProps(props);
+
+      expect(wrapper.find('[data-testid="card-title"]').text()).toBe(
+        props.title,
+      );
+      expect(wrapper.find('[data-testid="card-value"]').text()).toBe(
+        props.value,
+      );
+      expect(wrapper.find('[data-testid="card-description"]').text()).toBe(
+        props.description,
+      );
+      expect(
+        wrapper.find('[data-testid="card-value-description"]').text(),
+      ).toBe(props.valueDescription);
+      expect(
+        wrapper.find('[data-test-id="card-conversations-tooltip"]').exists(),
+      ).toBe(true);
+      expect(
+        wrapper.find('[data-testid="card-conversations"]').classes(),
+      ).toContain('card-conversations--border-left');
+    });
+
+    it('should render minimal elements when only required props are provided', () => {
+      expect(wrapper.find('[data-testid="card-title"]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid="card-value"]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid="card-description"]').exists()).toBe(
+        false,
+      );
+      expect(
+        wrapper.find('[data-testid="card-value-description"]').exists(),
+      ).toBe(false);
+      expect(
+        wrapper.find('[data-testid="card-conversations-tooltip"]').exists(),
+      ).toBe(false);
+    });
+  });
+});

--- a/src/components/insights/charts/NativeProgress.vue
+++ b/src/components/insights/charts/NativeProgress.vue
@@ -1,0 +1,61 @@
+<template>
+  <section
+    class="native-progress"
+    :style="containerStyles"
+    data-testid="native-progress"
+  >
+    <section
+      class="native-progress__bar"
+      :style="progressBarStyles"
+      data-testid="native-progress-bar"
+    />
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+interface Props {
+  progress: number;
+  progressColor?: string;
+  backgroundColor?: string;
+  height?: number;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  progress: 0,
+  progressColor: '#007bff',
+  backgroundColor: '#e9ecef',
+  height: 8,
+});
+
+const normalizedProgress = computed(() => {
+  return Math.max(0, Math.min(100, props.progress));
+});
+
+const containerStyles = computed(() => ({
+  backgroundColor: props.backgroundColor,
+  height: `${props.height}px`,
+}));
+
+const progressBarStyles = computed(() => ({
+  width: `${normalizedProgress.value}%`,
+  backgroundColor: props.progressColor,
+}));
+</script>
+
+<style scoped lang="scss">
+.native-progress {
+  width: 100%;
+  border-radius: 4px;
+  overflow: hidden;
+  position: relative;
+
+  &__bar {
+    height: 100%;
+    border-radius: inherit;
+    transition: width 0.3s ease-in-out;
+    position: relative;
+  }
+}
+</style>

--- a/src/components/insights/charts/__tests__/NativeProgress.spec.js
+++ b/src/components/insights/charts/__tests__/NativeProgress.spec.js
@@ -1,0 +1,229 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mount, config } from '@vue/test-utils';
+
+import NativeProgress from '../NativeProgress.vue';
+
+config.global.plugins = [];
+
+const defaultProps = {
+  progress: 50,
+};
+
+const createWrapper = (props = {}) => {
+  return mount(NativeProgress, {
+    props: { ...defaultProps, ...props },
+  });
+};
+
+const hexToRgb = (hex) => {
+  const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+  if (result) {
+    const r = parseInt(result[1], 16);
+    const g = parseInt(result[2], 16);
+    const b = parseInt(result[3], 16);
+    return `rgb(${r}, ${g}, ${b})`;
+  }
+  return hex;
+};
+
+const expectStyleProperty = (element, property, value) => {
+  const expectedValue =
+    property.includes('color') || property.includes('Color')
+      ? hexToRgb(value)
+      : value;
+  expect(element.style[property]).toBe(expectedValue);
+};
+
+const expectElementStyles = (wrapper, testId, expectedStyles) => {
+  const element = wrapper.find(`[data-testid="${testId}"]`).element;
+  Object.entries(expectedStyles).forEach(([property, value]) => {
+    expectStyleProperty(element, property, value);
+  });
+};
+
+describe('NativeProgress.vue', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = createWrapper();
+  });
+
+  describe('Component Structure', () => {
+    it('should render container and progress bar elements', () => {
+      expect(wrapper.find('[data-testid="native-progress"]').exists()).toBe(
+        true,
+      );
+      expect(wrapper.find('[data-testid="native-progress-bar"]').exists()).toBe(
+        true,
+      );
+    });
+
+    it('should apply correct CSS classes', () => {
+      const container = wrapper.find('[data-testid="native-progress"]');
+      const progressBar = wrapper.find('[data-testid="native-progress-bar"]');
+
+      expect(container.classes()).toContain('native-progress');
+      expect(progressBar.classes()).toContain('native-progress__bar');
+    });
+  });
+
+  describe('Default Props', () => {
+    const defaultValues = [
+      { prop: 'progressColor', expected: '#007bff' },
+      { prop: 'backgroundColor', expected: '#e9ecef' },
+      { prop: 'height', expected: 8 },
+    ];
+
+    defaultValues.forEach(({ prop, expected }) => {
+      it(`should have correct default value for ${prop}`, () => {
+        const testWrapper = createWrapper({ progress: 25 });
+        expect(testWrapper.props(prop)).toBe(expected);
+      });
+    });
+  });
+
+  describe('Progress Value Normalization', () => {
+    const progressTests = [
+      { input: 0, expected: 0, description: 'minimum value' },
+      { input: 50, expected: 50, description: 'normal value' },
+      { input: 100, expected: 100, description: 'maximum value' },
+      { input: -10, expected: 0, description: 'negative value' },
+      { input: 150, expected: 100, description: 'exceeding maximum' },
+    ];
+
+    progressTests.forEach(({ input, expected, description }) => {
+      it(`should normalize progress for ${description}`, () => {
+        const testWrapper = createWrapper({ progress: input });
+        expect(testWrapper.vm.normalizedProgress).toBe(expected);
+      });
+    });
+  });
+
+  describe('Style Calculations', () => {
+    it('should calculate container styles correctly', () => {
+      const testWrapper = createWrapper({
+        backgroundColor: '#f0f0f0',
+        height: 12,
+      });
+
+      const expectedStyles = {
+        backgroundColor: '#f0f0f0',
+        height: '12px',
+      };
+
+      expectElementStyles(testWrapper, 'native-progress', expectedStyles);
+    });
+
+    it('should calculate progress bar styles correctly', () => {
+      const testWrapper = createWrapper({
+        progress: 75,
+        progressColor: '#28a745',
+      });
+
+      const expectedStyles = {
+        width: '75%',
+        backgroundColor: '#28a745',
+      };
+
+      expectElementStyles(testWrapper, 'native-progress-bar', expectedStyles);
+    });
+  });
+
+  describe('Props Integration', () => {
+    it('should render with all custom props', () => {
+      const customProps = {
+        progress: 80,
+        progressColor: '#dc3545',
+        backgroundColor: '#f8f9fa',
+        height: 16,
+      };
+
+      const testWrapper = createWrapper(customProps);
+
+      expectElementStyles(testWrapper, 'native-progress', {
+        backgroundColor: '#f8f9fa',
+        height: '16px',
+      });
+
+      expectElementStyles(testWrapper, 'native-progress-bar', {
+        width: '80%',
+        backgroundColor: '#dc3545',
+      });
+    });
+
+    it('should update styles when props change', async () => {
+      await wrapper.setProps({ progress: 25, progressColor: '#ffc107' });
+
+      expectElementStyles(wrapper, 'native-progress-bar', {
+        width: '25%',
+        backgroundColor: '#ffc107',
+      });
+    });
+  });
+
+  describe('Edge Cases', () => {
+    const edgeCaseTests = [
+      {
+        progress: 0.5,
+        expected: '0.5%',
+        description: 'decimal progress value',
+      },
+      {
+        progress: 99.99,
+        expected: '99.99%',
+        description: 'high decimal progress value',
+      },
+    ];
+
+    edgeCaseTests.forEach(({ progress, expected, description }) => {
+      it(`should handle ${description}`, () => {
+        const testWrapper = createWrapper({ progress });
+        expectElementStyles(testWrapper, 'native-progress-bar', {
+          width: expected,
+        });
+      });
+    });
+  });
+
+  describe('Computed Properties Reactivity', () => {
+    it('should update computed properties when props change', async () => {
+      const vm = wrapper.vm;
+
+      expect(vm.normalizedProgress).toBe(50);
+      expect(vm.containerStyles.height).toBe('8px');
+      expect(vm.progressBarStyles.width).toBe('50%');
+
+      await wrapper.setProps({
+        progress: 75,
+        height: 10,
+        progressColor: '#success',
+      });
+
+      expect(vm.normalizedProgress).toBe(75);
+      expect(vm.containerStyles.height).toBe('10px');
+      expect(vm.progressBarStyles.width).toBe('75%');
+      expect(vm.progressBarStyles.backgroundColor).toBe('#success');
+    });
+  });
+
+  describe('Component Lifecycle', () => {
+    it('should mount successfully with minimal props', () => {
+      const minimalWrapper = createWrapper({ progress: 10 });
+
+      expect(minimalWrapper.exists()).toBe(true);
+      expect(
+        minimalWrapper.find('[data-testid="native-progress"]').exists(),
+      ).toBe(true);
+      expect(minimalWrapper.vm.normalizedProgress).toBe(10);
+    });
+
+    it('should handle prop updates without errors', async () => {
+      const initialProgress = wrapper.vm.normalizedProgress;
+
+      await wrapper.setProps({ progress: 90 });
+
+      expect(wrapper.vm.normalizedProgress).not.toBe(initialProgress);
+      expect(wrapper.vm.normalizedProgress).toBe(90);
+    });
+  });
+});

--- a/src/components/insights/conversations/DashboardCsat.vue
+++ b/src/components/insights/conversations/DashboardCsat.vue
@@ -1,0 +1,23 @@
+<template>
+  <ProgressWidget
+    title="CSAT"
+    :progressItems="[
+      { text: 'Promoters', value: 80 },
+      { text: 'Detractors', value: 20 },
+      { text: 'Passives', value: 10.2 },
+      { text: 'Passives', value: 25.5 },
+      { text: 'Passives', value: 10.2 },
+    ]"
+    footerText="1500 reviews"
+    :isLoading="false"
+    @tab-change="handleTabChange"
+  />
+</template>
+
+<script setup lang="ts">
+import ProgressWidget from '@/components/insights/widgets/ProgressWidget.vue';
+
+const handleTabChange = (tab: string) => {
+  console.log('tabChange CSAT   ', tab);
+};
+</script>

--- a/src/components/insights/conversations/DashboardHeader.vue
+++ b/src/components/insights/conversations/DashboardHeader.vue
@@ -8,7 +8,7 @@
       data-testid="dashboard-header"
     >
       <section
-        class="dashboard-conversational__header-left"
+        class="dashboard-conversational__cards"
         data-testid="dashboard-header-left"
       >
         <template
@@ -20,14 +20,13 @@
             :value="card.value"
             :description="card.description"
             :tooltipInfo="card.tooltipInfo"
-            :valueDescription="card.valueDescription"
             :borderRadius="getBorderRadius(index, cards.length)"
             :isLoading="card.isLoading"
           />
         </template>
       </section>
       <section
-        class="dashboard-conversational__header-right"
+        class="dashboard-conversational__summary"
         data-testid="dashboard-header-right"
       >
         <CardConversations
@@ -287,16 +286,16 @@ onMounted(() => {
     justify-content: space-between;
     align-items: center;
     gap: $unnnic-spacing-sm;
+  }
 
-    &-left {
-      display: flex;
-      flex: 8;
-    }
+  &__cards {
+    display: flex;
+    flex: 8;
+  }
 
-    &-right {
-      display: flex;
-      flex: 2;
-    }
+  &__summary {
+    display: flex;
+    flex: 2;
   }
 }
 </style>

--- a/src/components/insights/conversations/DashboardHeader.vue
+++ b/src/components/insights/conversations/DashboardHeader.vue
@@ -1,7 +1,16 @@
 <template>
-  <section class="dashboard-conversational">
-    <section class="dashboard-conversational__header">
-      <section class="dashboard-conversational__header-left">
+  <section
+    class="dashboard-conversational"
+    data-testid="dashboard-conversational"
+  >
+    <section
+      class="dashboard-conversational__header"
+      data-testid="dashboard-header"
+    >
+      <section
+        class="dashboard-conversational__header-left"
+        data-testid="dashboard-header-left"
+      >
         <template
           v-for="(card, index) in cards"
           :key="card.id"
@@ -17,7 +26,10 @@
           />
         </template>
       </section>
-      <section class="dashboard-conversational__header-right">
+      <section
+        class="dashboard-conversational__header-right"
+        data-testid="dashboard-header-right"
+      >
         <CardConversations
           :title="rightCard.title"
           :value="rightCard.value"

--- a/src/components/insights/conversations/DashboardHeader.vue
+++ b/src/components/insights/conversations/DashboardHeader.vue
@@ -1,0 +1,290 @@
+<template>
+  <section class="dashboard-conversational">
+    <section class="dashboard-conversational__header">
+      <section class="dashboard-conversational__header-left">
+        <template
+          v-for="(card, index) in cards"
+          :key="card.id"
+        >
+          <CardConversations
+            :title="card.title"
+            :value="card.value"
+            :description="card.description"
+            :tooltipInfo="card.tooltipInfo"
+            :valueDescription="card.valueDescription"
+            :borderRadius="getBorderRadius(index, cards.length)"
+            :isLoading="card.isLoading"
+          />
+        </template>
+      </section>
+      <section class="dashboard-conversational__header-right">
+        <CardConversations
+          :title="rightCard.title"
+          :value="rightCard.value"
+          :description="rightCard.description"
+          :tooltipInfo="rightCard.tooltipInfo"
+          :isLoading="rightCard.isLoading"
+        />
+      </section>
+    </section>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue';
+import CardConversations from '@/components/insights/cards/CardConversations.vue';
+import Unnnic from '@/utils/plugins/UnnnicSystem';
+import { useI18n } from 'vue-i18n';
+
+const { t } = useI18n();
+
+const mockApiCalls = {
+  async fetchTotalConversations() {
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+    return {
+      value: '48.179',
+      description: null,
+    };
+  },
+
+  async fetchResolvedConversations() {
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+    return {
+      value: '85.75%',
+      description: `41.313 ${t('conversations_dashboard.conversations')}`,
+    };
+  },
+
+  async fetchUnresolvedConversations() {
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+    return {
+      value: '5.25%',
+      description: `2.529 ${t('conversations_dashboard.conversations')}`,
+    };
+  },
+
+  async fetchUnengagedConversations() {
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+    return {
+      value: '9.00%',
+      description: `4.338 ${t('conversations_dashboard.conversations')}`,
+    };
+  },
+
+  async fetchTransferredConversations() {
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+    return {
+      value: '12.22%',
+      description: `5.887 ${t('conversations_dashboard.conversations')}`,
+    };
+  },
+};
+
+const cardsData = ref([
+  {
+    id: 'total_conversations',
+    value: '-',
+    description: null,
+    isLoading: true,
+  },
+  {
+    id: 'resolved',
+    value: '-',
+    description: null,
+    isLoading: true,
+  },
+  {
+    id: 'unresolved',
+    value: '-',
+    description: null,
+    isLoading: true,
+  },
+  {
+    id: 'unengaged',
+    value: '-',
+    description: null,
+    isLoading: true,
+  },
+]);
+
+const rightCardData = ref({
+  value: '-',
+  description: null,
+  isLoading: true,
+});
+
+const cards = computed(() => [
+  {
+    id: 'total_conversations',
+    title: t('conversations_dashboard.header.total'),
+    value: cardsData.value[0].value,
+    description: cardsData.value[0].description,
+    tooltipInfo: t('conversations_dashboard.header.tooltips.total'),
+    isLoading: cardsData.value[0].isLoading,
+  },
+  {
+    id: 'resolved',
+    title: t('conversations_dashboard.header.resolved'),
+    value: cardsData.value[1].value,
+    description: cardsData.value[1].description,
+    tooltipInfo: t('conversations_dashboard.header.tooltips.resolved'),
+    isLoading: cardsData.value[1].isLoading,
+  },
+  {
+    id: 'unresolved',
+    title: t('conversations_dashboard.header.unresolved'),
+    value: cardsData.value[2].value,
+    description: cardsData.value[2].description,
+    tooltipInfo: t('conversations_dashboard.header.tooltips.unresolved'),
+    isLoading: cardsData.value[2].isLoading,
+  },
+  {
+    id: 'unengaged',
+    title: t('conversations_dashboard.header.unengaged'),
+    value: cardsData.value[3].value,
+    description: cardsData.value[3].description,
+    tooltipInfo: t('conversations_dashboard.header.tooltips.unengaged'),
+    isLoading: cardsData.value[3].isLoading,
+  },
+]);
+
+const rightCard = computed(() => ({
+  title: t('conversations_dashboard.header.transferred'),
+  value: rightCardData.value.value,
+  description: rightCardData.value.description,
+  tooltipInfo: t('conversations_dashboard.header.tooltips.transferred'),
+  isLoading: rightCardData.value.isLoading,
+}));
+
+const getBorderRadius = (index: number, totalCards: number) => {
+  if (totalCards === 1) return 'full';
+  if (index === 0) return 'left';
+  if (index === totalCards - 1) return 'right';
+  return 'none';
+};
+
+const showErrorToast = () => {
+  Unnnic.unnnicCallAlert({
+    props: {
+      text: t('widgets.graph_funnel.error.title'),
+      type: 'error',
+    },
+    seconds: 5,
+  });
+};
+
+const loadCardData = async () => {
+  const loadTotalConversations = async () => {
+    try {
+      const totalData = await mockApiCalls.fetchTotalConversations();
+      cardsData.value[0].value = totalData.value;
+      cardsData.value[0].description = totalData.description;
+      cardsData.value[0].isLoading = false;
+    } catch (error) {
+      console.error('Error loading total conversations:', error);
+      cardsData.value[0].value = '--';
+      cardsData.value[0].description = null;
+      cardsData.value[0].isLoading = false;
+      showErrorToast();
+    }
+  };
+
+  const loadResolvedConversations = async () => {
+    try {
+      const resolvedData = await mockApiCalls.fetchResolvedConversations();
+      cardsData.value[1].value = resolvedData.value;
+      cardsData.value[1].description = resolvedData.description;
+      cardsData.value[1].isLoading = false;
+    } catch (error) {
+      console.error('Error loading resolved conversations:', error);
+      cardsData.value[1].value = '--';
+      cardsData.value[1].description = null;
+      cardsData.value[1].isLoading = false;
+      showErrorToast();
+    }
+  };
+
+  const loadUnresolvedConversations = async () => {
+    try {
+      const unresolvedData = await mockApiCalls.fetchUnresolvedConversations();
+      cardsData.value[2].value = unresolvedData.value;
+      cardsData.value[2].description = unresolvedData.description;
+      cardsData.value[2].isLoading = false;
+    } catch (error) {
+      console.error('Error loading unresolved conversations:', error);
+      cardsData.value[2].value = '--';
+      cardsData.value[2].description = null;
+      cardsData.value[2].isLoading = false;
+      showErrorToast();
+    }
+  };
+
+  const loadUnengagedConversations = async () => {
+    try {
+      const unengagedData = await mockApiCalls.fetchUnengagedConversations();
+      cardsData.value[3].value = unengagedData.value;
+      cardsData.value[3].description = unengagedData.description;
+      cardsData.value[3].isLoading = false;
+    } catch (error) {
+      console.error('Error loading unengaged conversations:', error);
+      cardsData.value[3].value = '--';
+      cardsData.value[3].description = null;
+      cardsData.value[3].isLoading = false;
+      showErrorToast();
+    }
+  };
+
+  const loadTransferredConversations = async () => {
+    try {
+      const transferredData =
+        await mockApiCalls.fetchTransferredConversations();
+      rightCardData.value.value = transferredData.value;
+      rightCardData.value.description = transferredData.description;
+      rightCardData.value.isLoading = false;
+    } catch (error) {
+      console.error('Error loading transferred conversations:', error);
+      rightCardData.value.value = '--';
+      rightCardData.value.description = null;
+      rightCardData.value.isLoading = false;
+      showErrorToast();
+    }
+  };
+
+  Promise.all([
+    loadTotalConversations(),
+    loadResolvedConversations(),
+    loadUnresolvedConversations(),
+    loadUnengagedConversations(),
+    loadTransferredConversations(),
+  ]);
+};
+
+onMounted(() => {
+  loadCardData();
+});
+</script>
+
+<style scoped lang="scss">
+.dashboard-conversational {
+  display: flex;
+  flex-direction: column;
+  gap: $unnnic-spacing-sm;
+
+  &__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: $unnnic-spacing-sm;
+
+    &-left {
+      display: flex;
+      flex: 8;
+    }
+
+    &-right {
+      display: flex;
+      flex: 2;
+    }
+  }
+}
+</style>

--- a/src/components/insights/conversations/DashboardNps.vue
+++ b/src/components/insights/conversations/DashboardNps.vue
@@ -1,0 +1,28 @@
+<template>
+  <ProgressWidget
+    title="NPS"
+    :card="{
+      title: 'Current Store',
+      value: '-33,6%',
+      valueDescription: '(Low)',
+      tooltipInfo: 'NPS',
+      isLoading: false,
+    }"
+    :progressItems="[
+      { text: 'Promoters', value: 80 },
+      { text: 'Detractors', value: 20 },
+      { text: 'Passives', value: 0 },
+    ]"
+    footerText="1500 reviews"
+    :isLoading="false"
+    @tab-change="handleTabChange"
+  />
+</template>
+
+<script setup lang="ts">
+import ProgressWidget from '@/components/insights/widgets/ProgressWidget.vue';
+
+const handleTabChange = (tab: string) => {
+  console.log('tabChange NPS   ', tab);
+};
+</script>

--- a/src/components/insights/conversations/__tests__/DashboardHeader.spec.js
+++ b/src/components/insights/conversations/__tests__/DashboardHeader.spec.js
@@ -1,0 +1,482 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mount, config } from '@vue/test-utils';
+
+import DashboardHeader from '../DashboardHeader.vue';
+
+import { createI18n } from 'vue-i18n';
+import UnnnicSystem from '@/utils/plugins/UnnnicSystem';
+
+vi.mock('@/utils/plugins/UnnnicSystem', () => ({
+  default: {
+    unnnicCallAlert: vi.fn(),
+  },
+}));
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      conversations_dashboard: {
+        conversations: 'conversations',
+        header: {
+          total: 'Total conversations',
+          resolved: 'Resolved',
+          unresolved: 'Unresolved',
+          unengaged: 'Unengaged',
+          transferred: 'Transferred to human support',
+          tooltips: {
+            total: 'Total number of conversations',
+            resolved: 'Conversations that were resolved',
+            unresolved: 'Conversations that were not resolved',
+            unengaged: 'Conversations where users did not engage',
+            transferred: 'Conversations transferred to human support',
+          },
+        },
+      },
+      widgets: {
+        graph_funnel: {
+          error: {
+            title: 'Error loading data',
+          },
+        },
+      },
+    },
+  },
+  fallbackWarn: false,
+  missingWarn: false,
+});
+
+config.global.plugins = [i18n];
+
+const createWrapper = () => {
+  return mount(DashboardHeader, {
+    global: { plugins: [UnnnicSystem] },
+  });
+};
+
+describe('DashboardHeader.vue', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    wrapper = createWrapper();
+  });
+
+  describe('Component Structure', () => {
+    it('should render dashboard structure correctly', () => {
+      expect(
+        wrapper.find('[data-testid="dashboard-conversational"]').exists(),
+      ).toBe(true);
+      expect(wrapper.find('[data-testid="dashboard-header"]').exists()).toBe(
+        true,
+      );
+      expect(
+        wrapper.find('[data-testid="dashboard-header-left"]').exists(),
+      ).toBe(true);
+      expect(
+        wrapper.find('[data-testid="dashboard-header-right"]').exists(),
+      ).toBe(true);
+    });
+
+    it('should render 4 cards in left section and 1 card in right section', () => {
+      const leftSection = wrapper.find('[data-testid="dashboard-header-left"]');
+      const rightSection = wrapper.find(
+        '[data-testid="dashboard-header-right"]',
+      );
+
+      expect(
+        leftSection.findAllComponents({ name: 'CardConversations' }),
+      ).toHaveLength(4);
+      expect(
+        rightSection.findAllComponents({ name: 'CardConversations' }),
+      ).toHaveLength(1);
+    });
+  });
+
+  describe('Initial Loading States', () => {
+    it('should show loading state for all cards initially', () => {
+      const allCards = wrapper.findAllComponents({ name: 'CardConversations' });
+
+      allCards.forEach((card) => {
+        expect(card.props('isLoading')).toBe(true);
+        expect(card.props('value')).toBe('-');
+      });
+    });
+
+    it('should display initial titles and tooltips correctly', () => {
+      const leftCards = wrapper
+        .find('[data-testid="dashboard-header-left"]')
+        .findAllComponents({ name: 'CardConversations' });
+      const rightCard = wrapper
+        .find('[data-testid="dashboard-header-right"]')
+        .findComponent({ name: 'CardConversations' });
+
+      expect(leftCards[0].props('title')).toBe('Total conversations');
+      expect(leftCards[1].props('title')).toBe('Resolved');
+      expect(leftCards[2].props('title')).toBe('Unresolved');
+      expect(leftCards[3].props('title')).toBe('Unengaged');
+      expect(rightCard.props('title')).toBe('Transferred to human support');
+    });
+  });
+
+  describe('Border Radius Logic', () => {
+    const borderRadiusTests = [
+      { index: 0, total: 4, expected: 'left' },
+      { index: 1, total: 4, expected: 'none' },
+      { index: 2, total: 4, expected: 'none' },
+      { index: 3, total: 4, expected: 'right' },
+      { index: 0, total: 1, expected: 'full' },
+    ];
+
+    borderRadiusTests.forEach(({ index, total, expected }) => {
+      it(`should apply ${expected} border radius for card ${index} of ${total}`, () => {
+        const vm = wrapper.vm;
+        expect(vm.getBorderRadius(index, total)).toBe(expected);
+      });
+    });
+  });
+
+  describe('API Loading and State Management', () => {
+    it('should handle successful API data loading', async () => {
+      const mockData = {
+        total: { value: '48.179', description: null },
+        resolved: { value: '85.75%', description: '41.313 conversations' },
+        unresolved: { value: '5.25%', description: '2.529 conversations' },
+        unengaged: { value: '9.00%', description: '4.338 conversations' },
+        transferred: { value: '12.22%', description: '5.887 conversations' },
+      };
+
+      wrapper.vm.cardsData[0] = {
+        ...wrapper.vm.cardsData[0],
+        ...mockData.total,
+        isLoading: false,
+      };
+      wrapper.vm.cardsData[1] = {
+        ...wrapper.vm.cardsData[1],
+        ...mockData.resolved,
+        isLoading: false,
+      };
+      wrapper.vm.cardsData[2] = {
+        ...wrapper.vm.cardsData[2],
+        ...mockData.unresolved,
+        isLoading: false,
+      };
+      wrapper.vm.cardsData[3] = {
+        ...wrapper.vm.cardsData[3],
+        ...mockData.unengaged,
+        isLoading: false,
+      };
+      wrapper.vm.rightCardData = {
+        ...wrapper.vm.rightCardData,
+        ...mockData.transferred,
+        isLoading: false,
+      };
+
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.vm.cardsData[0].value).toBe('48.179');
+      expect(wrapper.vm.cardsData[1].value).toBe('85.75%');
+      expect(wrapper.vm.cardsData[2].value).toBe('5.25%');
+      expect(wrapper.vm.cardsData[3].value).toBe('9.00%');
+      expect(wrapper.vm.rightCardData.value).toBe('12.22%');
+
+      expect(wrapper.vm.cardsData[0].isLoading).toBe(false);
+      expect(wrapper.vm.rightCardData.isLoading).toBe(false);
+    });
+
+    it('should handle API errors with error toast and fallback values', async () => {
+      const consoleSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      wrapper.vm.cardsData[0] = {
+        ...wrapper.vm.cardsData[0],
+        value: '--',
+        description: null,
+        isLoading: false,
+      };
+      wrapper.vm.cardsData[1] = {
+        ...wrapper.vm.cardsData[1],
+        value: '--',
+        description: null,
+        isLoading: false,
+      };
+      wrapper.vm.cardsData[2] = {
+        ...wrapper.vm.cardsData[2],
+        value: '--',
+        description: null,
+        isLoading: false,
+      };
+      wrapper.vm.cardsData[3] = {
+        ...wrapper.vm.cardsData[3],
+        value: '--',
+        description: null,
+        isLoading: false,
+      };
+      wrapper.vm.rightCardData = {
+        ...wrapper.vm.rightCardData,
+        value: '--',
+        description: null,
+        isLoading: false,
+      };
+
+      wrapper.vm.showErrorToast();
+
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.vm.cardsData[0].value).toBe('--');
+      expect(wrapper.vm.cardsData[1].value).toBe('--');
+      expect(wrapper.vm.cardsData[2].value).toBe('--');
+      expect(wrapper.vm.cardsData[3].value).toBe('--');
+      expect(wrapper.vm.rightCardData.value).toBe('--');
+
+      expect(UnnnicSystem.unnnicCallAlert).toHaveBeenCalledWith({
+        props: {
+          text: 'Error loading data',
+          type: 'error',
+        },
+        seconds: 5,
+      });
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should handle mixed success and error scenarios', async () => {
+      const consoleSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      wrapper.vm.cardsData[0] = {
+        ...wrapper.vm.cardsData[0],
+        value: '48.179',
+        isLoading: false,
+      };
+      wrapper.vm.cardsData[1] = {
+        ...wrapper.vm.cardsData[1],
+        value: '--',
+        isLoading: false,
+      };
+      wrapper.vm.cardsData[2] = {
+        ...wrapper.vm.cardsData[2],
+        value: '5.25%',
+        isLoading: false,
+      };
+      wrapper.vm.cardsData[3] = {
+        ...wrapper.vm.cardsData[3],
+        value: '--',
+        isLoading: false,
+      };
+      wrapper.vm.rightCardData = {
+        ...wrapper.vm.rightCardData,
+        value: '12.22%',
+        isLoading: false,
+      };
+
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.vm.cardsData[0].value).toBe('48.179');
+      expect(wrapper.vm.cardsData[1].value).toBe('--');
+      expect(wrapper.vm.cardsData[2].value).toBe('5.25%');
+      expect(wrapper.vm.cardsData[3].value).toBe('--');
+      expect(wrapper.vm.rightCardData.value).toBe('12.22%');
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should test loading state transitions', async () => {
+      expect(wrapper.vm.cardsData[0].isLoading).toBe(true);
+      expect(wrapper.vm.rightCardData.isLoading).toBe(true);
+
+      wrapper.vm.cardsData[0].isLoading = false;
+      wrapper.vm.rightCardData.isLoading = false;
+
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.vm.cardsData[0].isLoading).toBe(false);
+      expect(wrapper.vm.rightCardData.isLoading).toBe(false);
+    });
+  });
+
+  describe('Computed Properties Reactivity', () => {
+    it('should reactively compute card properties', async () => {
+      const vm = wrapper.vm;
+
+      expect(vm.cards).toHaveLength(4);
+      expect(vm.rightCard).toBeDefined();
+
+      vm.cards.forEach((card) => {
+        expect(card).toHaveProperty('id');
+        expect(card).toHaveProperty('title');
+        expect(card).toHaveProperty('value');
+        expect(card).toHaveProperty('description');
+        expect(card).toHaveProperty('tooltipInfo');
+        expect(card).toHaveProperty('isLoading');
+      });
+    });
+
+    it('should update translations when locale changes', async () => {
+      const vm = wrapper.vm;
+      const initialTitle = vm.cards[0].title;
+
+      i18n.global.locale = 'es';
+      await wrapper.vm.$nextTick();
+
+      i18n.global.locale = 'en';
+      await wrapper.vm.$nextTick();
+
+      expect(vm.cards[0].title).toBe(initialTitle);
+    });
+  });
+
+  describe('Translation Coverage', () => {
+    it('should display translated tooltips correctly', () => {
+      const leftCards = wrapper
+        .find('[data-testid="dashboard-header-left"]')
+        .findAllComponents({ name: 'CardConversations' });
+      const rightCard = wrapper
+        .find('[data-testid="dashboard-header-right"]')
+        .findComponent({ name: 'CardConversations' });
+
+      expect(leftCards[0].props('tooltipInfo')).toBe(
+        'Total number of conversations',
+      );
+      expect(leftCards[1].props('tooltipInfo')).toBe(
+        'Conversations that were resolved',
+      );
+      expect(leftCards[2].props('tooltipInfo')).toBe(
+        'Conversations that were not resolved',
+      );
+      expect(leftCards[3].props('tooltipInfo')).toBe(
+        'Conversations where users did not engage',
+      );
+      expect(rightCard.props('tooltipInfo')).toBe(
+        'Conversations transferred to human support',
+      );
+    });
+  });
+
+  describe('Integration Testing', () => {
+    it('should handle complete component lifecycle', async () => {
+      expect(
+        wrapper.find('[data-testid="dashboard-conversational"]').exists(),
+      ).toBe(true);
+
+      const allCards = wrapper.findAllComponents({ name: 'CardConversations' });
+      expect(allCards).toHaveLength(5);
+
+      allCards.forEach((card) => {
+        expect(card.props('title')).toBeDefined();
+        expect(card.props('value')).toBeDefined();
+        expect(card.props('tooltipInfo')).toBeDefined();
+      });
+    });
+
+    it('should apply correct border radius to left section cards', () => {
+      const leftCards = wrapper
+        .find('[data-testid="dashboard-header-left"]')
+        .findAllComponents({ name: 'CardConversations' });
+
+      expect(leftCards[0].props('borderRadius')).toBe('left');
+      expect(leftCards[1].props('borderRadius')).toBe('none');
+      expect(leftCards[2].props('borderRadius')).toBe('none');
+      expect(leftCards[3].props('borderRadius')).toBe('right');
+    });
+
+    it('should not apply border radius to right section card', () => {
+      const rightCard = wrapper
+        .find('[data-testid="dashboard-header-right"]')
+        .findComponent({ name: 'CardConversations' });
+
+      expect(rightCard.props('borderRadius')).toBeUndefined();
+    });
+  });
+
+  describe('Mock API Functions', () => {
+    it('should test mockApiCalls structure', () => {
+      const vm = wrapper.vm;
+      expect(vm.mockApiCalls).toBeDefined();
+      expect(vm.mockApiCalls.fetchTotalConversations).toBeDefined();
+      expect(vm.mockApiCalls.fetchResolvedConversations).toBeDefined();
+      expect(vm.mockApiCalls.fetchUnresolvedConversations).toBeDefined();
+      expect(vm.mockApiCalls.fetchUnengagedConversations).toBeDefined();
+      expect(vm.mockApiCalls.fetchTransferredConversations).toBeDefined();
+    });
+
+    it('should test loadCardData function exists', () => {
+      const vm = wrapper.vm;
+      expect(vm.loadCardData).toBeDefined();
+      expect(typeof vm.loadCardData).toBe('function');
+    });
+
+    it('should test showErrorToast function', () => {
+      const vm = wrapper.vm;
+      expect(vm.showErrorToast).toBeDefined();
+      expect(typeof vm.showErrorToast).toBe('function');
+
+      vm.showErrorToast();
+      expect(UnnnicSystem.unnnicCallAlert).toHaveBeenCalled();
+    });
+  });
+
+  describe('Component Lifecycle', () => {
+    it('should mount component successfully', () => {
+      const testWrapper = createWrapper();
+
+      expect(testWrapper.exists()).toBe(true);
+      expect(
+        testWrapper.find('[data-testid="dashboard-conversational"]').exists(),
+      ).toBe(true);
+
+      expect(testWrapper.vm.cardsData).toHaveLength(4);
+      expect(testWrapper.vm.rightCardData).toBeDefined();
+    });
+  });
+
+  describe('Enhanced Border Radius Coverage', () => {
+    it('should handle edge cases for getBorderRadius', () => {
+      const vm = wrapper.vm;
+
+      expect(vm.getBorderRadius(0, 0)).toBe('left');
+
+      expect(vm.getBorderRadius(0, 1)).toBe('full');
+
+      expect(vm.getBorderRadius(0, 2)).toBe('left');
+      expect(vm.getBorderRadius(1, 2)).toBe('right');
+
+      expect(vm.getBorderRadius(0, 3)).toBe('left');
+      expect(vm.getBorderRadius(1, 3)).toBe('none');
+      expect(vm.getBorderRadius(2, 3)).toBe('right');
+    });
+  });
+
+  describe('Data Mutation Coverage', () => {
+    it('should handle direct data mutations', async () => {
+      const vm = wrapper.vm;
+
+      vm.cardsData[0].value = 'test-value';
+      vm.cardsData[0].description = 'test-description';
+      vm.cardsData[0].isLoading = false;
+
+      await wrapper.vm.$nextTick();
+
+      expect(vm.cardsData[0].value).toBe('test-value');
+      expect(vm.cardsData[0].description).toBe('test-description');
+      expect(vm.cardsData[0].isLoading).toBe(false);
+    });
+
+    it('should handle rightCardData mutations', async () => {
+      const vm = wrapper.vm;
+
+      vm.rightCardData.value = 'right-test-value';
+      vm.rightCardData.description = 'right-test-description';
+      vm.rightCardData.isLoading = false;
+
+      await wrapper.vm.$nextTick();
+
+      expect(vm.rightCardData.value).toBe('right-test-value');
+      expect(vm.rightCardData.description).toBe('right-test-description');
+      expect(vm.rightCardData.isLoading).toBe(false);
+    });
+  });
+});

--- a/src/components/insights/widgets/ProgressWidget.vue
+++ b/src/components/insights/widgets/ProgressWidget.vue
@@ -1,0 +1,176 @@
+<template>
+  <section
+    v-if="showProgressWidget"
+    class="progress-widget"
+    data-testid="progress-widget"
+  >
+    <section
+      class="progress-widget__header"
+      data-testid="progress-widget-header"
+    >
+      <p
+        class="progress-widget__header-title"
+        data-testid="progress-widget-title"
+      >
+        {{ title }}
+      </p>
+      <div
+        class="progress-widget__header__actions"
+        data-testid="progress-widget-actions"
+      >
+        <ShortTab
+          :tabs="tabs"
+          data-testid="progress-widget-tabs"
+          @tab-change="handleTabChange"
+        />
+      </div>
+    </section>
+    <section
+      class="progress-widget__content"
+      data-testid="progress-widget-content"
+    >
+      <section
+        v-if="card"
+        class="progress-widget__content__card"
+        data-testid="progress-widget-card"
+      >
+        <CardConversations
+          :title="card.title"
+          :value="card.value"
+          :valueDescription="card.valueDescription"
+          :tooltipInfo="card.tooltipInfo"
+          :isLoading="card.isLoading"
+        />
+      </section>
+      <ProgressItem
+        v-for="item in progressItems"
+        :key="item.text"
+        :text="item.text"
+        :value="item.value"
+        :backgroundColor="item.backgroundColor"
+        :color="item.color"
+        data-testid="progress-widget-progress-item"
+      />
+    </section>
+    <section
+      v-if="footerText"
+      class="progress-widget__footer"
+      data-testid="progress-widget-footer"
+    >
+      <p
+        class="progress-widget__footer-text"
+        data-testid="progress-widget-footer-text"
+      >
+        {{ footerText }}
+      </p>
+    </section>
+  </section>
+  <UnnnicSkeletonLoading
+    v-if="isLoading"
+    class="progress-widget__skeleton"
+    :width="`100%`"
+    height="450px"
+    data-testid="progress-widget-skeleton"
+  />
+</template>
+
+<script setup lang="ts">
+import ProgressItem from '@/components/ProgressItem.vue';
+import { defineProps, computed } from 'vue';
+import CardConversations from '@/components/insights/cards/CardConversations.vue';
+import ShortTab from '@/components/ShortTab.vue';
+
+const emit = defineEmits<{
+  (_e: 'tabChange', tab: string): void;
+}>();
+
+const props = defineProps<{
+  title: string;
+  card?: {
+    title: string;
+    value: string;
+    valueDescription: string;
+    tooltipInfo: string;
+    isLoading: boolean;
+  };
+  progressItems: {
+    text: string;
+    value: number;
+    backgroundColor?: string;
+    color?: string;
+  }[];
+  footerText?: string;
+  isLoading?: boolean;
+}>();
+
+const tabs = computed(() => [
+  {
+    name: 'IA',
+    key: 'intelligence-artificial',
+  },
+  {
+    name: 'Human support',
+    key: 'human-support',
+  },
+]);
+
+const showProgressWidget = computed(() => {
+  return !props.isLoading;
+});
+
+const handleTabChange = (tab: string) => {
+  emit('tabChange', tab);
+};
+</script>
+
+<style scoped lang="scss">
+.progress-widget {
+  width: 100%;
+  display: flex;
+  padding: $unnnic-spacing-md;
+  flex-direction: column;
+  gap: $unnnic-spacing-sm;
+  flex: 1 0 0;
+  align-self: stretch;
+
+  border-radius: $unnnic-spacing-xs;
+  border: 1px solid $unnnic-color-neutral-soft;
+  background: $unnnic-color-neutral-white;
+
+  &__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    &-title {
+      color: $unnnic-color-neutral-darkest;
+      font-family: $unnnic-font-family-secondary;
+      font-size: $unnnic-font-size-title-sm;
+      font-weight: $unnnic-font-weight-bold;
+      font-style: normal;
+      line-height: $unnnic-font-size-title-sm + $unnnic-line-height-md;
+    }
+  }
+
+  &__content {
+    &__card {
+      padding-bottom: $unnnic-spacing-sm;
+    }
+  }
+
+  &__footer {
+    display: flex;
+    justify-content: flex-start;
+    align-items: center;
+
+    &-text {
+      color: $unnnic-color-neutral-clean;
+      font-family: $unnnic-font-family-secondary;
+      font-size: $unnnic-font-size-body-gt;
+      font-weight: $unnnic-font-weight-regular;
+      font-style: normal;
+      line-height: $unnnic-font-size-body-gt + $unnnic-line-height-md;
+    }
+  }
+}
+</style>

--- a/src/components/insights/widgets/__tests__/ProgressWidget.spec.js
+++ b/src/components/insights/widgets/__tests__/ProgressWidget.spec.js
@@ -1,0 +1,258 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mount, config } from '@vue/test-utils';
+import { createI18n } from 'vue-i18n';
+import UnnnicSystem from '@/utils/plugins/UnnnicSystem';
+import ProgressWidget from '../ProgressWidget.vue';
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en: {} },
+  fallbackWarn: false,
+  missingWarn: false,
+});
+
+config.global.plugins = [i18n];
+
+const defaultProps = {
+  title: 'Test Progress Widget',
+  progressItems: [
+    { text: 'Item 1', value: 75, backgroundColor: '#f0f0f0', color: '#333' },
+    { text: 'Item 2', value: 50 },
+  ],
+};
+
+const createWrapper = (props = {}) => {
+  return mount(ProgressWidget, {
+    global: { plugins: [UnnnicSystem] },
+    props: { ...defaultProps, ...props },
+  });
+};
+
+const expectElementExists = (wrapper, testId, shouldExist = true) => {
+  expect(wrapper.find(`[data-testid="${testId}"]`).exists()).toBe(shouldExist);
+};
+
+const expectElementText = (wrapper, testId, expectedText) => {
+  expect(wrapper.find(`[data-testid="${testId}"]`).text()).toBe(expectedText);
+};
+
+describe('ProgressWidget.vue', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = createWrapper();
+  });
+
+  describe('Loading State', () => {
+    it('should show skeleton when isLoading is true', async () => {
+      await wrapper.setProps({ isLoading: true });
+
+      expectElementExists(wrapper, 'progress-widget-skeleton');
+      expectElementExists(wrapper, 'progress-widget', false);
+    });
+
+    it('should show content when isLoading is false', () => {
+      expectElementExists(wrapper, 'progress-widget-skeleton', false);
+      expectElementExists(wrapper, 'progress-widget');
+    });
+  });
+
+  describe('Content Rendering', () => {
+    it('should render title correctly', () => {
+      expectElementText(
+        wrapper,
+        'progress-widget-title',
+        'Test Progress Widget',
+      );
+    });
+
+    it('should render tabs with correct configuration', () => {
+      expectElementExists(wrapper, 'progress-widget-tabs');
+      expect(wrapper.vm.tabs).toEqual([
+        { name: 'IA', key: 'intelligence-artificial' },
+        { name: 'Human support', key: 'human-support' },
+      ]);
+    });
+
+    it('should render progress items', () => {
+      const progressItems = wrapper.findAll(
+        '[data-testid="progress-widget-progress-item"]',
+      );
+      expect(progressItems).toHaveLength(2);
+    });
+
+    it('should render card when provided', async () => {
+      const card = {
+        title: 'Card Title',
+        value: '123',
+        valueDescription: 'Low',
+        tooltipInfo: 'Test tooltip',
+        isLoading: false,
+      };
+
+      await wrapper.setProps({ card });
+
+      expectElementExists(wrapper, 'progress-widget-card');
+
+      const cardConversations = wrapper.findComponent({
+        name: 'CardConversations',
+      });
+      expect(cardConversations.exists()).toBe(true);
+      expect(cardConversations.props('title')).toBe('Card Title');
+      expect(cardConversations.props('value')).toBe('123');
+    });
+
+    it('should not render card when not provided', () => {
+      expectElementExists(wrapper, 'progress-widget-card', false);
+    });
+
+    it('should render footer when footerText is provided', async () => {
+      await wrapper.setProps({ footerText: 'Footer text' });
+
+      expectElementExists(wrapper, 'progress-widget-footer');
+      expectElementText(wrapper, 'progress-widget-footer-text', 'Footer text');
+    });
+
+    it('should not render footer when footerText is not provided', () => {
+      expectElementExists(wrapper, 'progress-widget-footer', false);
+    });
+  });
+
+  describe('Tab Functionality', () => {
+    it('should emit tabChange event when tab is changed', async () => {
+      const shortTab = wrapper.findComponent({ name: 'ShortTab' });
+      await shortTab.vm.$emit('tab-change', 'human-support');
+
+      expect(wrapper.emitted('tabChange')).toBeTruthy();
+      expect(wrapper.emitted('tabChange')[0]).toEqual(['human-support']);
+    });
+
+    it('should handle tab change correctly', async () => {
+      await wrapper.vm.handleTabChange('intelligence-artificial');
+
+      expect(wrapper.emitted('tabChange')).toBeTruthy();
+      expect(wrapper.emitted('tabChange')[0]).toEqual([
+        'intelligence-artificial',
+      ]);
+    });
+  });
+
+  describe('Props Integration', () => {
+    it('should render all elements when all props are provided', async () => {
+      const props = {
+        title: 'Complete Widget',
+        card: {
+          title: 'Complete Card',
+          value: '456',
+          valueDescription: 'High',
+          tooltipInfo: 'Complete tooltip',
+          isLoading: false,
+        },
+        progressItems: [
+          {
+            text: 'Complete Item',
+            value: 90,
+            backgroundColor: '#green',
+            color: '#white',
+          },
+        ],
+        footerText: 'Complete footer',
+        isLoading: false,
+      };
+
+      await wrapper.setProps(props);
+
+      expectElementText(wrapper, 'progress-widget-title', props.title);
+      expectElementExists(wrapper, 'progress-widget-card');
+      expectElementExists(wrapper, 'progress-widget-footer');
+      expectElementText(
+        wrapper,
+        'progress-widget-footer-text',
+        props.footerText,
+      );
+
+      const cardConversations = wrapper.findComponent({
+        name: 'CardConversations',
+      });
+      expect(cardConversations.exists()).toBe(true);
+      expect(cardConversations.props('title')).toBe('Complete Card');
+
+      const progressItems = wrapper.findAll(
+        '[data-testid="progress-widget-progress-item"]',
+      );
+      expect(progressItems).toHaveLength(1);
+    });
+
+    it('should render minimal elements when only required props are provided', () => {
+      const minimalWrapper = createWrapper({
+        title: 'Minimal Widget',
+        progressItems: [{ text: 'Minimal Item', value: 25 }],
+      });
+
+      expectElementExists(minimalWrapper, 'progress-widget-title');
+      expectElementExists(minimalWrapper, 'progress-widget-tabs');
+      expectElementExists(minimalWrapper, 'progress-widget-card', false);
+      expectElementExists(minimalWrapper, 'progress-widget-footer', false);
+
+      const progressItems = minimalWrapper.findAll(
+        '[data-testid="progress-widget-progress-item"]',
+      );
+      expect(progressItems).toHaveLength(1);
+    });
+  });
+
+  describe('Computed Properties', () => {
+    it('should compute showProgressWidget correctly', async () => {
+      expect(wrapper.vm.showProgressWidget).toBe(true);
+
+      await wrapper.setProps({ isLoading: true });
+      expect(wrapper.vm.showProgressWidget).toBe(false);
+    });
+
+    it('should compute tabs correctly', () => {
+      expect(wrapper.vm.tabs).toEqual([
+        { name: 'IA', key: 'intelligence-artificial' },
+        { name: 'Human support', key: 'human-support' },
+      ]);
+    });
+  });
+
+  describe('Component Structure', () => {
+    const requiredElements = [
+      'progress-widget-header',
+      'progress-widget-title',
+      'progress-widget-actions',
+      'progress-widget-tabs',
+      'progress-widget-content',
+    ];
+
+    requiredElements.forEach((testId) => {
+      it(`should render ${testId} element`, () => {
+        expectElementExists(wrapper, testId);
+      });
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('should handle empty progress items array', async () => {
+      await wrapper.setProps({ progressItems: [] });
+
+      const progressItems = wrapper.findAll(
+        '[data-testid="progress-widget-progress-item"]',
+      );
+      expect(progressItems).toHaveLength(0);
+    });
+
+    it('should handle progress items without optional properties', async () => {
+      await wrapper.setProps({
+        progressItems: [{ text: 'Simple Item', value: 60 }],
+      });
+
+      const progressItems = wrapper.findAll(
+        '[data-testid="progress-widget-progress-item"]',
+      );
+      expect(progressItems).toHaveLength(1);
+    });
+  });
+});

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -18,6 +18,23 @@
       "closeds": "Total number of chats that have been completed."
     }
   },
+  "conversations_dashboard": {
+    "conversations": "conversations",
+    "header": {
+      "total": "Total Conversations",
+      "resolved": "Resolved",
+      "unresolved": "Unresolved",
+      "unengaged": "Unengaged",
+      "transferred": "Transferred to human support",
+      "tooltips": {
+        "total": "Total number of conversations",
+        "resolved": "Number of conversations that have been resolved",
+        "unresolved": "Number of conversations that have not been resolved",
+        "unengaged": "Number of conversations that have not been engaged",
+        "transferred": "Number of conversations that have been transferred to human support"
+      }
+    }
+  },
   "template_messages_dashboard": {
     "title": "Template messages Meta",
     "favorites": "Favorites",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -18,6 +18,23 @@
       "closeds": "Número total de chats que ya han finalizado."
     }
   },
+  "conversations_dashboard": {
+    "conversations": "conversaciones",
+    "header": {
+      "total": "Total de conversaciones",
+      "resolved": "Resueltas",
+      "unresolved": "No resueltas",
+      "unengaged": "No engajadas",
+      "transferred": "Transferidas para atención humana",
+      "tooltips": {
+        "total": "Total de conversaciones",
+        "resolved": "Total de conversaciones resolvidas",
+        "unresolved": "Total de conversaciones no resolvidas",
+        "unengaged": "Total de conversaciones no engajadas",
+        "transferred": "Total de conversaciones transferidas para atención humana"
+      }
+    }
+  },
   "template_messages_dashboard": {
     "title": "Plantilla de mensajes Meta",
     "favorites": "Favoritos",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -18,6 +18,23 @@
       "closeds": "Total de chats que já foram finalizados."
     }
   },
+  "conversations_dashboard": {
+    "conversations": "conversas",
+    "header": {
+      "total": "Total de conversas",
+      "resolved": "Resolvidas",
+      "unresolved": "Não resolvidas",
+      "unengaged": "Não engajadas",
+      "transferred": "Transferidas para atendimento humano",
+      "tooltips": {
+        "total": "Total de conversas",
+        "resolved": "Total de conversas resolvidas",
+        "unresolved": "Total de conversas não resolvidas",
+        "unengaged": "Total de conversas não engajadas",
+        "transferred": "Total de conversas transferidas para atendimento humano"
+      }
+    }
+  },
   "template_messages_dashboard": {
     "title": "Mensagens template Meta",
     "favorites": "Favoritos",


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [X] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [X] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Add more dashboards to conversational dashboard

### Summary of Changes
<!--- Describe your changes in detail -->

- Add ProgressWidget 
- Add initial structure nps and csat
- Add tests

### Design Files <!--- (If not appropriate, remove this topic) -->
<!--- Links to the design files used for reference during implementation. -->

- [Design File 1](https://www.figma.com/design/aN8dbWdTMWAYlPA4t4o51D/Conversational-Data-Dashboards--4388-?node-id=528-11510&m=dev)

