### PR TITLE
[ENGAGE-7008] fix: attendant table empty after disconnect some agent

### DIFF
--- a/src/components/insights/humanSupport/Analysis/Tables/Attendant.vue
+++ b/src/components/insights/humanSupport/Analysis/Tables/Attendant.vue
@@ -91,6 +91,7 @@ const {
 } = useInfiniteScrollTable<AttendantDataResult, FormattedAttendantData>({
   fetchData,
   formatResults,
+  sort: currentSort.value,
 });
 
 const formattedHeaders = computed(() => {

--- a/src/components/insights/humanSupport/Analysis/Tables/Finished.vue
+++ b/src/components/insights/humanSupport/Analysis/Tables/Finished.vue
@@ -84,6 +84,7 @@ const {
 } = useInfiniteScrollTable<FinishedDataResult, FormattedFinishedData>({
   fetchData,
   formatResults,
+  sort: currentSort.value,
 });
 
 const formattedHeaders = computed(() => {

--- a/src/components/insights/humanSupport/Monitoring/Tables/Attendant.vue
+++ b/src/components/insights/humanSupport/Monitoring/Tables/Attendant.vue
@@ -52,6 +52,10 @@ import { formatSecondsToTime } from '@/utils/time';
 import { useInfiniteScrollTable } from '@/composables/useInfiniteScrollTable';
 import { storeToRefs } from 'pinia';
 
+defineOptions({
+  name: 'AttendantTable',
+});
+
 type FormattedAttendantData = Omit<
   AttendantDataResult,
   | 'average_first_response_time'
@@ -129,6 +133,7 @@ const {
 } = useInfiniteScrollTable<AttendantDataResult, FormattedAttendantData>({
   fetchData,
   formatResults,
+  sort: currentSort.value,
 });
 
 const isLoadingVisible = computed(() => {

--- a/src/components/insights/humanSupport/Monitoring/Tables/InAwaiting.vue
+++ b/src/components/insights/humanSupport/Monitoring/Tables/InAwaiting.vue
@@ -80,6 +80,7 @@ const {
 } = useInfiniteScrollTable<InAwaitingDataResult, FormattedInAwaitingData>({
   fetchData,
   formatResults,
+  sort: currentSort.value,
 });
 
 const isLoadingVisible = computed(() => {

--- a/src/components/insights/humanSupport/Monitoring/Tables/InProgress.vue
+++ b/src/components/insights/humanSupport/Monitoring/Tables/InProgress.vue
@@ -87,6 +87,7 @@ const {
 } = useInfiniteScrollTable<InProgressDataResult, FormattedInProgressData>({
   fetchData,
   formatResults,
+  sort: currentSort.value,
 });
 
 const isLoadingVisible = computed(() => {
@@ -138,7 +139,7 @@ const isRequestPending = ref(false);
 
 const loadDataSafely = async (sortValue: typeof currentSort.value) => {
   if (isRequestPending.value) return;
-  
+
   try {
     isRequestPending.value = true;
     await resetAndLoadData(sortValue);

--- a/src/composables/useInfiniteScrollTable.ts
+++ b/src/composables/useInfiniteScrollTable.ts
@@ -9,12 +9,19 @@ interface UseInfiniteScrollTableOptions<T, R> {
   ) => Promise<{ results: T[]; count: number }>;
   formatResults: (_results: T[]) => R[];
   onSortChange?: () => void;
+  sort?: { itemKey: string; order: string };
 }
 
 export function useInfiniteScrollTable<T = any, R = any>(
   options: UseInfiniteScrollTableOptions<T, R>,
 ) {
-  const { pageSize = 12, fetchData, formatResults, onSortChange } = options;
+  const {
+    pageSize = 12,
+    fetchData,
+    formatResults,
+    onSortChange,
+    sort,
+  } = options;
 
   const isLoading = ref(false);
   const isLoadingMore = ref(false);
@@ -27,8 +34,12 @@ export function useInfiniteScrollTable<T = any, R = any>(
     () => formattedItems.value.length < totalCount.value,
   );
 
-  const buildOrdering = (sort: { itemKey: string; order: string }) => {
-    return sort.order === 'desc' ? `-${sort.itemKey}` : sort.itemKey;
+  const buildOrdering = (
+    buildSort: { itemKey: string; order: string } = sort,
+  ) => {
+    return buildSort.order === 'desc'
+      ? `-${buildSort.itemKey}`
+      : buildSort.itemKey;
   };
 
   const loadMoreData = async (currentSort: {


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When disconnecting an agent, the reload was interrupted by a problem related to the table's sorting, forcing the user to reload the data to continue viewing the agent table.


### Summary of Changes
<!--- Describe your changes in detail -->
- Add sorting functionality to useInfiniteScrollTable 
