### PR TITLE
[ENGAGE-6981] feat: remove resetAndLoadData call from sorting function in useInfiniteScrollTable

### DIFF
--- a/src/components/insights/humanSupport/Analysis/Tables/__tests__/Attendant.spec.js
+++ b/src/components/insights/humanSupport/Analysis/Tables/__tests__/Attendant.spec.js
@@ -135,6 +135,24 @@ describe('Attendant', () => {
       expect(mockInfiniteScroll.handleSort).toHaveBeenCalled();
     });
 
+    it('triggers only one data load when sort changes (no double request)', async () => {
+      vi.clearAllMocks();
+
+      mockInfiniteScroll.handleSort.mockImplementation((sort, currentSort) => {
+        currentSort.value = sort;
+      });
+
+      wrapper.vm.handleSort({
+        header: 'Agent',
+        itemKey: 'agent',
+        order: 'desc',
+      });
+
+      await wrapper.vm.$nextTick();
+
+      expect(mockInfiniteScroll.resetAndLoadData).toHaveBeenCalledTimes(1);
+    });
+
     it('handles load more', () => {
       wrapper.vm.loadMore();
       expect(mockInfiniteScroll.loadMoreData).toHaveBeenCalled();

--- a/src/components/insights/humanSupport/Analysis/Tables/__tests__/Finished.spec.js
+++ b/src/components/insights/humanSupport/Analysis/Tables/__tests__/Finished.spec.js
@@ -138,6 +138,24 @@ describe('Finished', () => {
       expect(mockInfiniteScroll.handleSort).toHaveBeenCalled();
     });
 
+    it('triggers only one data load when sort changes (no double request)', async () => {
+      vi.clearAllMocks();
+
+      mockInfiniteScroll.handleSort.mockImplementation((sort, currentSort) => {
+        currentSort.value = sort;
+      });
+
+      wrapper.vm.handleSort({
+        header: 'Agent',
+        itemKey: 'agent',
+        order: 'desc',
+      });
+
+      await wrapper.vm.$nextTick();
+
+      expect(mockInfiniteScroll.resetAndLoadData).toHaveBeenCalledTimes(1);
+    });
+
     it('handles load more', () => {
       wrapper.vm.loadMore();
       expect(mockInfiniteScroll.loadMoreData).toHaveBeenCalled();

--- a/src/components/insights/humanSupport/Common/Tables/__tests__/Pauses.spec.js
+++ b/src/components/insights/humanSupport/Common/Tables/__tests__/Pauses.spec.js
@@ -184,6 +184,24 @@ describe('Pauses', () => {
       expect(mockInfiniteScroll.handleSort).toHaveBeenCalled();
     });
 
+    it('triggers only one data load when sort changes (no double request)', async () => {
+      vi.clearAllMocks();
+
+      mockInfiniteScroll.handleSort.mockImplementation((sort, currentSort) => {
+        currentSort.value = sort;
+      });
+
+      wrapper.vm.handleSort({
+        header: 'Agent',
+        itemKey: 'agent',
+        order: 'desc',
+      });
+
+      await wrapper.vm.$nextTick();
+
+      expect(mockInfiniteScroll.resetAndLoadData).toHaveBeenCalledTimes(1);
+    });
+
     it('handles load more', () => {
       wrapper.vm.loadMore();
       expect(mockInfiniteScroll.loadMoreData).toHaveBeenCalled();

--- a/src/components/insights/humanSupport/Monitoring/Tables/__tests__/Attendant.spec.js
+++ b/src/components/insights/humanSupport/Monitoring/Tables/__tests__/Attendant.spec.js
@@ -150,6 +150,24 @@ describe('Attendant', () => {
       expect(mockInfiniteScroll.handleSort).toHaveBeenCalled();
     });
 
+    it('triggers only one data load when sort changes (no double request)', async () => {
+      vi.clearAllMocks();
+
+      mockInfiniteScroll.handleSort.mockImplementation((sort, currentSort) => {
+        currentSort.value = sort;
+      });
+
+      wrapper.vm.handleSort({
+        header: 'Agent',
+        itemKey: 'agent',
+        order: 'desc',
+      });
+
+      await wrapper.vm.$nextTick();
+
+      expect(mockInfiniteScroll.resetAndLoadData).toHaveBeenCalledTimes(1);
+    });
+
     it('handles load more', () => {
       wrapper.vm.loadMore();
       expect(mockInfiniteScroll.loadMoreData).toHaveBeenCalled();

--- a/src/components/insights/humanSupport/Monitoring/Tables/__tests__/InAwaiting.spec.js
+++ b/src/components/insights/humanSupport/Monitoring/Tables/__tests__/InAwaiting.spec.js
@@ -111,6 +111,24 @@ describe('InAwaiting', () => {
       expect(mockInfiniteScroll.handleSort).toHaveBeenCalled();
     });
 
+    it('triggers only one data load when sort changes (no double request)', async () => {
+      vi.clearAllMocks();
+
+      mockInfiniteScroll.handleSort.mockImplementation((sort, currentSort) => {
+        currentSort.value = sort;
+      });
+
+      wrapper.vm.handleSort({
+        header: 'Awaiting Time',
+        itemKey: 'awaiting_time',
+        order: 'desc',
+      });
+
+      await wrapper.vm.$nextTick();
+
+      expect(mockInfiniteScroll.resetAndLoadData).toHaveBeenCalledTimes(1);
+    });
+
     it('handles load more', () => {
       wrapper.vm.loadMore();
       expect(mockInfiniteScroll.loadMoreData).toHaveBeenCalled();

--- a/src/components/insights/humanSupport/Monitoring/Tables/__tests__/InProgress.spec.js
+++ b/src/components/insights/humanSupport/Monitoring/Tables/__tests__/InProgress.spec.js
@@ -137,6 +137,24 @@ describe('InProgress', () => {
       expect(mockInfiniteScroll.handleSort).toHaveBeenCalled();
     });
 
+    it('triggers only one data load when sort changes (no double request)', async () => {
+      vi.clearAllMocks();
+
+      mockInfiniteScroll.handleSort.mockImplementation((sort, currentSort) => {
+        currentSort.value = sort;
+      });
+
+      wrapper.vm.handleSort({
+        header: 'Duration',
+        itemKey: 'duration',
+        order: 'desc',
+      });
+
+      await wrapper.vm.$nextTick();
+
+      expect(mockInfiniteScroll.resetAndLoadData).toHaveBeenCalledTimes(1);
+    });
+
     it('handles load more', () => {
       wrapper.vm.loadMore();
       expect(mockInfiniteScroll.loadMoreData).toHaveBeenCalled();

--- a/src/composables/__tests__/useInfiniteScrollTable.spec.js
+++ b/src/composables/__tests__/useInfiniteScrollTable.spec.js
@@ -165,18 +165,18 @@ describe('useInfiniteScrollTable', () => {
   });
 
   describe('handleSort', () => {
-    it('updates currentSort and calls resetAndLoadData', async () => {
+    it('updates currentSort and calls onSortChange without triggering fetch', () => {
       const currentSort = { value: { itemKey: 'id', order: 'asc' } };
       const newSort = { header: 'Name', itemKey: 'name', order: 'desc' };
 
-      await composable.handleSort(newSort, currentSort);
+      composable.handleSort(newSort, currentSort);
 
       expect(currentSort.value).toEqual(newSort);
       expect(mockOnSortChange).toHaveBeenCalled();
-      expect(mockFetchData).toHaveBeenCalledWith(1, 12, '-name');
+      expect(mockFetchData).not.toHaveBeenCalled();
     });
 
-    it('works without onSortChange callback', async () => {
+    it('works without onSortChange callback', () => {
       const noCallbackComposable = useInfiniteScrollTable({
         fetchData: mockFetchData,
         formatResults: mockFormatResults,
@@ -185,10 +185,10 @@ describe('useInfiniteScrollTable', () => {
       const currentSort = { value: { itemKey: 'id', order: 'asc' } };
       const newSort = { header: 'Name', itemKey: 'name', order: 'asc' };
 
-      await noCallbackComposable.handleSort(newSort, currentSort);
+      noCallbackComposable.handleSort(newSort, currentSort);
 
       expect(currentSort.value).toEqual(newSort);
-      expect(mockFetchData).toHaveBeenCalled();
+      expect(mockFetchData).not.toHaveBeenCalled();
     });
   });
 

--- a/src/composables/useInfiniteScrollTable.ts
+++ b/src/composables/useInfiniteScrollTable.ts
@@ -91,7 +91,6 @@ export function useInfiniteScrollTable<T = any, R = any>(
   ) => {
     currentSort.value = sort;
     onSortChange?.();
-    resetAndLoadData(sort);
   };
 
   return {


### PR DESCRIPTION
## Description
### Type of Change
* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [x] Tests
* [ ] Other

### Motivation and Context
Fixed an issue where sorting tables in the Human Support components was triggering duplicate data requests. The `handleSort` method in the `useInfiniteScrollTable` composable was unnecessarily calling `resetAndLoadData` after updating the sort value, causing redundant API calls.

### Summary of Changes
- Added test cases across multiple table components to verify that only one data load is triggered when sort changes
- Modified the `handleSort` method in `useInfiniteScrollTable.ts` to no longer call `resetAndLoadData` after updating the sort value
- Updated existing tests in `useInfiniteScrollTable.spec.js` to reflect the new behavior where sorting doesn't automatically trigger data fetching

This change prevents unnecessary API requests when users sort tables in the Human Support components, improving performance and reducing server load.