### PR TITLE
[ENGAGE-6958] Feat: Data feedback modal

### DIFF
--- a/src/components/insights/conversations/Feedback/DataFeedbackModal.vue
+++ b/src/components/insights/conversations/Feedback/DataFeedbackModal.vue
@@ -1,0 +1,161 @@
+<template>
+  <UnnnicDialog
+    :open="modelValue"
+    @update:open="emit('update:modelValue', $event)"
+  >
+    <UnnnicDialogContent size="large">
+      <UnnnicDialogHeader>
+        <UnnnicDialogTitle>
+          {{ t('data_feedback.title') }}
+        </UnnnicDialogTitle>
+      </UnnnicDialogHeader>
+
+      <div class="feedback-modal__body">
+        <p class="feedback-modal__description">
+          {{ t('data_feedback.description') }}
+        </p>
+
+        <UnnnicRadioGroup
+          v-model="trustData"
+          :label="t('data_feedback.q1')"
+        >
+          <UnnnicRadio
+            v-for="option in likertOptions"
+            :key="option.value"
+            :value="option.value"
+            :label="t(option.labelKey)"
+          />
+        </UnnnicRadioGroup>
+
+        <UnnnicRadioGroup
+          v-model="helpDecisions"
+          :label="t('data_feedback.q2')"
+        >
+          <UnnnicRadio
+            v-for="option in likertOptions"
+            :key="option.value"
+            :value="option.value"
+            :label="t(option.labelKey)"
+          />
+        </UnnnicRadioGroup>
+
+        <UnnnicRadioGroup
+          v-model="understandImpact"
+          :label="t('data_feedback.q3')"
+        >
+          <UnnnicRadio
+            v-for="option in likertOptions"
+            :key="option.value"
+            :value="option.value"
+            :label="t(option.labelKey)"
+          />
+        </UnnnicRadioGroup>
+
+        <UnnnicTextArea
+          v-model="suggestions"
+          :label="t('data_feedback.textarea_label')"
+          :placeholder="t('data_feedback.textarea_placeholder')"
+          :maxLength="1000"
+        />
+      </div>
+
+      <UnnnicDialogFooter>
+        <UnnnicDialogClose>
+          <UnnnicButton
+            :text="t('data_feedback.postpone')"
+            type="tertiary"
+          />
+        </UnnnicDialogClose>
+
+        <UnnnicButton
+          :text="t('data_feedback.submit')"
+          type="primary"
+          :disabled="!isFormValid"
+          @click="handleSubmit"
+        />
+      </UnnnicDialogFooter>
+    </UnnnicDialogContent>
+  </UnnnicDialog>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import {
+  UnnnicDialog,
+  UnnnicDialogContent,
+  UnnnicDialogHeader,
+  UnnnicDialogTitle,
+  UnnnicDialogFooter,
+  UnnnicDialogClose,
+  UnnnicButton,
+  UnnnicRadioGroup,
+  UnnnicRadio,
+  UnnnicTextArea,
+} from '@weni/unnnic-system';
+
+const { t } = useI18n();
+
+interface Props {
+  modelValue: boolean;
+}
+
+const props = defineProps<Props>();
+
+const emit = defineEmits<{
+  (_e: 'update:modelValue', _value: boolean): void;
+}>();
+
+const likertOptions = [
+  { value: 'strongly_agree', labelKey: 'data_feedback.strongly_agree' },
+  { value: 'partially_agree', labelKey: 'data_feedback.partially_agree' },
+  { value: 'neutral', labelKey: 'data_feedback.neutral' },
+  {
+    value: 'partially_disagree',
+    labelKey: 'data_feedback.partially_disagree',
+  },
+  {
+    value: 'strongly_disagree',
+    labelKey: 'data_feedback.strongly_disagree',
+  },
+];
+
+const trustData = ref<string>('');
+const helpDecisions = ref<string>('');
+const understandImpact = ref<string>('');
+const suggestions = ref<string>('');
+
+const isFormValid = computed(
+  () => !!trustData.value && !!helpDecisions.value && !!understandImpact.value,
+);
+
+function handleSubmit() {
+  const feedbackData = {
+    trustData: trustData.value,
+    helpDecisions: helpDecisions.value,
+    understandImpact: understandImpact.value,
+    suggestions: suggestions.value,
+  };
+
+  console.log('Feedback submitted:', feedbackData);
+
+  emit('update:modelValue', false);
+}
+</script>
+
+<style scoped lang="scss">
+.feedback-modal {
+  &__body {
+    display: flex;
+    flex-direction: column;
+    gap: $unnnic-space-6;
+    padding: $unnnic-space-6;
+  }
+
+  &__description {
+    margin: 0;
+    font: $unnnic-font-emphasis;
+    color: $unnnic-color-fg-base;
+  }
+}
+</style>

