### PR TITLE
refactor: optimize legend item generation in CrosstabWidget component

### DIFF
--- a/src/components/insights/widgets/CrosstabWidget.vue
+++ b/src/components/insights/widgets/CrosstabWidget.vue
@@ -62,7 +62,6 @@ import { useCustomWidgets } from '@/store/modules/conversational/customWidgets';
 import ProgressTable from '@/components/ProgressTable.vue';
 import SeeAllDrawer from '../conversations/CustomizableWidget/SeeAllDrawer.vue';
 
-import { UnnnicDisclaimer } from '@weni/unnnic-system';
 import { getWidgetCrosstabTooltip } from '@/utils/widget';
 
 const customWidgetsStore = useCustomWidgets();
@@ -104,8 +103,13 @@ const widgetData = computed(() => {
 
 const legendItems = computed(() => {
   if (!widgetData.value.results.length) return [];
-  const eventsKeys = Object.keys(widgetData.value.results[0].events);
-  return eventsKeys.map((key, index) => {
+  const allEventsKeys = [
+    ...new Set(
+      widgetData.value.results.flatMap((item) => Object.keys(item.events)),
+    ),
+  ];
+  const limitLegendItems = allEventsKeys.slice(0, 2);
+  return limitLegendItems.map((key, index) => {
     return {
       title: `${key.charAt(0).toUpperCase() + key.slice(1)}`,
       color: index === 0 ? '#3182CE' : '#E5812A',


### PR DESCRIPTION
## Description
### Type of Change
* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Tests
* [ ] Other

### Motivation and Context
Fixed an issue in the CrosstabWidget where the legend items were not being properly generated when some results had different event keys than others.

### Summary of Changes
- Modified the `legendItems` computed property to collect all unique event keys across all results
- Limited the legend items to a maximum of 2 items