### PR TITLE
refactor: update TemplateMessageMeta component to support MMLite configuration

### DIFF
--- a/src/components/insights/dashboards/TemplateMessageMeta.vue
+++ b/src/components/insights/dashboards/TemplateMessageMeta.vue
@@ -158,6 +158,10 @@ const app_uuid = computed(
   () => dashboardsStore.currentDashboard.config?.app_uuid,
 );
 
+const isMMLiteActive = computed(() => {
+  return dashboardsStore.currentDashboard?.config?.is_mm_lite_active;
+});
+
 const project_uuid = computed(() => configStore.project?.uuid);
 
 const lastOpenTemplates = ref(
@@ -190,7 +194,9 @@ const dataSourceOptions = [
   },
 ];
 
-const selectedApiOptions = ref([dataSourceOptions[0]]);
+const selectedApiOptions = ref([
+  dataSourceOptions[isMMLiteActive.value ? 1 : 0],
+]);
 
 onUnmounted(() => {
   metaTemplateMessageStore.setSelectedTemplateUuid('');


### PR DESCRIPTION
## Description
### Type of Change
* [x] Refactor

### Motivation and Context
This change adds support for MM Lite in the template message meta component by dynamically selecting the appropriate API option based on the dashboard configuration.

### Summary of Changes
- Added a new computed property `isMMLiteActive` that checks if MM Lite is active in the current dashboard configuration
- Modified the default selection of API options to use the second option (index 1) when MM Lite is active, otherwise defaulting to the first option (index 0)