--- a/src/components/insights/conversations/Feedback/DataFeedbackModal.vue
+++ b/src/components/insights/conversations/Feedback/DataFeedbackModal.vue
@@ -126,6 +126,7 @@ const emit = defineEmits<{
   (_e: 'update:modelValue', _value: boolean): void;
   (_e: 'postpone'): void;
   (_e: 'submitted'): void;
+  (_e: 'submit-error'): void;
 }>();
 
 const scoreMap: Record<string, string> = {
@@ -202,8 +203,9 @@ async function handleSubmit() {
 
     emit('submitted');
     emit('update:modelValue', false);
-  } catch (error) {
-    console.error('Failed to submit feedback:', error);
+  } catch {
+    emit('update:modelValue', false);
+    emit('submit-error');
   } finally {
     isSubmitting.value = false;
   }

--- a/src/components/insights/conversations/Feedback/DataFeedbackModal.vue
+++ b/src/components/insights/conversations/Feedback/DataFeedbackModal.vue
@@ -112,11 +112,9 @@ interface Props {
   modelValue: boolean;
 }
 
-const props = defineProps<Props>();
+defineProps<Props>();
 
-const emit = defineEmits<{
-  (_e: 'update:modelValue', _value: boolean): void;
-}>();
+const emit = defineEmits<(_e: 'update:modelValue', _value: boolean) => void>();
 
 const likertOptions = [
   { value: 'strongly_agree', labelKey: 'data_feedback.strongly_agree' },

--- a/src/components/insights/conversations/Feedback/DataFeedbackModal.vue
+++ b/src/components/insights/conversations/Feedback/DataFeedbackModal.vue
@@ -75,13 +75,14 @@
             :text="t('data_feedback.postpone')"
             type="tertiary"
             data-testid="feedback-postpone-button"
+            @click="handlePostpone"
           />
         </UnnnicDialogClose>
 
         <UnnnicButton
           :text="t('data_feedback.submit')"
           type="primary"
-          :disabled="!isFormValid"
+          :disabled="!isFormValid || isSubmitting"
           data-testid="feedback-submit-button"
           @click="handleSubmit"
         />
@@ -105,16 +106,35 @@ import {
   UnnnicRadio,
   UnnnicTextArea,
 } from '@weni/unnnic-system';
+import { useDashboards } from '@/store/modules/dashboards';
+import feedbackApi, {
+  DashboardType,
+  FormType,
+  Reference,
+} from '@/services/api/resources/conversational/feedback';
 
 const { t } = useI18n();
 
 interface Props {
   modelValue: boolean;
+  surveyUuid: string;
 }
 
-defineProps<Props>();
+const props = defineProps<Props>();
 
-const emit = defineEmits<(_e: 'update:modelValue', _value: boolean) => void>();
+const emit = defineEmits<{
+  (_e: 'update:modelValue', _value: boolean): void;
+  (_e: 'postpone'): void;
+  (_e: 'submitted'): void;
+}>();
+
+const scoreMap: Record<string, string> = {
+  strongly_agree: '5',
+  partially_agree: '4',
+  neutral: '3',
+  partially_disagree: '2',
+  strongly_disagree: '1',
+};
 
 const likertOptions = [
   { value: 'strongly_agree', labelKey: 'data_feedback.strongly_agree' },
@@ -134,22 +154,59 @@ const trustData = ref<string>('');
 const helpDecisions = ref<string>('');
 const understandImpact = ref<string>('');
 const suggestions = ref<string>('');
+const isSubmitting = ref(false);
 
 const isFormValid = computed(
   () => !!trustData.value && !!helpDecisions.value && !!understandImpact.value,
 );
 
-function handleSubmit() {
-  const feedbackData = {
-    trustData: trustData.value,
-    helpDecisions: helpDecisions.value,
-    understandImpact: understandImpact.value,
-    suggestions: suggestions.value,
-  };
+function handlePostpone() {
+  emit('postpone');
+}
 
-  console.log('Feedback submitted:', feedbackData);
+async function handleSubmit() {
+  if (isSubmitting.value) return;
 
-  emit('update:modelValue', false);
+  const { currentDashboard } = useDashboards();
+
+  isSubmitting.value = true;
+
+  try {
+    await feedbackApi.submitFeedback({
+      type: DashboardType.CONVERSATIONAL,
+      dashboard: currentDashboard.uuid,
+      survey: props.surveyUuid,
+      answers: [
+        {
+          reference: Reference.TRUST,
+          answer: scoreMap[trustData.value],
+          type: FormType.SCORE_1_5,
+        },
+        {
+          reference: Reference.MAKE_DECISION,
+          answer: scoreMap[helpDecisions.value],
+          type: FormType.SCORE_1_5,
+        },
+        {
+          reference: Reference.ROI,
+          answer: scoreMap[understandImpact.value],
+          type: FormType.SCORE_1_5,
+        },
+        {
+          reference: Reference.COMMENT,
+          answer: suggestions.value,
+          type: FormType.TEXT,
+        },
+      ],
+    });
+
+    emit('submitted');
+    emit('update:modelValue', false);
+  } catch (error) {
+    console.error('Failed to submit feedback:', error);
+  } finally {
+    isSubmitting.value = false;
+  }
 }
 </script>
 

--- a/src/components/insights/conversations/Feedback/DataFeedbackModal.vue
+++ b/src/components/insights/conversations/Feedback/DataFeedbackModal.vue
@@ -10,14 +10,21 @@
         </UnnnicDialogTitle>
       </UnnnicDialogHeader>
 
-      <div class="feedback-modal__body">
-        <p class="feedback-modal__description">
+      <div
+        class="feedback-modal__body"
+        data-testid="feedback-modal-body"
+      >
+        <p
+          class="feedback-modal__description"
+          data-testid="feedback-modal-description"
+        >
           {{ t('data_feedback.description') }}
         </p>
 
         <UnnnicRadioGroup
           v-model="trustData"
           :label="t('data_feedback.q1')"
+          data-testid="feedback-radio-trust"
         >
           <UnnnicRadio
             v-for="option in likertOptions"
@@ -30,6 +37,7 @@
         <UnnnicRadioGroup
           v-model="helpDecisions"
           :label="t('data_feedback.q2')"
+          data-testid="feedback-radio-decisions"
         >
           <UnnnicRadio
             v-for="option in likertOptions"
@@ -42,6 +50,7 @@
         <UnnnicRadioGroup
           v-model="understandImpact"
           :label="t('data_feedback.q3')"
+          data-testid="feedback-radio-impact"
         >
           <UnnnicRadio
             v-for="option in likertOptions"
@@ -56,6 +65,7 @@
           :label="t('data_feedback.textarea_label')"
           :placeholder="t('data_feedback.textarea_placeholder')"
           :maxLength="1000"
+          data-testid="feedback-textarea"
         />
       </div>
 
@@ -64,6 +74,7 @@
           <UnnnicButton
             :text="t('data_feedback.postpone')"
             type="tertiary"
+            data-testid="feedback-postpone-button"
           />
         </UnnnicDialogClose>
 
@@ -71,6 +82,7 @@
           :text="t('data_feedback.submit')"
           type="primary"
           :disabled="!isFormValid"
+          data-testid="feedback-submit-button"
           @click="handleSubmit"
         />
       </UnnnicDialogFooter>

--- a/src/components/insights/conversations/Feedback/__tests__/DataFeedbackModal.spec.js
+++ b/src/components/insights/conversations/Feedback/__tests__/DataFeedbackModal.spec.js
@@ -1,0 +1,180 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { config, shallowMount } from '@vue/test-utils';
+import { createI18n } from 'vue-i18n';
+
+import DataFeedbackModal from '../DataFeedbackModal.vue';
+
+config.global.plugins = [
+  createI18n({
+    legacy: false,
+  }),
+];
+
+const unnnicStubs = {
+  UnnnicDialog: {
+    template: '<div data-testid="feedback-dialog"><slot /></div>',
+    props: ['open'],
+  },
+  UnnnicDialogContent: {
+    template: '<div><slot /></div>',
+    props: ['size'],
+  },
+  UnnnicDialogHeader: { template: '<div><slot /></div>' },
+  UnnnicDialogTitle: { template: '<div><slot /></div>' },
+  UnnnicDialogFooter: { template: '<div><slot /></div>' },
+  UnnnicDialogClose: { template: '<div><slot /></div>' },
+  UnnnicButton: {
+    template: '<button :data-testid="$attrs[`data-testid`]"></button>',
+    props: ['text', 'type', 'disabled'],
+  },
+  UnnnicRadioGroup: {
+    template: '<div :data-testid="$attrs[`data-testid`]"><slot /></div>',
+    props: ['modelValue', 'label'],
+    emits: ['update:modelValue'],
+  },
+  UnnnicRadio: { template: '<div></div>', props: ['value', 'label'] },
+  UnnnicTextArea: {
+    template: '<div data-testid="feedback-textarea"></div>',
+    props: ['modelValue', 'label', 'placeholder', 'maxLength'],
+    emits: ['update:modelValue'],
+  },
+};
+
+const createWrapper = (props = {}) => {
+  return shallowMount(DataFeedbackModal, {
+    props: { modelValue: true, ...props },
+    global: { stubs: unnnicStubs },
+  });
+};
+
+describe('DataFeedbackModal', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    wrapper = createWrapper();
+  });
+
+  const findDialog = () =>
+    wrapper.findComponent('[data-testid="feedback-dialog"]');
+  const findBody = () => wrapper.find('[data-testid="feedback-modal-body"]');
+  const findDescription = () =>
+    wrapper.find('[data-testid="feedback-modal-description"]');
+  const findRadioTrust = () =>
+    wrapper.findComponent('[data-testid="feedback-radio-trust"]');
+  const findRadioDecisions = () =>
+    wrapper.findComponent('[data-testid="feedback-radio-decisions"]');
+  const findRadioImpact = () =>
+    wrapper.findComponent('[data-testid="feedback-radio-impact"]');
+  const findTextarea = () =>
+    wrapper.findComponent('[data-testid="feedback-textarea"]');
+  const findSubmitButton = () =>
+    wrapper.findComponent('[data-testid="feedback-submit-button"]');
+  const findPostponeButton = () =>
+    wrapper.findComponent('[data-testid="feedback-postpone-button"]');
+
+  const fillAllRadioGroups = async () => {
+    await findRadioTrust().vm.$emit('update:modelValue', 'strongly_agree');
+    await findRadioDecisions().vm.$emit('update:modelValue', 'neutral');
+    await findRadioImpact().vm.$emit(
+      'update:modelValue',
+      'partially_disagree',
+    );
+  };
+
+  describe('Initial render', () => {
+    it('should render all main elements', () => {
+      expect(findDialog().exists()).toBe(true);
+      expect(findBody().exists()).toBe(true);
+      expect(findDescription().exists()).toBe(true);
+      expect(findRadioTrust().exists()).toBe(true);
+      expect(findRadioDecisions().exists()).toBe(true);
+      expect(findRadioImpact().exists()).toBe(true);
+      expect(findTextarea().exists()).toBe(true);
+      expect(findSubmitButton().exists()).toBe(true);
+      expect(findPostponeButton().exists()).toBe(true);
+    });
+
+    it('should pass open prop to dialog', () => {
+      expect(findDialog().props('open')).toBe(true);
+    });
+
+    it('should pass open as false when modelValue is false', () => {
+      wrapper = createWrapper({ modelValue: false });
+      expect(findDialog().props('open')).toBe(false);
+    });
+
+    it('should configure textarea with maxLength 1000', () => {
+      expect(findTextarea().props('maxLength')).toBe(1000);
+    });
+  });
+
+  describe('Form validation', () => {
+    it('should disable submit button when no radio groups are filled', () => {
+      expect(findSubmitButton().props('disabled')).toBe(true);
+    });
+
+    it('should disable submit button when only one radio group is filled', async () => {
+      await findRadioTrust().vm.$emit('update:modelValue', 'strongly_agree');
+      expect(findSubmitButton().props('disabled')).toBe(true);
+    });
+
+    it('should disable submit button when only two radio groups are filled', async () => {
+      await findRadioTrust().vm.$emit('update:modelValue', 'strongly_agree');
+      await findRadioDecisions().vm.$emit('update:modelValue', 'neutral');
+      expect(findSubmitButton().props('disabled')).toBe(true);
+    });
+
+    it('should enable submit button when all three radio groups are filled', async () => {
+      await fillAllRadioGroups();
+      expect(findSubmitButton().props('disabled')).toBe(false);
+    });
+  });
+
+  describe('Submit', () => {
+    it('should log feedback data and emit close on submit', async () => {
+      const consoleSpy = vi.spyOn(console, 'log');
+
+      await fillAllRadioGroups();
+      await findTextarea().vm.$emit('update:modelValue', 'Great dashboard');
+      await findSubmitButton().vm.$emit('click');
+
+      expect(consoleSpy).toHaveBeenCalledWith('Feedback submitted:', {
+        trustData: 'strongly_agree',
+        helpDecisions: 'neutral',
+        understandImpact: 'partially_disagree',
+        suggestions: 'Great dashboard',
+      });
+      expect(wrapper.emitted('update:modelValue')).toContainEqual([false]);
+    });
+
+    it('should submit with empty suggestions when textarea is not filled', async () => {
+      const consoleSpy = vi.spyOn(console, 'log');
+
+      await fillAllRadioGroups();
+      await findSubmitButton().vm.$emit('click');
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'Feedback submitted:',
+        expect.objectContaining({ suggestions: '' }),
+      );
+    });
+  });
+
+  describe('Dialog events', () => {
+    it('should forward update:open event as update:modelValue', async () => {
+      await findDialog().vm.$emit('update:open', false);
+      expect(wrapper.emitted('update:modelValue')).toContainEqual([false]);
+    });
+  });
+
+  describe('Button props', () => {
+    it('should set postpone button as tertiary type', () => {
+      expect(findPostponeButton().props('type')).toBe('tertiary');
+    });
+
+    it('should set submit button as primary type', () => {
+      expect(findSubmitButton().props('type')).toBe('primary');
+    });
+  });
+});

