### PR TITLE
[NEXUS-3523] - Adjust the design of the "No data to show" variation of the Treemap

### DIFF
--- a/src/components/insights/charts/TreemapChart.vue
+++ b/src/components/insights/charts/TreemapChart.vue
@@ -17,13 +17,24 @@
       />
     </section>
 
-    <p
+    <section
       v-else-if="data.length === 0"
       data-testid="treemap-chart-no-data"
       class="treemap-chart__no-data"
     >
-      {{ $t('widgets.treemap.no_data') }}
-    </p>
+      <p
+        data-testid="treemap-chart-no-data"
+        class="no-data__title"
+      >
+        {{ $t('widgets.treemap.no_data') }}
+      </p>
+      <p
+        data-testid="treemap-chart-no-data"
+        class="no-data__description"
+      >
+        {{ $t('widgets.treemap.no_data_description') }}
+      </p>
+    </section>
 
     <canvas
       v-else
@@ -258,14 +269,27 @@ watch(treemapCanvas, (newValue) => {
 
   &__no-data {
     height: 100%;
+
     display: flex;
+    flex-direction: column;
+    gap: $unnnic-spacing-ant;
     justify-content: center;
     align-items: center;
 
-    font-size: $unnnic-font-size-body-gt;
-    font-family: $unnnic-font-family-secondary;
-    color: $unnnic-color-neutral-cloudy;
-    line-height: $unnnic-font-size-body-gt + $unnnic-line-height-md;
+    .no-data__title {
+      font-size: $unnnic-font-size-title-sm;
+      font-family: $unnnic-font-family-secondary;
+      font-weight: $unnnic-font-weight-bold;
+      color: $unnnic-color-neutral-darkest;
+      line-height: $unnnic-font-size-title-sm + $unnnic-line-height-md;
+    }
+
+    .no-data__description {
+      font-size: $unnnic-font-size-body-lg;
+      font-family: $unnnic-font-family-secondary;
+      color: $unnnic-color-neutral-cloudy;
+      line-height: $unnnic-font-size-body-lg + $unnnic-line-height-md;
+    }
   }
 
   &__canvas {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -383,7 +383,8 @@
       }
     },
     "treemap": {
-      "no_data": "No data to show"
+      "no_data": "No data to show",
+      "no_data_description": "No conversations have been classified yet"
     }
   },
   "drawers": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -383,7 +383,8 @@
       }
     },
     "treemap": {
-      "no_data": "No hay datos para mostrar"
+      "no_data": "No hay datos para mostrar",
+      "no_data_description": "No hay conversaciones clasificadas aún"
     }
   },
   "drawers": {

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -383,7 +383,8 @@
       }
     },
     "treemap": {
-      "no_data": "Nenhum dado para mostrar"
+      "no_data": "Nenhum dado para mostrar",
+      "no_data_description": "Ainda não há conversas classificadas"
     }
   },
   "drawers": {


### PR DESCRIPTION
…translations for multiple languages

## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
Adjust the design of the "No data to show" variation of the treemap

### Summary of Changes
Adjusted the design of the "No data to show" variation of the treemap

### Demonstration <!--- (If not appropriate, remove this topic) -->
<img width="1315" height="374" alt="image" src="https://github.com/user-attachments/assets/817940ba-9a02-4c4a-bf5b-22d1d3b2430a" />
