### PR TITLE
[ENGAGE-7332] Fix: undefined sales funnel widget

### DIFF
--- a/src/components/insights/widgets/SalesFunnelWidget.vue
+++ b/src/components/insights/widgets/SalesFunnelWidget.vue
@@ -26,7 +26,7 @@
           {{
             formatCurrency(
               (salesFunnelWidgetData?.total_value || 0) / 100,
-              currencySymbols[salesFunnelWidgetData?.currency || 'USD'],
+              salesFunnelWidgetData?.currency || 'USD',
               i18n.global.locale,
             )
           }}
@@ -40,7 +40,7 @@
           {{
             formatCurrency(
               (salesFunnelWidgetData?.average_ticket || 0) / 100,
-              currencySymbols[salesFunnelWidgetData?.currency || 'USD'],
+              salesFunnelWidgetData?.currency || 'USD',
               i18n.global.locale,
             )
           }}
@@ -59,7 +59,6 @@ import { computed } from 'vue';
 import { useConversationalWidgets } from '@/store/modules/conversational/widgets';
 import { UnnnicChartFunnel } from '@weni/unnnic-system';
 import WarningMessage from '@/components/WarningMessage.vue';
-import { currencySymbols } from '@/utils/currency';
 import {
   formatPercentage,
   formatNumber,

--- a/src/components/insights/widgets/__tests__/DynamicCard.spec.js
+++ b/src/components/insights/widgets/__tests__/DynamicCard.spec.js
@@ -20,14 +20,6 @@ vi.mock('@/utils/time', () => ({
   formatSecondsToHumanString: vi.fn((seconds) => `${seconds} seconds`),
 }));
 
-vi.mock('@/utils/currency', () => ({
-  currencySymbols: {
-    USD: '$',
-    EUR: '€',
-    BRL: 'R$',
-  },
-}));
-
 vi.mock('vue-i18n', async (importOriginal) => {
   const actual = await importOriginal();
   return {
@@ -209,8 +201,8 @@ describe('DynamicCard', () => {
 
         const result = wrapper.vm.widgetVtexData;
         expect(result.orders).toBe('4');
-        expect(result.total_value).toBe('$ 1,000.50');
-        expect(result.average_ticket).toBe('$ 250.75');
+        expect(result.total_value).toBe('$1,000.50');
+        expect(result.average_ticket).toBe('$250.75');
       });
 
       it('should handle empty VTEX order data', () => {
@@ -261,8 +253,8 @@ describe('DynamicCard', () => {
         });
 
         const result = wrapper.vm.widgetVtexConversionsData;
-        expect(result.utm_data.accumulated_total).toBe('$ 5,000.00');
-        expect(result.utm_data.medium_ticket).toBe('$ 125.50');
+        expect(result.utm_data.accumulated_total).toBe('$5,000.00');
+        expect(result.utm_data.medium_ticket).toBe('$125.50');
         expect(result.graph_data).toEqual(mockData.graph_data);
       });
 
@@ -333,7 +325,7 @@ describe('DynamicCard', () => {
           data: { value: 1234.56 },
         };
         const result = wrapper.vm.getWidgetFormattedData(widget);
-        expect(result).toBe('$ 1,234.56');
+        expect(result).toBe('$1,234.56');
       });
 
       it('should format regular number data correctly', () => {
@@ -707,7 +699,7 @@ describe('DynamicCard', () => {
 
       const props = wrapper.vm.widgetProps;
       expect(props.isLoadingData).toBe(true);
-      expect(props.data.utm_data.accumulated_total).toBe('$ 1,000.00');
+      expect(props.data.utm_data.accumulated_total).toBe('$1,000.00');
     });
   });
 });

--- a/src/composables/__tests__/useWidgetFormatting.spec.js
+++ b/src/composables/__tests__/useWidgetFormatting.spec.js
@@ -7,12 +7,13 @@ import { useDashboards } from '@/store/modules/dashboards';
 
 // Mock the numbers utility
 vi.mock('@/utils/numbers', () => ({
-  formatCurrency: vi.fn(
-    (value, symbol, locale) =>
-      `${symbol} ${(value || 0).toLocaleString(locale || 'en-US', {
-        minimumFractionDigits: 2,
-        maximumFractionDigits: 2,
-      })}`,
+  formatCurrency: vi.fn((value, currencyCode, locale) =>
+    new Intl.NumberFormat(locale || 'en-US', {
+      style: 'currency',
+      currency: currencyCode || 'USD',
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(value || 0),
   ),
   formatPercentageFixed: vi.fn(
     (value, locale) =>
@@ -51,16 +52,6 @@ vi.mock('@/utils/time', () => ({
   ),
 }));
 
-// Mock currency utility
-vi.mock('@/utils/currency', () => ({
-  currencySymbols: {
-    USD: '$',
-    EUR: '€',
-    BRL: 'R$',
-    GBP: '£',
-  },
-}));
-
 describe('useWidgetFormatting', () => {
   let pinia;
   let dashboardsStore;
@@ -92,14 +83,14 @@ describe('useWidgetFormatting', () => {
   });
 
   describe('formatCurrency', () => {
-    it('should format currency with USD symbol correctly', () => {
+    it('should format currency with USD code correctly', () => {
       const { formatCurrency } = useWidgetFormatting();
 
       const result = formatCurrency(1234.567);
-      expect(result).toBe('$ 1,234.57');
+      expect(result).toBe('$1,234.57');
     });
 
-    it('should format currency with EUR symbol correctly', () => {
+    it('should format currency with EUR code correctly', () => {
       dashboardsStore.currentDashboard = {
         config: { currency_type: 'EUR' },
       };
@@ -107,51 +98,51 @@ describe('useWidgetFormatting', () => {
       const { formatCurrency } = useWidgetFormatting();
 
       const result = formatCurrency(1234.567);
-      expect(result).toBe('€ 1,234.57');
+      expect(result).toBe('€1,234.57');
     });
 
     it('should handle zero values', () => {
       const { formatCurrency } = useWidgetFormatting();
 
       const result = formatCurrency(0);
-      expect(result).toBe('$ 0.00');
+      expect(result).toBe('$0.00');
     });
 
     it('should handle null/undefined values', () => {
       const { formatCurrency } = useWidgetFormatting();
 
-      expect(formatCurrency(null)).toBe('$ 0.00');
-      expect(formatCurrency(undefined)).toBe('$ 0.00');
+      expect(formatCurrency(null)).toBe('$0.00');
+      expect(formatCurrency(undefined)).toBe('$0.00');
     });
 
     it('should use custom locale when provided', () => {
       const { formatCurrency } = useWidgetFormatting();
 
       const result = formatCurrency(1234.567, 'pt-BR');
-      expect(result).toBe('$ 1.234,57');
+      expect(result).toMatch(/US\$\s*1\.234,57/);
     });
 
-    it('should handle missing currency config gracefully', () => {
+    it('should fallback to USD when currency config is missing', () => {
       dashboardsStore.currentDashboard = { config: {} };
 
       const { formatCurrency } = useWidgetFormatting();
 
       const result = formatCurrency(1234.567);
-      expect(result).toBe('undefined 1,234.57');
+      expect(result).toBe('$1,234.57');
     });
 
     it('should handle large numbers', () => {
       const { formatCurrency } = useWidgetFormatting();
 
       const result = formatCurrency(1234567.89);
-      expect(result).toBe('$ 1,234,567.89');
+      expect(result).toBe('$1,234,567.89');
     });
 
     it('should handle small decimal numbers', () => {
       const { formatCurrency } = useWidgetFormatting();
 
       const result = formatCurrency(0.01);
-      expect(result).toBe('$ 0.01');
+      expect(result).toBe('$0.01');
     });
   });
 
@@ -287,7 +278,7 @@ describe('useWidgetFormatting', () => {
       };
 
       const result = getWidgetFormattedData(widget);
-      expect(result).toBe('$ 1,234.56');
+      expect(result).toBe('$1,234.56');
     });
 
     it('should format regular number data correctly', () => {
@@ -459,8 +450,8 @@ describe('useWidgetFormatting', () => {
 
       const result = formatVtexData(vtexData);
 
-      expect(result.total_value).toBe('$ 1,000.50');
-      expect(result.average_ticket).toBe('$ 250.75');
+      expect(result.total_value).toBe('$1,000.50');
+      expect(result.average_ticket).toBe('$250.75');
       expect(result.orders).toBe('4');
     });
 
@@ -491,8 +482,8 @@ describe('useWidgetFormatting', () => {
 
       const result = formatVtexData(vtexData);
 
-      expect(result.total_value).toBe('$ 0.00');
-      expect(result.average_ticket).toBe('$ 0.00');
+      expect(result.total_value).toBe('$0.00');
+      expect(result.average_ticket).toBe('$0.00');
       expect(result.orders).toBe('0');
     });
 
@@ -527,8 +518,8 @@ describe('useWidgetFormatting', () => {
 
       const result = formatVtexData(vtexData);
 
-      expect(result.total_value).toBe('€ 1,000.00');
-      expect(result.average_ticket).toBe('€ 250.00');
+      expect(result.total_value).toBe('€1,000.00');
+      expect(result.average_ticket).toBe('€250.00');
       expect(result.orders).toBe('4');
     });
   });
@@ -540,7 +531,7 @@ describe('useWidgetFormatting', () => {
       const { formatCurrency, formatPercentage, formatNumber } =
         useWidgetFormatting();
 
-      expect(formatCurrency(1234.56)).toBe('$ 1.234,56');
+      expect(formatCurrency(1234.56)).toMatch(/US\$\s*1\.234,56/);
       expect(formatPercentage(75.5)).toBe('75,50%');
       expect(formatNumber(1234567)).toBe('1.234.567');
     });
@@ -551,7 +542,7 @@ describe('useWidgetFormatting', () => {
       const { formatCurrency } = useWidgetFormatting();
 
       const result = formatCurrency(1234.56);
-      expect(result).toBe('$ 1,234.56');
+      expect(result).toBe('$1,234.56');
     });
   });
 
@@ -559,26 +550,24 @@ describe('useWidgetFormatting', () => {
     it('should react to dashboard changes', () => {
       const { formatCurrency } = useWidgetFormatting();
 
-      // Initial currency
       let result = formatCurrency(100);
-      expect(result).toBe('$ 100.00');
+      expect(result).toBe('$100.00');
 
-      // Change currency in dashboard
       dashboardsStore.currentDashboard = {
         config: { currency_type: 'EUR' },
       };
 
       result = formatCurrency(100);
-      expect(result).toBe('€ 100.00');
+      expect(result).toBe('€100.00');
     });
 
-    it('should handle missing dashboard config', () => {
+    it('should fallback to USD when dashboard config is missing', () => {
       dashboardsStore.currentDashboard = {};
 
       const { formatCurrency } = useWidgetFormatting();
 
       const result = formatCurrency(100);
-      expect(result).toBe('undefined 100.00');
+      expect(result).toBe('$100.00');
     });
 
     it('should handle null dashboard', () => {
@@ -625,14 +614,14 @@ describe('useWidgetFormatting', () => {
       const { formatCurrency } = useWidgetFormatting();
 
       const result = formatCurrency(999999999999.99);
-      expect(result).toBe('$ 999,999,999,999.99');
+      expect(result).toBe('$999,999,999,999.99');
     });
 
     it('should handle negative numbers', () => {
       const { formatCurrency, formatPercentage, formatNumber } =
         useWidgetFormatting();
 
-      expect(formatCurrency(-100.5)).toBe('$ -100.50');
+      expect(formatCurrency(-100.5)).toBe('-$100.50');
       expect(formatPercentage(-25.5)).toBe('-25.50%');
       expect(formatNumber(-1000)).toBe('-1,000');
     });

--- a/src/composables/useWidgetFormatting.js
+++ b/src/composables/useWidgetFormatting.js
@@ -4,7 +4,6 @@ import { isNumber } from 'lodash';
 
 import { useDashboards } from '@/store/modules/dashboards';
 import { formatSecondsToHumanString } from '@/utils/time';
-import { currencySymbols } from '@/utils/currency';
 import {
   formatCurrency,
   formatPercentageFixed,
@@ -30,9 +29,8 @@ export function useWidgetFormatting() {
     value,
     localeValue = locale.value || 'en-US',
   ) => {
-    const symbol =
-      currencySymbols[currentDashboard.value?.config?.currency_type];
-    return formatCurrency(value, symbol, localeValue);
+    const currencyCode = currentDashboard.value?.config?.currency_type || 'USD';
+    return formatCurrency(value, currencyCode, localeValue);
   };
 
   /**

--- a/src/utils/__tests__/numbers.spec.js
+++ b/src/utils/__tests__/numbers.spec.js
@@ -96,37 +96,46 @@ describe('Number Utilities', () => {
   });
 
   describe('formatCurrency', () => {
-    it('formats currency with USD symbol correctly', () => {
-      expect(formatCurrency(1234.567, '$')).toBe('$ 1,234.57');
+    it('formats currency with USD code correctly', () => {
+      expect(formatCurrency(1234.567, 'USD')).toBe('$1,234.57');
     });
 
-    it('formats currency with EUR symbol correctly', () => {
-      expect(formatCurrency(1234.567, '€')).toBe('€ 1,234.57');
+    it('formats currency with EUR code correctly', () => {
+      expect(formatCurrency(1234.567, 'EUR')).toBe('€1,234.57');
+    });
+
+    it('formats currency with COP code correctly', () => {
+      expect(formatCurrency(1234.567, 'COP')).toBe('COP\u00a01,234.57');
     });
 
     it('handles zero values', () => {
-      expect(formatCurrency(0, '$')).toBe('$ 0.00');
+      expect(formatCurrency(0, 'USD')).toBe('$0.00');
     });
 
     it('handles null/undefined values', () => {
-      expect(formatCurrency(null, '$')).toBe('$ 0.00');
-      expect(formatCurrency(undefined, '$')).toBe('$ 0.00');
+      expect(formatCurrency(null, 'USD')).toBe('$0.00');
+      expect(formatCurrency(undefined, 'USD')).toBe('$0.00');
     });
 
     it('uses custom locale when provided', () => {
-      expect(formatCurrency(1234.567, '$', 'pt-BR')).toBe('$ 1.234,57');
+      expect(formatCurrency(1234.567, 'USD', 'pt-BR')).toBe('US$\u00a01.234,57');
     });
 
     it('handles large numbers', () => {
-      expect(formatCurrency(1234567.89, '$')).toBe('$ 1,234,567.89');
+      expect(formatCurrency(1234567.89, 'USD')).toBe('$1,234,567.89');
     });
 
     it('handles small decimal numbers', () => {
-      expect(formatCurrency(0.01, '$')).toBe('$ 0.01');
+      expect(formatCurrency(0.01, 'USD')).toBe('$0.01');
     });
 
     it('handles negative numbers', () => {
-      expect(formatCurrency(-100.5, '$')).toBe('$ -100.50');
+      expect(formatCurrency(-100.5, 'USD')).toBe('-$100.50');
+    });
+
+    it('falls back to USD when currency code is not provided', () => {
+      expect(formatCurrency(100, null)).toBe('$100.00');
+      expect(formatCurrency(100, undefined)).toBe('$100.00');
     });
   });
 

--- a/src/utils/currency.js
+++ b/src/utils/currency.js
@@ -1,6 +1,0 @@
-export const currencySymbols = {
-  BRL: 'R$',
-  ARS: '$',
-  USD: '$',
-  EUR: '€',
-};

--- a/src/utils/numbers.ts
+++ b/src/utils/numbers.ts
@@ -60,24 +60,24 @@ export function formatPercentageFixed(value: number, locale?: string): string {
 }
 
 /**
- * Formats a currency value with proper symbol and locale.
+ * Formats a currency value using the native Intl.NumberFormat API.
+ * Supports all ISO 4217 currency codes without manual symbol mapping.
  * @param value - The currency value
- * @param currencySymbol - The currency symbol to use
+ * @param currencyCode - The ISO 4217 currency code (e.g. 'USD', 'BRL', 'COP')
  * @param locale - The locale string for formatting
  * @returns A formatted currency string
  */
 export function formatCurrency(
   value: number,
-  currencySymbol: string,
+  currencyCode: string,
   locale?: string,
 ): string {
-  return `${currencySymbol} ${Number(value || 0).toLocaleString(
-    locale || 'en-US',
-    {
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
-    },
-  )}`;
+  return new Intl.NumberFormat(locale || 'en-US', {
+    style: 'currency',
+    currency: currencyCode || 'USD',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value || 0);
 }
 
 /**


### PR DESCRIPTION
## Description
### Type of Change
* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [x] Refactoring (no functional changes, no api changes)
* [x] Tests
* [ ] Other

### Motivation and Context
The sales funnel widget (`SalesFunnelWidget.vue`) was rendering `undefined` for currency values when the API returned a currency code not present in the manual mapping (e.g. `COP` - Colombian Peso). The `currencySymbols` map in `currency.js` only supported 4 currencies (BRL, ARS, USD, EUR), causing any other currency to resolve to `undefined` and display as `undefined 5.569.645,00`.

### Summary of Changes
- Replaced the manual `currencySymbols` mapping with the native `Intl.NumberFormat` API in the `formatCurrency` function (`src/utils/numbers.ts`), which now receives an ISO 4217 currency code (e.g. `'USD'`, `'COP'`, `'BRL'`) instead of a hardcoded symbol. This adds automatic support for all world currencies without any manual maintenance.
- Updated `SalesFunnelWidget.vue` and `useWidgetFormatting.js` to pass the currency code directly to `formatCurrency` instead of looking up a symbol in the map. Added a fallback to `'USD'` when currency config is missing.
- Deleted `src/utils/currency.js` as it is no longer needed.
- Updated unit tests across `numbers.spec.js`, `useWidgetFormatting.spec.js`, and `DynamicCard.spec.js` to reflect the new Intl-based formatting, including a new test case for COP and fallback behavior for missing currency codes.

### Design Files <!--- (If not appropriate, remove this topic) -->
<!--- Links to the design files used for reference during implementation. -->

- [Design File 1](link_to_design_file_1)

### Demonstration <!--- (If not appropriate, remove this topic) -->
<!--- Include a screenshot or video showcasing a feature or fix implemented in this pull request. -->