--- a/src/components/insights/dashboards/Conversational.vue
+++ b/src/components/insights/dashboards/Conversational.vue
@@ -28,6 +28,7 @@
       :surveyUuid="surveyUuid"
       @postpone="onPostpone"
       @submitted="onSubmitted"
+      @submit-error="onSubmitError"
     />
   </section>
 </template>
@@ -50,8 +51,14 @@ import { useFeedbackSurvey } from '@/composables/useFeedbackSurvey';
 const { isFeatureFlagEnabled } = useFeatureFlag();
 const { activeFeatures } = storeToRefs(useFeatureFlag());
 
-const { shouldShowModal, surveyUuid, checkSurvey, onPostpone, onSubmitted } =
-  useFeedbackSurvey();
+const {
+  shouldShowModal,
+  surveyUuid,
+  checkSurvey,
+  onPostpone,
+  onSubmitted,
+  onSubmitError,
+} = useFeedbackSurvey();
 
 type ConversationalWidgetType =
   | 'csat'

--- a/src/components/insights/dashboards/Conversational.vue
+++ b/src/components/insights/dashboards/Conversational.vue
@@ -24,7 +24,10 @@
     <CustomizableDrawer />
     <DataFeedbackModal
       v-if="isFeatureFlagEnabled('insightsDataFeedback')"
