### PR TITLE
[NEXUS-3479] - (Dashboard conversational) BaseConversationWidget actions

### DIFF
--- a/src/components/insights/conversations/BaseConversationWidget.vue
+++ b/src/components/insights/conversations/BaseConversationWidget.vue
@@ -32,7 +32,44 @@
           data-testid="base-conversation-widget-tabs"
           @tab-change="handleTabChange"
         />
-        <slot name="actions" />
+
+        <UnnnicDropdown
+          v-if="actions"
+          class="actions__dropdown"
+          data-testid="actions-dropdown"
+        >
+          <template #trigger>
+            <UnnnicIcon
+              icon="more_vert"
+              size="ant"
+              scheme="neutral-cloudy"
+            />
+          </template>
+
+          <UnnnicDropdownItem
+            v-for="(action, index) in actions"
+            :key="index"
+            class="dropdown__action"
+            data-testid="action"
+            @click="action.onClick()"
+          >
+            <UnnnicIcon
+              data-testid="action-icon"
+              :icon="action.icon"
+              size="sm"
+              :scheme="action.scheme || 'neutral-dark'"
+            />
+            <p
+              data-testid="action-text"
+              :class="[
+                'action__text',
+                `u color-${action.scheme || 'neutral-dark'}`, // Unnnic color classes
+              ]"
+            >
+              {{ action.text }}
+            </p>
+          </UnnnicDropdownItem>
+        </UnnnicDropdown>
       </section>
     </section>
     <slot />
@@ -51,6 +88,12 @@ const emit = defineEmits<{
 defineProps<{
   title: string;
   isLoading?: boolean;
+  actions?: {
+    icon: string;
+    text: string;
+    onClick: () => void;
+    scheme?: string;
+  }[];
 }>();
 
 const tabs = computed(() => [
@@ -95,6 +138,41 @@ const handleTabChange = (tab: string) => {
       font-weight: $unnnic-font-weight-bold;
       font-style: normal;
       line-height: $unnnic-font-size-title-sm + $unnnic-line-height-md;
+    }
+
+    .header__actions {
+      display: flex;
+      align-items: center;
+      gap: $unnnic-spacing-xs;
+
+      .actions__dropdown {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+
+        :deep(.unnnic-dropdown__trigger) {
+          display: flex;
+
+          cursor: pointer;
+        }
+
+        :deep(.unnnic-dropdown__content) {
+          padding: $unnnic-spacing-sm;
+        }
+
+        .dropdown__action {
+          display: flex;
+          align-items: center;
+          gap: $unnnic-spacing-xs;
+
+          .action__text {
+            font-family: $unnnic-font-family-secondary;
+            font-size: $unnnic-font-size-body-md;
+            line-height: $unnnic-font-size-body-md + $unnnic-line-height-md;
+            white-space: nowrap;
+          }
+        }
+      }
     }
   }
 }

--- a/src/components/insights/conversations/MostTalkedAboutTopicsWidget/index.vue
+++ b/src/components/insights/conversations/MostTalkedAboutTopicsWidget/index.vue
@@ -3,6 +3,15 @@
     <BaseConversationWidget
       class="most-talked-about-topics__conversation-widget"
       :title="$t('conversations_dashboard.most_talked_about_topics.title')"
+      :actions="[
+        {
+          icon: 'edit_square',
+          text: $t(
+            'conversations_dashboard.most_talked_about_topics.edit_topics_and_subtopics',
+          ),
+          onClick: topicsStore.toggleAddTopicsDrawer,
+        },
+      ]"
     >
       <TreemapChart
         :data="treemapData"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -72,7 +72,8 @@
       "subtopics": "subtopics",
       "no_topics": "No topics yet",
       "no_topics_description": "Add the topics you want to track. The AI will automatically tag every conversation with them, then you’ll see the most talked-about subjects right here.",
-      "add_first_topic": "Add your first topic"
+      "add_first_topic": "Add your first topic",
+      "edit_topics_and_subtopics": "Edit topics and sub-topics"
     },
     "csat": "CSAT",
     "nps": "NPS",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -72,7 +72,8 @@
       "subtopics": "subtemas",
       "no_topics": "No hay temas aún",
       "no_topics_description": "Agrega un tema para empezar a analizar las conversas",
-      "add_first_topic": "Agrega tu primer tema"
+      "add_first_topic": "Agrega tu primer tema",
+      "edit_topics_and_subtopics": "Editar temas y subtemas"
     },
     "csat": "CSAT",
     "nps": "NPS",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -72,7 +72,8 @@
       "subtopics": "subtópicos",
       "no_topics": "Nenhum tópico ainda",
       "no_topics_description": "Adicione um tópico para começar a analisar as conversas",
-      "add_first_topic": "Adicione seu primeiro tópico"
+      "add_first_topic": "Adicione seu primeiro tópico",
+      "edit_topics_and_subtopics": "Editar tópicos e subtópicos"
     },
     "csat": "CSAT",
     "nps": "NPS",


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
Add the action variation via the dropdown in the BaseConversationWidget header

### Summary of Changes
- Add actions dropdown with dynamic actions rendering and tests at BaseConversationWidget
- Add "edit topics and subtopics" action to MostTalkedAboutTopicsWidget

### Design Files <!--- (If not appropriate, remove this topic) -->
<!--- Links to the design files used for reference during implementation. -->

- [Design File](https://www.figma.com/design/aN8dbWdTMWAYlPA4t4o51D/Insights---Conversational-Data-Dashboards--4388-?node-id=666-9961&m=dev)

### Demonstration <!--- (If not appropriate, remove this topic) -->
<img width="722" height="132" alt="image" src="https://github.com/user-attachments/assets/1390079b-bc58-46d6-a6f4-bd0fa0b8d8d4" />