-      v-model="isDataFeedbackModalOpen"
+      v-model="shouldShowModal"
+      :surveyUuid="surveyUuid"
+      @postpone="onPostpone"
+      @submitted="onSubmitted"
     />
   </section>
 </template>
@@ -42,8 +45,12 @@ import { useCustomWidgets } from '@/store/modules/conversational/customWidgets';
 import Info from '@/components/insights/conversations/Info.vue';
 import DataFeedbackModal from '@/components/insights/conversations/Feedback/DataFeedbackModal.vue';
 import { useFeatureFlag } from '@/store/modules/featureFlag';
+import { useFeedbackSurvey } from '@/composables/useFeedbackSurvey';
 
 const { isFeatureFlagEnabled } = useFeatureFlag();
+
+const { shouldShowModal, surveyUuid, checkSurvey, onPostpone, onSubmitted } =
+  useFeedbackSurvey();
 
 type ConversationalWidgetType =
   | 'csat'
@@ -52,8 +59,6 @@ type ConversationalWidgetType =
   | 'sales_funnel'
   | 'custom'
   | 'crosstab';
-
-const isDataFeedbackModalOpen = ref(true);
 
 const customWidgets = useCustomWidgets();
 const conversationalWidgets = useConversationalWidgets();
@@ -132,6 +137,10 @@ watch(
 onMounted(() => {
   if (dynamicWidgets.value.length === 0) {
     setDynamicWidgets();
+  }
+
+  if (isFeatureFlagEnabled('insightsDataFeedback')) {
+    checkSurvey();
   }
 });
 

--- a/src/components/insights/dashboards/Conversational.vue
+++ b/src/components/insights/dashboards/Conversational.vue
@@ -48,6 +48,7 @@ import { useFeatureFlag } from '@/store/modules/featureFlag';
 import { useFeedbackSurvey } from '@/composables/useFeedbackSurvey';
 
 const { isFeatureFlagEnabled } = useFeatureFlag();
+const { activeFeatures } = storeToRefs(useFeatureFlag());
 
 const { shouldShowModal, surveyUuid, checkSurvey, onPostpone, onSubmitted } =
   useFeedbackSurvey();
@@ -138,7 +139,12 @@ onMounted(() => {
   if (dynamicWidgets.value.length === 0) {
     setDynamicWidgets();
   }
+  if (isFeatureFlagEnabled('insightsDataFeedback')) {
+    checkSurvey();
+  }
+});
 
+watch(activeFeatures, () => {
   if (isFeatureFlagEnabled('insightsDataFeedback')) {
     checkSurvey();
   }

--- a/src/components/insights/dashboards/Conversational.vue
+++ b/src/components/insights/dashboards/Conversational.vue
@@ -22,6 +22,10 @@
     />
 
     <CustomizableDrawer />
+    <DataFeedbackModal
+      v-if="isFeatureFlagEnabled('insightsDataFeedback')"
+      v-model="isDataFeedbackModalOpen"
+    />
   </section>
 </template>
 
@@ -36,6 +40,10 @@ import { useWidgets } from '@/store/modules/widgets';
 import CustomizableDrawer from '@/components/insights/conversations/CustomizableWidget/CustomizableDrawer.vue';
 import { useCustomWidgets } from '@/store/modules/conversational/customWidgets';
 import Info from '@/components/insights/conversations/Info.vue';
+import DataFeedbackModal from '@/components/insights/conversations/Feedback/DataFeedbackModal.vue';
+import { useFeatureFlag } from '@/store/modules/featureFlag';
+
+const { isFeatureFlagEnabled } = useFeatureFlag();
 
 type ConversationalWidgetType =
   | 'csat'
@@ -44,6 +52,8 @@ type ConversationalWidgetType =
   | 'sales_funnel'
   | 'custom'
   | 'crosstab';
+
+const isDataFeedbackModalOpen = ref(true);
 
 const customWidgets = useCustomWidgets();
 const conversationalWidgets = useConversationalWidgets();

--- a/src/composables/__tests__/useFeedbackSurvey.spec.js
+++ b/src/composables/__tests__/useFeedbackSurvey.spec.js
@@ -1,0 +1,222 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useFeedbackSurvey } from '../useFeedbackSurvey';
+import { moduleStorage } from '@/utils/storage';
+
+const STORAGE_KEY = 'data_feedback_state';
+const TWO_HOURS_MS = 2 * 60 * 60 * 1000;
+
+const mockCheckSurvey = vi.fn();
+
+vi.mock('@/services/api/resources/conversational/feedback', () => ({
+  default: { checkSurvey: (...args) => mockCheckSurvey(...args) },
+}));
+
+vi.mock('@/utils/storage', () => ({
+  moduleStorage: {
+    getItem: vi.fn((_key, defaultVal) => defaultVal ?? null),
+    setItem: vi.fn(),
+    removeItem: vi.fn(),
+  },
+}));
+
+const activeSurvey = {
+  uuid: 'survey-1',
+  is_active: true,
+  user_answered: false,
+};
+
+const today = () => new Date().toISOString().slice(0, 10);
+
+describe('useFeedbackSurvey', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    moduleStorage.getItem.mockImplementation(
+      (_key, defaultVal) => defaultVal ?? null,
+    );
+  });
+
+  describe('checkSurvey', () => {
+    it('should show modal when survey is active and no postpone state', async () => {
+      mockCheckSurvey.mockResolvedValue(activeSurvey);
+
+      const { shouldShowModal, surveyUuid, checkSurvey } = useFeedbackSurvey();
+      await checkSurvey();
+
+      expect(shouldShowModal.value).toBe(true);
+      expect(surveyUuid.value).toBe('survey-1');
+    });
+
+    it('should not show modal when survey is inactive', async () => {
+      mockCheckSurvey.mockResolvedValue({
+        ...activeSurvey,
+        is_active: false,
+      });
+
+      const { shouldShowModal, checkSurvey } = useFeedbackSurvey();
+      await checkSurvey();
+
+      expect(shouldShowModal.value).toBe(false);
+    });
+
+    it('should not show modal when user already answered', async () => {
+      mockCheckSurvey.mockResolvedValue({
+        ...activeSurvey,
+        user_answered: true,
+      });
+
+      const { shouldShowModal, checkSurvey } = useFeedbackSurvey();
+      await checkSurvey();
+
+      expect(shouldShowModal.value).toBe(false);
+    });
+
+    it('should not show modal when postponed twice today', async () => {
+      mockCheckSurvey.mockResolvedValue(activeSurvey);
+      moduleStorage.getItem.mockReturnValue({
+        lastPostponedDate: today(),
+        postponeCountToday: 2,
+        firstShownTodayAt: new Date(
+          Date.now() - TWO_HOURS_MS - 1,
+        ).toISOString(),
+        lastPostponedAt: new Date().toISOString(),
+      });
+
+      const { shouldShowModal, checkSurvey } = useFeedbackSurvey();
+      await checkSurvey();
+
+      expect(shouldShowModal.value).toBe(false);
+    });
+
+    it('should not show modal when less than 2h since first shown today', async () => {
+      mockCheckSurvey.mockResolvedValue(activeSurvey);
+      moduleStorage.getItem.mockReturnValue({
+        lastPostponedDate: today(),
+        postponeCountToday: 1,
+        firstShownTodayAt: new Date().toISOString(),
+        lastPostponedAt: new Date().toISOString(),
+      });
+
+      const { shouldShowModal, checkSurvey } = useFeedbackSurvey();
+      await checkSurvey();
+
+      expect(shouldShowModal.value).toBe(false);
+    });
+
+    it('should show modal when 2h+ elapsed and postpone count < 2', async () => {
+      mockCheckSurvey.mockResolvedValue(activeSurvey);
+      moduleStorage.getItem.mockReturnValue({
+        lastPostponedDate: today(),
+        postponeCountToday: 1,
+        firstShownTodayAt: new Date(
+          Date.now() - TWO_HOURS_MS - 1,
+        ).toISOString(),
+        lastPostponedAt: new Date().toISOString(),
+      });
+
+      const { shouldShowModal, checkSurvey } = useFeedbackSurvey();
+      await checkSurvey();
+
+      expect(shouldShowModal.value).toBe(true);
+    });
+
+    it('should reset state and show when lastPostponedDate is a different day', async () => {
+      mockCheckSurvey.mockResolvedValue(activeSurvey);
+      moduleStorage.getItem.mockReturnValue({
+        lastPostponedDate: '2020-01-01',
+        postponeCountToday: 2,
+        firstShownTodayAt: null,
+        lastPostponedAt: null,
+      });
+
+      const { shouldShowModal, checkSurvey } = useFeedbackSurvey();
+      await checkSurvey();
+
+      expect(shouldShowModal.value).toBe(true);
+      expect(moduleStorage.setItem).toHaveBeenCalledWith(
+        STORAGE_KEY,
+        expect.objectContaining({ postponeCountToday: 0 }),
+      );
+    });
+
+    it('should not show modal when API call fails', async () => {
+      mockCheckSurvey.mockRejectedValue(new Error('fail'));
+
+      const { shouldShowModal, checkSurvey } = useFeedbackSurvey();
+      await checkSurvey();
+
+      expect(shouldShowModal.value).toBe(false);
+    });
+  });
+
+  describe('onPostpone', () => {
+    it('should hide modal and write postpone state for new day', () => {
+      moduleStorage.getItem.mockReturnValue({
+        lastPostponedDate: '2020-01-01',
+        postponeCountToday: 5,
+        firstShownTodayAt: null,
+        lastPostponedAt: null,
+      });
+
+      const { shouldShowModal, onPostpone } = useFeedbackSurvey();
+      shouldShowModal.value = true;
+
+      onPostpone();
+
+      expect(shouldShowModal.value).toBe(false);
+      expect(moduleStorage.setItem).toHaveBeenCalledWith(
+        STORAGE_KEY,
+        expect.objectContaining({
+          postponeCountToday: 1,
+          lastPostponedDate: today(),
+        }),
+      );
+    });
+
+    it('should increment postpone count for same day', () => {
+      moduleStorage.getItem.mockReturnValue({
+        lastPostponedDate: today(),
+        postponeCountToday: 1,
+        firstShownTodayAt: new Date().toISOString(),
+        lastPostponedAt: null,
+      });
+
+      const { onPostpone } = useFeedbackSurvey();
+      onPostpone();
+
+      expect(moduleStorage.setItem).toHaveBeenCalledWith(
+        STORAGE_KEY,
+        expect.objectContaining({ postponeCountToday: 2 }),
+      );
+    });
+
+    it('should preserve existing firstShownTodayAt', () => {
+      const existingTime = '2026-01-01T10:00:00.000Z';
+      moduleStorage.getItem.mockReturnValue({
+        lastPostponedDate: today(),
+        postponeCountToday: 0,
+        firstShownTodayAt: existingTime,
+        lastPostponedAt: null,
+      });
+
+      const { onPostpone } = useFeedbackSurvey();
+      onPostpone();
+
+      expect(moduleStorage.setItem).toHaveBeenCalledWith(
+        STORAGE_KEY,
+        expect.objectContaining({ firstShownTodayAt: existingTime }),
+      );
+    });
+  });
+
+  describe('onSubmitted', () => {
+    it('should hide modal and remove storage', () => {
+      const { shouldShowModal, onSubmitted } = useFeedbackSurvey();
+      shouldShowModal.value = true;
+
+      onSubmitted();
+
+      expect(shouldShowModal.value).toBe(false);
+      expect(moduleStorage.removeItem).toHaveBeenCalledWith(STORAGE_KEY);
+    });
+  });
+});

--- a/src/composables/useFeedbackSurvey.ts
+++ b/src/composables/useFeedbackSurvey.ts
@@ -1,0 +1,121 @@
+import { ref } from 'vue';
+import feedbackApi from '@/services/api/resources/conversational/feedback';
+import { moduleStorage } from '@/utils/storage';
+
+const STORAGE_KEY = 'data_feedback_state';
+const TWO_HOURS_MS = 2 * 60 * 60 * 1000;
+
+interface FeedbackStorageState {
+  lastPostponedAt: string | null;
+  postponeCountToday: number;
+  firstShownTodayAt: string | null;
+  lastPostponedDate: string | null;
+}
+
+function getDefaultState(): FeedbackStorageState {
+  return {
+    lastPostponedAt: null,
+    postponeCountToday: 0,
+    firstShownTodayAt: null,
+    lastPostponedDate: null,
+  };
+}
+
+function readState(): FeedbackStorageState {
+  return moduleStorage.getItem(STORAGE_KEY, getDefaultState());
+}
+
+function writeState(state: FeedbackStorageState): void {
+  moduleStorage.setItem(STORAGE_KEY, state);
+}
+
+function getTodayDate(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function canShowBasedOnPostpone(state: FeedbackStorageState): boolean {
+  const today = getTodayDate();
+
+  if (state.lastPostponedDate !== today) {
+    return true;
+  }
+
+  if (state.postponeCountToday >= 2) {
+    return false;
+  }
+
+  if (state.firstShownTodayAt) {
+    const elapsed = Date.now() - new Date(state.firstShownTodayAt).getTime();
+    if (elapsed < TWO_HOURS_MS) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+export function useFeedbackSurvey() {
+  const shouldShowModal = ref(false);
+  const surveyUuid = ref('');
+
+  async function checkSurvey(): Promise<void> {
+    try {
+      const response = await feedbackApi.checkSurvey();
+
+      if (!response.is_active || response.user_answered) {
+        shouldShowModal.value = false;
+        return;
+      }
+
+      surveyUuid.value = response.uuid;
+
+      const state = readState();
+
+      if (!canShowBasedOnPostpone(state)) {
+        shouldShowModal.value = false;
+        return;
+      }
+
+      const today = getTodayDate();
+      if (state.lastPostponedDate !== today) {
+        writeState({
+          ...getDefaultState(),
+          firstShownTodayAt: new Date().toISOString(),
+        });
+      }
+
+      shouldShowModal.value = true;
+    } catch {
+      shouldShowModal.value = false;
+    }
+  }
+
+  function onPostpone(): void {
+    shouldShowModal.value = false;
+
+    const state = readState();
+    const today = getTodayDate();
+
+    const isNewDay = state.lastPostponedDate !== today;
+
+    writeState({
+      lastPostponedAt: new Date().toISOString(),
+      postponeCountToday: isNewDay ? 1 : state.postponeCountToday + 1,
+      firstShownTodayAt: state.firstShownTodayAt ?? new Date().toISOString(),
+      lastPostponedDate: today,
+    });
+  }
+
+  function onSubmitted(): void {
+    shouldShowModal.value = false;
+    moduleStorage.removeItem(STORAGE_KEY);
+  }
+
+  return {
+    shouldShowModal,
+    surveyUuid,
+    checkSurvey,
+    onPostpone,
+    onSubmitted,
+  };
+}

--- a/src/composables/useFeedbackSurvey.ts
+++ b/src/composables/useFeedbackSurvey.ts
@@ -1,6 +1,8 @@
 import { ref } from 'vue';
 import feedbackApi from '@/services/api/resources/conversational/feedback';
 import { moduleStorage } from '@/utils/storage';
+import { UnnnicToastManager } from '@weni/unnnic-system';
+import i18n from '@/utils/plugins/i18n';
 
 const STORAGE_KEY = 'data_feedback_state';
 const TWO_HOURS_MS = 2 * 60 * 60 * 1000;
@@ -90,6 +92,8 @@ export function useFeedbackSurvey() {
     }
   }
 
+  const t = (key: string) => i18n.global.t(key);
+
   function onPostpone(): void {
     shouldShowModal.value = false;
 
@@ -104,11 +108,33 @@ export function useFeedbackSurvey() {
       firstShownTodayAt: state.firstShownTodayAt ?? new Date().toISOString(),
       lastPostponedDate: today,
     });
+
+    UnnnicToastManager.info(t('data_feedback.toast_postponed'), '', {
+      button: {
+        text: t('data_feedback.toast_postponed_respond'),
+        action: () => {
+          shouldShowModal.value = true;
+        },
+      },
+    });
   }
 
   function onSubmitted(): void {
     shouldShowModal.value = false;
     moduleStorage.removeItem(STORAGE_KEY);
+
+    UnnnicToastManager.success(t('data_feedback.toast_success'));
+  }
+
+  function onSubmitError(): void {
+    UnnnicToastManager.error(t('data_feedback.toast_error'), '', {
+      button: {
+        text: t('data_feedback.toast_error_retry'),
+        action: () => {
+          shouldShowModal.value = true;
+        },
+      },
+    });
   }
 
   return {
@@ -117,5 +143,6 @@ export function useFeedbackSurvey() {
     checkSurvey,
     onPostpone,
     onSubmitted,
+    onSubmitError,
   };
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1026,5 +1026,21 @@
   },
   "on": "On",
   "off": "Off",
-  "paused": "Paused"
+  "paused": "Paused",
+  "data_feedback": {
+    "title": "Share your experience with the Conversational AI Dashboard",
+    "description": "Considering your experience with this dashboard, please indicate how much you agree with the statements below:",
+    "q1": "I trust the data presented in this dashboard.",
+    "q2": "The data in this dashboard helps me make decisions.",
+    "q3": "With this dashboard, I can understand the impact (ROI) of AI conversations on business results.",
+    "textarea_label": "What could we improve in this dashboard? (optional)",
+    "textarea_placeholder": "Share suggestions to improve data clarity, trust, or usefulness.",
+    "strongly_agree": "Strongly agree",
+    "partially_agree": "Partially agree",
+    "neutral": "Neutral",
+    "partially_disagree": "Partially disagree",
+    "strongly_disagree": "Strongly disagree",
+    "postpone": "Postpone",
+    "submit": "Submit feedback"
+  }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1041,6 +1041,11 @@
     "partially_disagree": "Partially disagree",
     "strongly_disagree": "Strongly disagree",
     "postpone": "Postpone",
-    "submit": "Submit feedback"
+    "submit": "Submit feedback",
+    "toast_success": "Feedback sent successfully. Thank you!",
+    "toast_error": "We couldn't send your feedback.",
+    "toast_error_retry": "Try again",
+    "toast_postponed": "Feedback postponed. You can respond later.",
+    "toast_postponed_respond": "Respond now"
   }
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1040,6 +1040,11 @@
     "partially_disagree": "Parcialmente en desacuerdo",
     "strongly_disagree": "Totalmente en desacuerdo",
     "postpone": "Posponer",
-    "submit": "Enviar feedback"
+    "submit": "Enviar feedback",
+    "toast_success": "Feedback enviado con éxito. ¡Gracias!",
+    "toast_error": "No pudimos enviar tu feedback.",
+    "toast_error_retry": "Intentar de nuevo",
+    "toast_postponed": "Feedback pospuesto. Podrás responder después.",
+    "toast_postponed_respond": "Responder ahora"
   }
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1025,5 +1025,21 @@
   },
   "on": "Activa",
   "off": "Inactiva",
-  "paused": "Pausada"
+  "paused": "Pausada",
+  "data_feedback": {
+    "title": "Comparte tu experiencia con el Dashboard de IA Conversacional",
+    "description": "Considerando tu experiencia con este dashboard, indica cuánto estás de acuerdo con las afirmaciones a continuación:",
+    "q1": "Confío en los datos presentados en este dashboard.",
+    "q2": "Los datos de este dashboard me ayudan a tomar decisiones.",
+    "q3": "Con este dashboard, puedo entender el impacto (ROI) de las conversaciones de IA en los resultados del negocio.",
+    "textarea_label": "¿Qué podríamos mejorar en este dashboard? (opcional)",
+    "textarea_placeholder": "Comparte sugerencias para mejorar la claridad, confianza o utilidad de los datos.",
+    "strongly_agree": "Totalmente de acuerdo",
+    "partially_agree": "Parcialmente de acuerdo",
+    "neutral": "Neutral",
+    "partially_disagree": "Parcialmente en desacuerdo",
+    "strongly_disagree": "Totalmente en desacuerdo",
+    "postpone": "Posponer",
+    "submit": "Enviar feedback"
+  }
 }

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -1025,5 +1025,21 @@
   },
   "on": "Ativa",
   "off": "Desativada",
-  "paused": "Pausada"
+  "paused": "Pausada",
+  "data_feedback": {
+    "title": "Compartilhe sua experiência com o Dashboard de IA Conversacional",
+    "description": "Considerando sua experiência com este dashboard, indique o quanto você concorda com as afirmações abaixo:",
+    "q1": "Eu confio nos dados apresentados neste dashboard.",
+    "q2": "Os dados deste dashboard me ajudam a tomar decisões.",
+    "q3": "Com este dashboard, consigo entender o impacto (ROI) das conversas de IA nos resultados do negócio.",
+    "textarea_label": "O que poderíamos melhorar neste dashboard? (opcional)",
+    "textarea_placeholder": "Compartilhe sugestões para melhorar a clareza, confiança ou utilidade dos dados.",
+    "strongly_agree": "Concordo totalmente",
+    "partially_agree": "Concordo parcialmente",
+    "neutral": "Neutro",
+    "partially_disagree": "Discordo parcialmente",
+    "strongly_disagree": "Discordo totalmente",
+    "postpone": "Adiar",
+    "submit": "Enviar feedback"
+  }
 }

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -1040,6 +1040,11 @@
     "partially_disagree": "Discordo parcialmente",
     "strongly_disagree": "Discordo totalmente",
     "postpone": "Adiar",
-    "submit": "Enviar feedback"
+    "submit": "Enviar feedback",
+    "toast_success": "Feedback enviado com sucesso. Obrigado!",
+    "toast_error": "Não conseguimos enviar seu feedback.",
+    "toast_error_retry": "Tentar novamente",
+    "toast_postponed": "Feedback adiado. Você poderá responder depois.",
+    "toast_postponed_respond": "Responder agora"
   }
 }

--- a/src/services/api/resources/conversational/__tests__/feedback.spec.js
+++ b/src/services/api/resources/conversational/__tests__/feedback.spec.js
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+import feedbackService from '../feedback';
+import http from '@/services/api/http';
+import { useConfig } from '@/store/modules/config';
+import { useDashboards } from '@/store/modules/dashboards';
+
+vi.mock('@/services/api/http', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}));
+
+vi.mock('@/store/modules/config', () => ({
+  useConfig: vi.fn(),
+}));
+
+vi.mock('@/store/modules/dashboards', () => ({
+  useDashboards: vi.fn(),
+}));
+
+const PROJECT_UUID = 'project-uuid-123';
+const DASHBOARD_UUID = 'dashboard-uuid-456';
+
+describe('feedbackService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setActivePinia(createPinia());
+
+    useConfig.mockReturnValue({ project: { uuid: PROJECT_UUID } });
+    useDashboards.mockReturnValue({
+      currentDashboard: { uuid: DASHBOARD_UUID },
+    });
+  });
+
+  describe('checkSurvey', () => {
+    it('should call GET with correct params and return response', async () => {
+      const mockResponse = {
+        uuid: 'survey-1',
+        is_active: true,
+        user_answered: false,
+      };
+      http.get.mockResolvedValue(mockResponse);
+
+      const result = await feedbackService.checkSurvey();
+
+      expect(http.get).toHaveBeenCalledWith('/feedback/check-survey/', {
+        params: {
+          project_uuid: PROJECT_UUID,
+          dashboard: DASHBOARD_UUID,
+        },
+      });
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('should reject when API fails', async () => {
+      http.get.mockRejectedValue(new Error('Network Error'));
+
+      await expect(feedbackService.checkSurvey()).rejects.toThrow(
+        'Network Error',
+      );
+    });
+  });
+
+  describe('submitFeedback', () => {
+    const payload = {
+      type: 'CONVERSATIONAL',
+      dashboard: DASHBOARD_UUID,
+      survey: 'survey-1',
+      answers: [
+        { reference: 'TRUST', answer: '5', type: 'SCORE_1_5' },
+        { reference: 'COMMENT', answer: 'Great', type: 'TEXT' },
+      ],
+    };
+
+    it('should call POST with payload and return response', async () => {
+      const mockResponse = { uuid: 'feedback-1', ...payload };
+      http.post.mockResolvedValue(mockResponse);
+
+      const result = await feedbackService.submitFeedback(payload);
+
+      expect(http.post).toHaveBeenCalledWith('/feedback/', payload);
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('should reject when API fails', async () => {
+      http.post.mockRejectedValue(new Error('Server Error'));
+
+      await expect(feedbackService.submitFeedback(payload)).rejects.toThrow(
+        'Server Error',
+      );
+    });
+  });
+});

--- a/src/services/api/resources/conversational/feedback.ts
+++ b/src/services/api/resources/conversational/feedback.ts
@@ -1,0 +1,78 @@
+import http from '@/services/api/http';
+import { useConfig } from '@/store/modules/config';
+import { useDashboards } from '@/store/modules/dashboards';
+
+export const DashboardType = {
+  CONVERSATIONAL: 'CONVERSATIONAL',
+} as const;
+
+export const FormType = {
+  SCORE_1_5: 'SCORE_1_5',
+  TEXT: 'TEXT',
+} as const;
+
+export const Reference = {
+  TRUST: 'TRUST',
+  MAKE_DECISION: 'MAKE_DECISION',
+  ROI: 'ROI',
+  COMMENT: 'COMMENT',
+} as const;
+
+export interface CheckSurveyResponse {
+  uuid: string;
+  is_active: boolean;
+  user_answered: boolean;
+}
+
+export type DashboardTypeValue =
+  (typeof DashboardType)[keyof typeof DashboardType];
+export type FormTypeValue = (typeof FormType)[keyof typeof FormType];
+export type ReferenceValue = (typeof Reference)[keyof typeof Reference];
+
+export interface FeedbackAnswer {
+  reference: ReferenceValue;
+  answer: string;
+  type: FormTypeValue;
+}
+
+export interface SubmitFeedbackRequest {
+  type: DashboardTypeValue;
+  dashboard: string;
+  survey: string;
+  answers: FeedbackAnswer[];
+}
+
+export interface SubmitFeedbackResponse {
+  uuid: string;
+  type: DashboardTypeValue;
+  dashboard: string;
+  survey: string;
+  answers: FeedbackAnswer[];
+}
+
+export default {
+  async checkSurvey(): Promise<CheckSurveyResponse> {
+    const { project } = useConfig();
+    const { currentDashboard } = useDashboards();
+
+    const response = (await http.get('/feedback/check-survey/', {
+      params: {
+        project_uuid: project.uuid,
+        dashboard: currentDashboard.uuid,
+      },
+    })) as CheckSurveyResponse;
+
+    return response;
+  },
+
+  async submitFeedback(
+    payload: SubmitFeedbackRequest,
+  ): Promise<SubmitFeedbackResponse> {
+    const response = (await http.post(
+      '/feedback/',
+      payload,
+    )) as SubmitFeedbackResponse;
+
+    return response;
+  },
+};


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Add a feedback modal to the Conversational AI Dashboard so users can share their experience regarding data trust, decision-making usefulness, and ROI understanding. This will help the team collect structured user feedback to improve the dashboard. The modal is gated behind a feature flag (insightsDataFeedback) for controlled rollout.

### Summary of Changes
<!--- Describe your changes in detail -->

- New component: DataFeedbackModal.vue at src/components/insights/conversations/Feedback/ using <script setup lang="ts"> and UnnnicDialog (large size)
- 3 Likert-scale radio group questions (Strongly agree to Strongly disagree) using UnnnicRadioGroup + UnnnicRadio
- Optional textarea for improvement suggestions (max 1000 chars) using UnnnicTextArea
- "Postpone" (tertiary) and "Submit feedback" (primary, disabled until all 3 questions are answered) buttons in the footer
- Submit handler collects all values via console.log (placeholder for future API integration)
- Translations: Added data_feedback section to en.json, pt_br.json, and es.json with all modal texts
- Feature flag: Integrated DataFeedbackModal in Conversational.vue behind isFeatureFlagEnabled('insightsDataFeedback')

### Design Files <!--- (If not appropriate, remove this topic) -->
<!--- Links to the design files used for reference during implementation. -->

- [Design File](https://www.figma.com/design/HrECtH1SoEUjk5kaJe6dEL/Analytics---Research?node-id=2-17&m=dev)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new user-facing modal logic with client-side persistence and new API calls that can affect when/if users see prompts and how feedback is submitted. Risk is mitigated by the `insightsDataFeedback` feature flag and unit tests, but rollout should validate API availability and storage/cooldown behavior.
> 
> **Overview**
> Adds a feature-flagged (**`insightsDataFeedback`**) feedback survey flow to the Conversational Insights dashboard.
> 
> Introduces `DataFeedbackModal` with 3 required Likert questions plus an optional comment, and submits results to a new `conversational/feedback` API (`GET /feedback/check-survey/` to decide whether to show, `POST /feedback/` to send answers). A new `useFeedbackSurvey` composable manages when the modal appears using local storage (max 2 postpones/day and a 2-hour cooldown) and shows success/error/postpone toasts.
> 
> Includes new unit tests for the modal, composable, and API client, plus i18n strings (en/es/pt_br) for all modal/toast copy.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d6cd855080a7c4f25f596952da4153b9880cb7e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->