### PR TITLE
[ENGAGE-7236] Feat: update unnnic with new tokens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@rspack/core": "^1.1.5",
         "@sentry/vue": "^9.19.0",
         "@vueuse/core": "^10.11.0",
-        "@weni/unnnic-system": "3.24.4-redesign.4",
+        "@weni/unnnic-system": "^3.24.5-redesign.0",
         "axios": "^1.7.2",
         "chart.js": "^4.4.2",
         "chartjs-chart-treemap": "^3.1.0",
@@ -5466,9 +5466,9 @@
       }
     },
     "node_modules/@weni/unnnic-system": {
-      "version": "3.24.4-redesign.4",
-      "resolved": "https://registry.npmjs.org/@weni/unnnic-system/-/unnnic-system-3.24.4-redesign.4.tgz",
-      "integrity": "sha512-axFZykgLaLJGfW3slDq+biXQq+rzNqWdszXg7riamJfPKbdKaVkO8BcFaltEGmV2csPbEtJ00wHpEuCRR+PjSQ==",
+      "version": "3.24.5-redesign.0",
+      "resolved": "https://registry.npmjs.org/@weni/unnnic-system/-/unnnic-system-3.24.5-redesign.0.tgz",
+      "integrity": "sha512-d/iWBS6Ps99Wlo/wLFskxsxKrgrjpZBgfCGmPTsQPXMkXKHb/8nt57sJQVrvnveY4WhutJCIYj/QJrkt3xFJgQ==",
       "dependencies": {
         "@iconify/vue": "^5.0.0",
         "@vueuse/components": "^10.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@rspack/core": "^1.1.5",
         "@sentry/vue": "^9.19.0",
         "@vueuse/core": "^10.11.0",
-        "@weni/unnnic-system": "^3.24.5-redesign.0",
+        "@weni/unnnic-system": "^3.24.5-redesign.1",
         "axios": "^1.7.2",
         "chart.js": "^4.4.2",
         "chartjs-chart-treemap": "^3.1.0",
@@ -5466,9 +5466,9 @@
       }
     },
     "node_modules/@weni/unnnic-system": {
-      "version": "3.24.5-redesign.0",
-      "resolved": "https://registry.npmjs.org/@weni/unnnic-system/-/unnnic-system-3.24.5-redesign.0.tgz",
-      "integrity": "sha512-d/iWBS6Ps99Wlo/wLFskxsxKrgrjpZBgfCGmPTsQPXMkXKHb/8nt57sJQVrvnveY4WhutJCIYj/QJrkt3xFJgQ==",
+      "version": "3.24.5-redesign.1",
+      "resolved": "https://registry.npmjs.org/@weni/unnnic-system/-/unnnic-system-3.24.5-redesign.1.tgz",
+      "integrity": "sha512-od2/pkmFiQVwV+Hb18x1rj43Yme9d3NrlGLxAiP/WtGe9N+6jVUyXdh8ZA1PLf3geolXwizPGuuWsGbgs3E7/g==",
       "dependencies": {
         "@iconify/vue": "^5.0.0",
         "@vueuse/components": "^10.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@rspack/core": "^1.1.5",
         "@sentry/vue": "^9.19.0",
         "@vueuse/core": "^10.11.0",
-        "@weni/unnnic-system": "^3.24.2",
+        "@weni/unnnic-system": "3.24.4-redesign.2",
         "axios": "^1.7.2",
         "chart.js": "^4.4.2",
         "chartjs-chart-treemap": "^3.1.0",
@@ -5466,9 +5466,9 @@
       }
     },
     "node_modules/@weni/unnnic-system": {
-      "version": "3.24.2",
-      "resolved": "https://registry.npmjs.org/@weni/unnnic-system/-/unnnic-system-3.24.2.tgz",
-      "integrity": "sha512-//J2pNwccgzE3uL4coWtEPmNR3s6cBexkNBJVAGdOy2GCOmYiB3JnT4G4Y5ynauo08iksHWc+7MSInV6c1yBSQ==",
+      "version": "3.24.4-redesign.2",
+      "resolved": "https://registry.npmjs.org/@weni/unnnic-system/-/unnnic-system-3.24.4-redesign.2.tgz",
+      "integrity": "sha512-nEyP9q6iaDJRP+jbUj4SrVRCClOWP6v1GatbWupTAYATVghdG/s9Ennd8X+e2l9HhcXkt63sgzj0oMmQxcd97A==",
       "dependencies": {
         "@iconify/vue": "^5.0.0",
         "@vueuse/components": "^10.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@rspack/core": "^1.1.5",
         "@sentry/vue": "^9.19.0",
         "@vueuse/core": "^10.11.0",
-        "@weni/unnnic-system": "^3.24.5-redesign.1",
+        "@weni/unnnic-system": "^3.24.5-redesign.2",
         "axios": "^1.7.2",
         "chart.js": "^4.4.2",
         "chartjs-chart-treemap": "^3.1.0",
@@ -5466,9 +5466,9 @@
       }
     },
     "node_modules/@weni/unnnic-system": {
-      "version": "3.24.5-redesign.1",
-      "resolved": "https://registry.npmjs.org/@weni/unnnic-system/-/unnnic-system-3.24.5-redesign.1.tgz",
-      "integrity": "sha512-od2/pkmFiQVwV+Hb18x1rj43Yme9d3NrlGLxAiP/WtGe9N+6jVUyXdh8ZA1PLf3geolXwizPGuuWsGbgs3E7/g==",
+      "version": "3.24.5-redesign.2",
+      "resolved": "https://registry.npmjs.org/@weni/unnnic-system/-/unnnic-system-3.24.5-redesign.2.tgz",
+      "integrity": "sha512-XczhnzaVCi36UODNhwXbhVTW2nuvsuIN8/3Kgne/UABXtc/1MIlJk0HUnnt69t1YtxtyxLC5cAR0zw/BlYWGCg==",
       "dependencies": {
         "@iconify/vue": "^5.0.0",
         "@vueuse/components": "^10.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@rspack/core": "^1.1.5",
         "@sentry/vue": "^9.19.0",
         "@vueuse/core": "^10.11.0",
-        "@weni/unnnic-system": "3.24.4-redesign.2",
+        "@weni/unnnic-system": "3.24.4-redesign.4",
         "axios": "^1.7.2",
         "chart.js": "^4.4.2",
         "chartjs-chart-treemap": "^3.1.0",
@@ -5466,9 +5466,9 @@
       }
     },
     "node_modules/@weni/unnnic-system": {
-      "version": "3.24.4-redesign.2",
-      "resolved": "https://registry.npmjs.org/@weni/unnnic-system/-/unnnic-system-3.24.4-redesign.2.tgz",
-      "integrity": "sha512-nEyP9q6iaDJRP+jbUj4SrVRCClOWP6v1GatbWupTAYATVghdG/s9Ennd8X+e2l9HhcXkt63sgzj0oMmQxcd97A==",
+      "version": "3.24.4-redesign.4",
+      "resolved": "https://registry.npmjs.org/@weni/unnnic-system/-/unnnic-system-3.24.4-redesign.4.tgz",
+      "integrity": "sha512-axFZykgLaLJGfW3slDq+biXQq+rzNqWdszXg7riamJfPKbdKaVkO8BcFaltEGmV2csPbEtJ00wHpEuCRR+PjSQ==",
       "dependencies": {
         "@iconify/vue": "^5.0.0",
         "@vueuse/components": "^10.4.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@rspack/core": "^1.1.5",
     "@sentry/vue": "^9.19.0",
     "@vueuse/core": "^10.11.0",
-    "@weni/unnnic-system": "3.24.4-redesign.2",
+    "@weni/unnnic-system": "3.24.4-redesign.4",
     "axios": "^1.7.2",
     "chart.js": "^4.4.2",
     "chartjs-chart-treemap": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@rspack/core": "^1.1.5",
     "@sentry/vue": "^9.19.0",
     "@vueuse/core": "^10.11.0",
-    "@weni/unnnic-system": "3.24.4-redesign.4",
+    "@weni/unnnic-system": "^3.24.5-redesign.0",
     "axios": "^1.7.2",
     "chart.js": "^4.4.2",
     "chartjs-chart-treemap": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@rspack/core": "^1.1.5",
     "@sentry/vue": "^9.19.0",
     "@vueuse/core": "^10.11.0",
-    "@weni/unnnic-system": "^3.24.5-redesign.0",
+    "@weni/unnnic-system": "^3.24.5-redesign.1",
     "axios": "^1.7.2",
     "chart.js": "^4.4.2",
     "chartjs-chart-treemap": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@rspack/core": "^1.1.5",
     "@sentry/vue": "^9.19.0",
     "@vueuse/core": "^10.11.0",
-    "@weni/unnnic-system": "^3.24.5-redesign.1",
+    "@weni/unnnic-system": "^3.24.5-redesign.2",
     "axios": "^1.7.2",
     "chart.js": "^4.4.2",
     "chartjs-chart-treemap": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@rspack/core": "^1.1.5",
     "@sentry/vue": "^9.19.0",
     "@vueuse/core": "^10.11.0",
-    "@weni/unnnic-system": "^3.24.2",
+    "@weni/unnnic-system": "3.24.4-redesign.2",
     "axios": "^1.7.2",
     "chart.js": "^4.4.2",
     "chartjs-chart-treemap": "^3.1.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -23,10 +23,7 @@
       class="loading-container"
       data-testid="loading-container-dashboards"
     >
-      <img
-        src="./assets/images/weni-loading.svg"
-        width="64"
-      />
+      <UnnnicIconLoading size="xl" />
     </section>
     <InsightsLayout
       v-else-if="dashboards.length"

--- a/src/components/CheckboxList.vue
+++ b/src/components/CheckboxList.vue
@@ -64,6 +64,6 @@ export default defineComponent({
 .checkbox-list {
   display: flex;
   flex-wrap: wrap;
-  row-gap: $unnnic-spacing-nano;
+  row-gap: $unnnic-space-1;
 }
 </style>

--- a/src/components/CompleteOnboardingModal.vue
+++ b/src/components/CompleteOnboardingModal.vue
@@ -46,17 +46,17 @@ const emit = defineEmits(['close', 'finish-onboarding']);
     align-items: center;
     text-align: center;
     &__title {
-      font-size: $unnnic-font-size-title-sm;
-      font-weight: $unnnic-font-weight-black;
-      line-height: $unnnic-line-height-large * 1.75;
-      color: $unnnic-color-neutral-darkest;
+      font-size: 20px;
+      font-weight: 900;
+      line-height: 16px * 1.75;
+      color: $unnnic-color-gray-12;
     }
     &__info {
-      font-size: $unnnic-font-size-body-gt;
+      font-size: 14px;
       font-weight: $unnnic-font-weight-regular;
-      line-height: $unnnic-line-height-large * 1.375;
-      color: $unnnic-color-neutral-cloudy;
-      margin-top: $unnnic-spacing-xs;
+      line-height: 16px * 1.375;
+      color: $unnnic-color-gray-7;
+      margin-top: $unnnic-space-2;
     }
   }
 }

--- a/src/components/CompleteOnboardingModal.vue
+++ b/src/components/CompleteOnboardingModal.vue
@@ -46,15 +46,12 @@ const emit = defineEmits(['close', 'finish-onboarding']);
     align-items: center;
     text-align: center;
     &__title {
-      font-size: 20px;
+      font: $unnnic-font-display-2;
       font-weight: 900;
-      line-height: 16px * 1.75;
       color: $unnnic-color-gray-12;
     }
     &__info {
-      font-size: 14px;
-      font-weight: $unnnic-font-weight-regular;
-      line-height: 16px * 1.375;
+      font: $unnnic-font-body;
       color: $unnnic-color-gray-7;
       margin-top: $unnnic-space-2;
     }

--- a/src/components/DisconnectAgent.vue
+++ b/src/components/DisconnectAgent.vue
@@ -161,11 +161,7 @@ const handleTooltipText = computed(() => {
 
   &__text {
     color: $unnnic-color-gray-7;
-
-    font-family: $unnnic-font-family;
-    font-size: 14px;
-    font-weight: $unnnic-font-weight-regular;
-    line-height: 8px + 14px;
+    font: $unnnic-font-body;
   }
 }
 </style>

--- a/src/components/DisconnectAgent.vue
+++ b/src/components/DisconnectAgent.vue
@@ -149,7 +149,7 @@ const handleTooltipText = computed(() => {
   }
 
   :deep(.material-symbols-rounded.unnnic-icon-size--sm) {
-    font-size: $unnnic-font-size-title-sm;
+    font-size: 20px;
   }
 }
 
@@ -157,15 +157,15 @@ const handleTooltipText = computed(() => {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: $unnnic-spacing-sm;
+  gap: $unnnic-space-4;
 
   &__text {
-    color: $unnnic-color-neutral-cloudy;
+    color: $unnnic-color-gray-7;
 
-    font-family: $unnnic-font-family-secondary;
-    font-size: $unnnic-font-size-body-gt;
+    font-family: $unnnic-font-family;
+    font-size: 14px;
     font-weight: $unnnic-font-weight-regular;
-    line-height: $unnnic-line-height-md + $unnnic-font-size-body-gt;
+    line-height: 8px + 14px;
   }
 }
 </style>

--- a/src/components/FormAccordion.vue
+++ b/src/components/FormAccordion.vue
@@ -60,16 +60,16 @@ export default {
 
 <style lang="scss" scoped>
 .form-accordion {
-  border-radius: $unnnic-border-radius-sm;
-  border: $unnnic-border-width-thinner solid $unnnic-color-neutral-soft;
+  border-radius: $unnnic-radius-1;
+  border: 1px solid $unnnic-color-gray-2;
 
   &--active.highlighted {
-    background-color: $unnnic-color-weni-50;
-    border: 1px solid $unnnic-color-weni-500;
+    background-color: $unnnic-color-teal-1;
+    border: 1px solid $unnnic-color-teal-7;
   }
 
   :deep(.unnnic-collapse__header) {
-    padding: $unnnic-spacing-ant;
+    padding: $unnnic-space-3;
   }
 
   :deep(.unnnic-collapse__body) {
@@ -77,19 +77,19 @@ export default {
     padding: 0;
     box-sizing: border-box;
 
-    margin-top: - calc($unnnic-spacing-ant + $unnnic-spacing-nano);
-    padding: $unnnic-spacing-xs $unnnic-spacing-ant 0;
+    margin-top: - calc($unnnic-space-3 + $unnnic-space-1);
+    padding: $unnnic-space-2 $unnnic-space-3 0;
   }
 
   &__header {
     display: flex;
     align-items: center;
-    gap: $unnnic-spacing-nano;
+    gap: $unnnic-space-1;
 
-    color: $unnnic-color-neutral-dark;
-    font-size: $unnnic-font-size-body-gt;
+    color: $unnnic-color-gray-10;
+    font-size: 14px;
     font-weight: $unnnic-font-weight-bold;
-    line-height: $unnnic-line-height-small * 5.5;
+    line-height: 4px * 5.5;
   }
 }
 </style>

--- a/src/components/FormAccordion.vue
+++ b/src/components/FormAccordion.vue
@@ -87,9 +87,7 @@ export default {
     gap: $unnnic-space-1;
 
     color: $unnnic-color-gray-10;
-    font-size: 14px;
-    font-weight: $unnnic-font-weight-bold;
-    line-height: 4px * 5.5;
+    font: $unnnic-font-action;
   }
 }
 </style>

--- a/src/components/IconLoading.vue
+++ b/src/components/IconLoading.vue
@@ -13,7 +13,7 @@ export default {
 
 <style lang="scss" scoped>
 .unnnic-icon-loading.icon-loading {
-  font-size: $unnnic-font-size-body-lg * 3;
-  color: $unnnic-color-neutral-clean;
+  font-size: $unnnic-font-size * 3;
+  color: $unnnic-color-gray-5;
 }
 </style>

--- a/src/components/ProgressTable.vue
+++ b/src/components/ProgressTable.vue
@@ -74,7 +74,7 @@ const maxValue = computed(() => {
 .progress-table__loading {
   display: flex;
   flex-direction: column;
-  gap: $unnnic-spacing-nano;
+  gap: $unnnic-space-1;
 }
 
 .progress-table {

--- a/src/components/ProgressTableRowItem.vue
+++ b/src/components/ProgressTableRowItem.vue
@@ -133,9 +133,9 @@ const handleExpand = () => {
       content: '';
       display: block;
       width: 100%;
-      margin: $unnnic-spacing-nano 0;
-      height: $unnnic-border-width-thinner;
-      background-color: $unnnic-color-neutral-soft;
+      margin: $unnnic-space-1 0;
+      height: 1px;
+      background-color: $unnnic-color-gray-2;
     }
   }
 
@@ -145,14 +145,14 @@ const handleExpand = () => {
 
   &__main-row {
     & > * {
-      padding: $unnnic-spacing-sm 0;
+      padding: $unnnic-space-4 0;
     }
   }
 
   &__label {
     display: flex;
     align-items: center;
-    gap: $unnnic-spacing-xs;
+    gap: $unnnic-space-2;
 
     .label__icon {
       transform: rotate(-90deg);
@@ -172,11 +172,11 @@ const handleExpand = () => {
         overflow: hidden;
         text-overflow: ellipsis;
 
-        color: $unnnic-color-neutral-darkest;
-        font-family: $unnnic-font-family-secondary;
-        font-size: $unnnic-font-size-body-lg;
+        color: $unnnic-color-gray-12;
+        font-family: $unnnic-font-family;
+        font-size: $unnnic-font-size;
         font-weight: $unnnic-font-weight-regular;
-        line-height: $unnnic-font-size-body-lg + $unnnic-line-height-md;
+        line-height: $unnnic-font-size + 8px;
 
         width: 200px;
 
@@ -199,10 +199,10 @@ const handleExpand = () => {
 
       .infos__description {
         white-space: nowrap;
-        color: $unnnic-color-neutral-cloudy;
-        font-family: $unnnic-font-family-secondary;
-        font-size: $unnnic-font-size-body-md;
-        line-height: $unnnic-font-size-body-md + $unnnic-line-height-md;
+        color: $unnnic-color-gray-7;
+        font-family: $unnnic-font-family;
+        font-size: 12px;
+        line-height: 12px + 8px;
       }
     }
   }
@@ -210,7 +210,7 @@ const handleExpand = () => {
   &__progress {
     width: 100%;
 
-    padding: 0 $unnnic-spacing-sm;
+    padding: 0 $unnnic-space-4;
   }
 
   &__description {
@@ -219,11 +219,11 @@ const handleExpand = () => {
     text-overflow: ellipsis;
 
     text-align: end;
-    color: $unnnic-color-neutral-dark;
-    font-family: $unnnic-font-family-secondary;
-    font-size: $unnnic-font-size-body-lg;
+    color: $unnnic-color-gray-10;
+    font-family: $unnnic-font-family;
+    font-size: $unnnic-font-size;
     font-weight: $unnnic-font-weight-bold;
-    line-height: $unnnic-font-size-body-lg + $unnnic-line-height-md;
+    line-height: $unnnic-font-size + 8px;
     min-width: 55px;
   }
 
@@ -239,23 +239,24 @@ const handleExpand = () => {
         display: flex;
         flex-direction: column;
 
-        margin: 0 0 $unnnic-spacing-sm $unnnic-spacing-lg;
+        margin: 0 0 $unnnic-space-4 $unnnic-space-8;
 
-        border: $unnnic-border-width-thinner solid $unnnic-color-neutral-soft;
-        border-radius: $unnnic-border-radius-md;
+        border: 1px solid $unnnic-color-gray-2;
+        border-radius: $unnnic-radius-2;
 
         overflow: hidden;
 
-        padding: 0 $unnnic-spacing-sm;
+        padding: 0 $unnnic-space-4;
 
-        width: calc(100% - $unnnic-spacing-lg);
+        width: calc(100% - $unnnic-space-8);
 
         :deep(.progress-table-row-item__main-row > *) {
-          padding-top: $unnnic-spacing-md;
-          padding-bottom: $unnnic-spacing-md;
+          padding-top: $unnnic-space-6;
+          padding-bottom: $unnnic-space-6;
         }
       }
     }
   }
 }
 </style>
+style>

--- a/src/components/ProgressTableRowItem.vue
+++ b/src/components/ProgressTableRowItem.vue
@@ -196,7 +196,7 @@ const handleExpand = () => {
 
       .infos__description {
         white-space: nowrap;
-        color: $unnnic-color-gray-7;
+        color: $unnnic-color-fg-muted;
         font: $unnnic-font-caption-2;
       }
     }

--- a/src/components/ProgressTableRowItem.vue
+++ b/src/components/ProgressTableRowItem.vue
@@ -173,10 +173,7 @@ const handleExpand = () => {
         text-overflow: ellipsis;
 
         color: $unnnic-color-gray-12;
-        font-family: $unnnic-font-family;
-        font-size: $unnnic-font-size;
-        font-weight: $unnnic-font-weight-regular;
-        line-height: $unnnic-font-size + 8px;
+        font: $unnnic-font-display-4;
 
         width: 200px;
 
@@ -200,9 +197,7 @@ const handleExpand = () => {
       .infos__description {
         white-space: nowrap;
         color: $unnnic-color-gray-7;
-        font-family: $unnnic-font-family;
-        font-size: 12px;
-        line-height: 12px + 8px;
+        font: $unnnic-font-caption-2;
       }
     }
   }
@@ -220,10 +215,7 @@ const handleExpand = () => {
 
     text-align: end;
     color: $unnnic-color-gray-10;
-    font-family: $unnnic-font-family;
-    font-size: $unnnic-font-size;
-    font-weight: $unnnic-font-weight-bold;
-    line-height: $unnnic-font-size + 8px;
+    font: $unnnic-font-display-3;
     min-width: 55px;
   }
 

--- a/src/components/RadioList.vue
+++ b/src/components/RadioList.vue
@@ -77,7 +77,7 @@ export default defineComponent({
 .radio-list {
   display: flex;
   flex-wrap: wrap;
-  row-gap: $unnnic-spacing-nano;
+  row-gap: $unnnic-space-1;
 
   &__radio {
     width: 100%;

--- a/src/components/SelectEmojiButton.vue
+++ b/src/components/SelectEmojiButton.vue
@@ -110,20 +110,20 @@ export default {
 
   cursor: pointer;
 
-  padding: $unnnic-spacing-nano;
+  padding: $unnnic-space-1;
 
-  border: $unnnic-border-width-thinner solid $unnnic-color-neutral-cleanest;
-  border-radius: $unnnic-border-radius-lg;
-  background-color: $unnnic-color-neutral-white;
+  border: 1px solid $unnnic-color-gray-4;
+  border-radius: $unnnic-radius-4;
+  background-color: $unnnic-color-gray-0;
 
   &--selected {
-    border-color: $unnnic-color-weni-500;
-    background-color: $unnnic-color-weni-50;
+    border-color: $unnnic-color-teal-7;
+    background-color: $unnnic-color-teal-1;
   }
 
   &__selected-emoji {
-    height: $unnnic-avatar-size-nano;
-    width: $unnnic-avatar-size-nano;
+    height: 20px;
+    width: 20px;
   }
 }
 </style>

--- a/src/components/ShortTab.vue
+++ b/src/components/ShortTab.vue
@@ -63,7 +63,7 @@ const switchTab = (key: string) => {
   &__tabs {
     display: flex;
     gap: $unnnic-space-1;
-    background-color: $unnnic-color-bg-soft;
+    background-color: $unnnic-color-bg-base-soft;
     border-radius: $unnnic-radius-2;
     padding: $unnnic-space-1;
     align-items: center;
@@ -81,8 +81,8 @@ const switchTab = (key: string) => {
     white-space: nowrap;
     align-items: center;
 
-    background-color: $unnnic-color-bg-soft;
-    color: $unnnic-color-gray-500;
+    background-color: $unnnic-color-bg-base-soft;
+    color: $unnnic-color-gray-7;
     font: $unnnic-font-caption-1;
 
     cursor: pointer;
@@ -90,13 +90,13 @@ const switchTab = (key: string) => {
     transition: all 0.3s ease;
 
     &:hover {
-      background-color: $unnnic-color-bg-soft;
+      background-color: $unnnic-color-bg-base-soft;
       color: $unnnic-color-fg-emphasized;
     }
 
     &--active {
       background-color: $unnnic-color-bg-base;
-      border: 1px solid $unnnic-color-border-soft;
+      border: 1px solid $unnnic-color-border-base;
       color: $unnnic-color-fg-emphasized;
 
       &:hover {

--- a/src/components/SugestionCard.vue
+++ b/src/components/SugestionCard.vue
@@ -26,27 +26,27 @@ export default {
 
 <style scoped lang="scss">
 .insights-card {
-  background-color: $unnnic-color-neutral-lightest;
-  padding: $unnnic-spacing-sm;
-  border-radius: $unnnic-spacing-nano;
+  background-color: $unnnic-color-gray-1;
+  padding: $unnnic-space-4;
+  border-radius: $unnnic-space-1;
   display: flex;
   flex-direction: column;
-  gap: $unnnic-spacing-xs;
+  gap: $unnnic-space-2;
   justify-content: center;
   cursor: pointer;
   border: none;
   text-align: left;
 
   &__title {
-    color: $unnnic-color-neutral-darkest;
-    font-size: $unnnic-font-size-body-lg;
+    color: $unnnic-color-gray-12;
+    font-size: $unnnic-font-size;
     font-weight: $unnnic-font-weight-bold;
   }
 
   &__description {
-    color: $unnnic-color-neutral-dark;
-    font-size: $unnnic-font-size-body-gt;
-    font-family: $unnnic-font-family-secondary;
+    color: $unnnic-color-gray-10;
+    font-size: 14px;
+    font-family: $unnnic-font-family;
     position: relative;
     white-space: nowrap;
     width: 22em;

--- a/src/components/SugestionCard.vue
+++ b/src/components/SugestionCard.vue
@@ -39,14 +39,12 @@ export default {
 
   &__title {
     color: $unnnic-color-gray-12;
-    font-size: $unnnic-font-size;
-    font-weight: $unnnic-font-weight-bold;
+    font: $unnnic-font-display-3;
   }
 
   &__description {
     color: $unnnic-color-gray-10;
-    font-size: 14px;
-    font-family: $unnnic-font-family;
+    font: $unnnic-font-body;
     position: relative;
     white-space: nowrap;
     width: 22em;

--- a/src/components/TagGroup.vue
+++ b/src/components/TagGroup.vue
@@ -210,9 +210,7 @@ $tag-size: 28px;
     padding-left: $unnnic-space-2;
 
     color: $unnnic-color-gray-10;
-    font-size: 12px;
-
-    line-height: 20px;
+    font: $unnnic-font-caption-2;
     margin-right: -16px;
 
     top: calc($tag-size / 2);

--- a/src/components/TagGroup.vue
+++ b/src/components/TagGroup.vue
@@ -179,7 +179,7 @@ $tag-size: 28px;
     position: relative;
     display: flex;
     flex-wrap: wrap;
-    gap: $unnnic-spacing-xs;
+    gap: $unnnic-space-2;
     flex: 1;
 
     align-self: flex-start;
@@ -199,18 +199,18 @@ $tag-size: 28px;
       }
 
       &.tag-group__tags__tag--selected {
-        outline: $unnnic-border-width-thinner solid $unnnic-color-neutral-clean;
-        outline-offset: -$unnnic-border-width-thinner;
+        outline: 1px solid $unnnic-color-gray-5;
+        outline-offset: -1px;
       }
     }
   }
 
   &__remaining-children {
     position: absolute;
-    padding-left: $unnnic-spacing-xs;
+    padding-left: $unnnic-space-2;
 
-    color: $unnnic-color-neutral-dark;
-    font-size: $unnnic-font-size-body-md;
+    color: $unnnic-color-gray-10;
+    font-size: 12px;
 
     line-height: 20px;
     margin-right: -16px;

--- a/src/components/WarningMessage.vue
+++ b/src/components/WarningMessage.vue
@@ -33,10 +33,7 @@ defineProps<{
 
   &__title {
     color: $unnnic-color-gray-10;
-    font-family: $unnnic-font-family;
-    font-size: 14px;
-    font-weight: $unnnic-font-weight-regular;
-    line-height: 14px + 8px;
+    font: $unnnic-font-body;
   }
 }
 </style>

--- a/src/components/WarningMessage.vue
+++ b/src/components/WarningMessage.vue
@@ -22,21 +22,21 @@ defineProps<{
 <style scoped lang="scss">
 .warning-message {
   display: flex;
-  padding: $unnnic-spacing-sm;
+  padding: $unnnic-space-4;
   align-items: center;
-  gap: $unnnic-spacing-xs;
+  gap: $unnnic-space-2;
   align-self: stretch;
 
-  border-radius: $unnnic-border-radius-sm;
-  border: 1px solid $unnnic-color-neutral-soft;
-  background: $unnnic-color-background-carpet;
+  border-radius: $unnnic-radius-1;
+  border: 1px solid $unnnic-color-gray-2;
+  background: $unnnic-color-gray-1;
 
   &__title {
-    color: $unnnic-color-neutral-dark;
-    font-family: $unnnic-font-family-secondary;
-    font-size: $unnnic-font-size-body-gt;
+    color: $unnnic-color-gray-10;
+    font-family: $unnnic-font-family;
+    font-size: 14px;
     font-weight: $unnnic-font-weight-regular;
-    line-height: $unnnic-font-size-body-gt + $unnnic-line-height-md;
+    line-height: 14px + 8px;
   }
 }
 </style>

--- a/src/components/WelcomeOnboardingModal.vue
+++ b/src/components/WelcomeOnboardingModal.vue
@@ -60,23 +60,18 @@ const ignoreOnboarding = () => {
   }
 
   &__title {
-    font-size: 20px;
+    font: $unnnic-font-display-2;
     font-weight: 900;
-    line-height: 16px * 1.75;
     color: $unnnic-color-gray-12;
   }
 
   &__version {
-    font-size: 12px;
-    font-weight: $unnnic-font-weight-regular;
-    line-height: 16px * 1.25;
+    font: $unnnic-font-caption-2;
     color: $unnnic-color-gray-12;
   }
 
   &__info {
-    font-size: 14px;
-    font-weight: $unnnic-font-weight-regular;
-    line-height: 16px * 1.375;
+    font: $unnnic-font-body;
     color: $unnnic-color-gray-7;
     margin-top: $unnnic-space-2;
   }

--- a/src/components/WelcomeOnboardingModal.vue
+++ b/src/components/WelcomeOnboardingModal.vue
@@ -55,30 +55,30 @@ const ignoreOnboarding = () => {
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: $unnnic-spacing-md;
+    gap: $unnnic-space-6;
     text-align: center;
   }
 
   &__title {
-    font-size: $unnnic-font-size-title-sm;
-    font-weight: $unnnic-font-weight-black;
-    line-height: $unnnic-line-height-large * 1.75;
-    color: $unnnic-color-neutral-darkest;
+    font-size: 20px;
+    font-weight: 900;
+    line-height: 16px * 1.75;
+    color: $unnnic-color-gray-12;
   }
 
   &__version {
-    font-size: $unnnic-font-size-body-md;
+    font-size: 12px;
     font-weight: $unnnic-font-weight-regular;
-    line-height: $unnnic-line-height-large * 1.25;
-    color: $unnnic-color-neutral-darkest;
+    line-height: 16px * 1.25;
+    color: $unnnic-color-gray-12;
   }
 
   &__info {
-    font-size: $unnnic-font-size-body-gt;
+    font-size: 14px;
     font-weight: $unnnic-font-weight-regular;
-    line-height: $unnnic-line-height-large * 1.375;
-    color: $unnnic-color-neutral-cloudy;
-    margin-top: $unnnic-spacing-xs;
+    line-height: 16px * 1.375;
+    color: $unnnic-color-gray-7;
+    margin-top: $unnnic-space-2;
   }
 }
 </style>

--- a/src/components/__tests__/ProgressTableRowItem.spec.js
+++ b/src/components/__tests__/ProgressTableRowItem.spec.js
@@ -150,8 +150,8 @@ describe('ProgressTableRowItem.vue', () => {
         name: 'NativeProgress',
       });
 
-      expect(nativeProgress.props('color')).toBe('#3993F4'); // colorBlue500
-      expect(nativeProgress.props('backgroundColor')).toBe('#F5F5F5'); // colorGray50
+      expect(nativeProgress.props('color')).toBe('#3993F4'); // colorBgBlueStrong
+      expect(nativeProgress.props('backgroundColor')).toBe('#F5F5F5'); // colorBgBaseSoft
     });
   });
 

--- a/src/components/__tests__/ProgressTableRowItem.spec.js
+++ b/src/components/__tests__/ProgressTableRowItem.spec.js
@@ -150,8 +150,8 @@ describe('ProgressTableRowItem.vue', () => {
         name: 'NativeProgress',
       });
 
-      expect(nativeProgress.props('color')).toBe('#3182CE'); // colorBlue500
-      expect(nativeProgress.props('backgroundColor')).toBe('#F6F7F9'); // colorGray50
+      expect(nativeProgress.props('color')).toBe('#3993F4'); // colorBlue500
+      expect(nativeProgress.props('backgroundColor')).toBe('#F5F5F5'); // colorGray50
     });
   });
 

--- a/src/components/__tests__/__snapshots__/FormAccordion.unit.spec.js.snap
+++ b/src/components/__tests__/__snapshots__/FormAccordion.unit.spec.js.snap
@@ -6,12 +6,12 @@ exports[`FormAccordion.vue > should match the snapshot 1`] = `
   data-test-id="form-accordion"
   data-testid="collapse"
   data-v-085a4372=""
-  data-v-4c30fa39=""
+  data-v-cc0e62a7=""
 >
   <div
     class="unnnic-collapse__header"
     data-testid="collapse-header"
-    data-v-4c30fa39=""
+    data-v-cc0e62a7=""
   >
     
     
@@ -33,16 +33,16 @@ exports[`FormAccordion.vue > should match the snapshot 1`] = `
     
     <unnnic-icon-stub
       clickable="false"
-      data-v-4c30fa39=""
+      data-v-cc0e62a7=""
       filled="false"
       icon="arrow-button-down-1"
-      scheme="neutral-cloudy"
+      scheme="fg-base"
       size="ant"
     />
   </div>
   <div
     class="unnnic-collapse__body"
-    data-v-4c30fa39=""
+    data-v-cc0e62a7=""
     style="display: none;"
   >
     

--- a/src/components/__tests__/__snapshots__/ProgressBar.unit.spec.js.snap
+++ b/src/components/__tests__/__snapshots__/ProgressBar.unit.spec.js.snap
@@ -8,30 +8,30 @@ exports[`ProgressBar > Matches the snapshot 1`] = `
   <div
     class="unnnic-progress-bar primary inline"
     data-test-id="progress-bar"
+    data-v-2ad61a9a=""
     data-v-84df1bb9=""
-    data-v-ac4fc1a8=""
   >
     <div
       class="main"
-      data-v-ac4fc1a8=""
+      data-v-2ad61a9a=""
     >
       <div
         class="title"
-        data-v-ac4fc1a8=""
+        data-v-2ad61a9a=""
       >
         Loading...
       </div>
       <div
         class="progress-bar-container"
-        data-v-ac4fc1a8=""
+        data-v-2ad61a9a=""
       >
         <div
           class="progress-container"
-          data-v-ac4fc1a8=""
+          data-v-2ad61a9a=""
         >
           <div
             class="bar"
-            data-v-ac4fc1a8=""
+            data-v-2ad61a9a=""
             style="width: 0%;"
           >
             <!---->
@@ -39,7 +39,7 @@ exports[`ProgressBar > Matches the snapshot 1`] = `
         </div>
         <div
           class="percentage"
-          data-v-ac4fc1a8=""
+          data-v-2ad61a9a=""
         >
           0% 
         </div>

--- a/src/components/home/CardMetric.vue
+++ b/src/components/home/CardMetric.vue
@@ -95,54 +95,54 @@ defineProps({
 
 <style lang="scss" scoped>
 .metric-card {
-  background: $unnnic-color-neutral-white;
-  border: $unnnic-border-width-thinner solid $unnnic-color-neutral-soft;
-  padding: $unnnic-spacing-sm;
+  background: $unnnic-color-gray-0;
+  border: 1px solid $unnnic-color-gray-2;
+  padding: $unnnic-space-4;
   border-radius: 0;
   margin: -1px 0 0 -1px;
 
-  border-right: $unnnic-border-width-thinner solid $unnnic-color-neutral-soft;
-  border-left: $unnnic-border-width-thinner solid $unnnic-color-neutral-soft;
-  border-bottom: $unnnic-border-width-thinner solid $unnnic-color-neutral-soft;
+  border-right: 1px solid $unnnic-color-gray-2;
+  border-left: 1px solid $unnnic-color-gray-2;
+  border-bottom: 1px solid $unnnic-color-gray-2;
 
   &--left-column {
     &.metric-card--first-row {
-      border-top-left-radius: $unnnic-border-radius-md;
+      border-top-left-radius: $unnnic-radius-2;
     }
 
     &.metric-card--last-row {
-      border-bottom-left-radius: $unnnic-border-radius-md;
+      border-bottom-left-radius: $unnnic-radius-2;
     }
   }
 
   &--right-column {
     &.metric-card--first-row {
-      border-top-right-radius: $unnnic-border-radius-md;
+      border-top-right-radius: $unnnic-radius-2;
     }
 
     &.metric-card--last-row {
-      border-bottom-right-radius: $unnnic-border-radius-md;
+      border-bottom-right-radius: $unnnic-radius-2;
     }
   }
 
   &__header {
     display: flex;
     align-items: center;
-    gap: $unnnic-spacing-xs;
-    margin-bottom: $unnnic-spacing-xs;
+    gap: $unnnic-space-2;
+    margin-bottom: $unnnic-space-2;
 
     :deep(.material-symbols-rounded.unnnic-icon-size--sm) {
-      font-size: $unnnic-font-size-body-gt;
+      font-size: 14px;
     }
   }
 
   &__title {
-    font-family: $unnnic-font-family-secondary;
-    font-size: $unnnic-font-size-body-gt;
+    font-family: $unnnic-font-family;
+    font-size: 14px;
     font-style: normal;
     font-weight: $unnnic-font-weight-regular;
-    line-height: $unnnic-font-size-body-gt + $unnnic-line-height-md;
-    color: $unnnic-color-neutral-dark;
+    line-height: 14px + 8px;
+    color: $unnnic-color-gray-10;
     margin: 0;
   }
 
@@ -151,15 +151,15 @@ defineProps({
   }
 
   &__value {
-    color: $unnnic-color-neutral-darkest;
-    font-family: $unnnic-font-family-primary;
-    font-size: $unnnic-font-size-title-md;
+    color: $unnnic-color-gray-12;
+    font-family: $unnnic-font-family;
+    font-size: 24px;
     font-style: normal;
     font-weight: $unnnic-font-weight-bold;
-    line-height: $unnnic-font-size-title-md + $unnnic-line-height-md;
+    line-height: 24px + 8px;
     display: flex;
     align-items: baseline;
-    gap: $unnnic-spacing-xs;
+    gap: $unnnic-space-2;
   }
 }
 </style>

--- a/src/components/home/CardMetric.vue
+++ b/src/components/home/CardMetric.vue
@@ -137,11 +137,7 @@ defineProps({
   }
 
   &__title {
-    font-family: $unnnic-font-family;
-    font-size: 14px;
-    font-style: normal;
-    font-weight: $unnnic-font-weight-regular;
-    line-height: 14px + 8px;
+    font: $unnnic-font-body;
     color: $unnnic-color-gray-10;
     margin: 0;
   }
@@ -152,11 +148,7 @@ defineProps({
 
   &__value {
     color: $unnnic-color-gray-12;
-    font-family: $unnnic-font-family;
-    font-size: 24px;
-    font-style: normal;
-    font-weight: $unnnic-font-weight-bold;
-    line-height: 24px + 8px;
+    font: $unnnic-font-display-1;
     display: flex;
     align-items: baseline;
     gap: $unnnic-space-2;

--- a/src/components/home/DropdownFilter.vue
+++ b/src/components/home/DropdownFilter.vue
@@ -97,10 +97,7 @@ const handleItemAction = (action: () => void, name: string) => {
   &__title {
     margin-right: $unnnic-space-1;
     color: $unnnic-color-gray-12;
-    font-family: $unnnic-font-family;
-    font-size: 14px;
-    font-weight: $unnnic-font-weight-regular;
-    line-height: 14px + 8px;
+    font: $unnnic-font-body;
   }
 
   &__option {
@@ -118,10 +115,7 @@ const handleItemAction = (action: () => void, name: string) => {
     cursor: pointer;
     white-space: nowrap;
 
-    font-family: $unnnic-font-family;
-    font-size: 12px;
-    font-weight: $unnnic-font-weight-regular;
-    line-height: 12px + 8px;
+    font: $unnnic-font-caption-2;
 
     &:last-child {
       border-bottom: none;

--- a/src/components/home/DropdownFilter.vue
+++ b/src/components/home/DropdownFilter.vue
@@ -90,25 +90,25 @@ const handleItemAction = (action: () => void, name: string) => {
     }
 
     :deep(.unnnic-dropdown__content) {
-      width: $unnnic-avatar-size-sm * 4;
+      width: 40px * 4;
     }
   }
 
   &__title {
-    margin-right: $unnnic-spacing-nano;
-    color: $unnnic-color-neutral-darkest;
-    font-family: $unnnic-font-family-secondary;
-    font-size: $unnnic-font-size-body-gt;
+    margin-right: $unnnic-space-1;
+    color: $unnnic-color-gray-12;
+    font-family: $unnnic-font-family;
+    font-size: 14px;
     font-weight: $unnnic-font-weight-regular;
-    line-height: $unnnic-font-size-body-gt + $unnnic-line-height-md;
+    line-height: 14px + 8px;
   }
 
   &__option {
     display: flex;
-    padding: $unnnic-spacing-sm;
+    padding: $unnnic-space-4;
     flex-direction: column;
     align-items: flex-start;
-    gap: $unnnic-spacing-xs;
+    gap: $unnnic-space-2;
     border-bottom: 1px solid $unnnic-color-background-sky;
 
     &::before {
@@ -118,10 +118,10 @@ const handleItemAction = (action: () => void, name: string) => {
     cursor: pointer;
     white-space: nowrap;
 
-    font-family: $unnnic-font-family-secondary;
-    font-size: $unnnic-font-size-body-md;
+    font-family: $unnnic-font-family;
+    font-size: 12px;
     font-weight: $unnnic-font-weight-regular;
-    line-height: $unnnic-font-size-body-md + $unnnic-line-height-md;
+    line-height: 12px + 8px;
 
     &:last-child {
       border-bottom: none;
@@ -132,7 +132,7 @@ const handleItemAction = (action: () => void, name: string) => {
     }
 
     &:hover {
-      border-radius: $unnnic-spacing-nano;
+      border-radius: $unnnic-space-1;
       background-color: $unnnic-color-background-sky;
     }
   }

--- a/src/components/insights/Layout/BlurSetupWidget.vue
+++ b/src/components/insights/Layout/BlurSetupWidget.vue
@@ -61,7 +61,7 @@ const props = withDefaults(defineProps<SetupWidgetProps>(), {
   }
 
   &__description {
-    color: $unnnic-color-gray-7;
+    color: $unnnic-color-fg-muted;
     font: $unnnic-font-display-4;
   }
 }

--- a/src/components/insights/Layout/BlurSetupWidget.vue
+++ b/src/components/insights/Layout/BlurSetupWidget.vue
@@ -56,12 +56,12 @@ const props = withDefaults(defineProps<SetupWidgetProps>(), {
   border-radius: $unnnic-radius-2;
 
   &__title {
-    color: $unnnic-color-neutral-darkest;
+    color: $unnnic-color-gray-12;
     font: $unnnic-font-display-2;
   }
 
   &__description {
-    color: $unnnic-color-neutral-cloudy;
+    color: $unnnic-color-gray-7;
     font: $unnnic-font-display-4;
   }
 }

--- a/src/components/insights/Layout/Header.vue
+++ b/src/components/insights/Layout/Header.vue
@@ -228,11 +228,9 @@ export default {
     padding: $unnnic-space-2 $unnnic-space-6;
 
     &-title {
-      font-size: 20px;
+      font: $unnnic-font-display-2;
       font-weight: 900;
       color: $unnnic-color-gray-12;
-      font-family: $unnnic-font-family;
-      line-height: 20px + 8px;
     }
 
     &-close {

--- a/src/components/insights/Layout/Header.vue
+++ b/src/components/insights/Layout/Header.vue
@@ -204,39 +204,39 @@ export default {
 <style lang="scss" scoped>
 .insights-layout-header {
   display: grid;
-  gap: $unnnic-spacing-sm;
+  gap: $unnnic-space-4;
 
   &__content {
     display: flex;
     flex-direction: row;
     justify-content: space-between;
     align-items: center;
-    gap: $unnnic-spacing-xs;
+    gap: $unnnic-space-2;
 
     .content__actions {
       display: flex;
-      gap: $unnnic-spacing-ant;
+      gap: $unnnic-space-3;
     }
   }
   &__expansive {
     border-radius: 0.5rem 0.5rem 0rem 0rem;
-    background: $unnnic-color-neutral-white;
+    background: $unnnic-color-gray-0;
     display: flex;
     width: 100%;
     justify-content: space-between;
     align-items: center;
-    padding: $unnnic-spacing-xs $unnnic-spacing-md;
+    padding: $unnnic-space-2 $unnnic-space-6;
 
     &-title {
-      font-size: $unnnic-font-size-title-sm;
-      font-weight: $unnnic-font-weight-black;
-      color: $unnnic-color-neutral-darkest;
-      font-family: $unnnic-font-family-primary;
-      line-height: $unnnic-font-size-title-sm + $unnnic-line-height-md;
+      font-size: 20px;
+      font-weight: 900;
+      color: $unnnic-color-gray-12;
+      font-family: $unnnic-font-family;
+      line-height: 20px + 8px;
     }
 
     &-close {
-      background-color: $unnnic-color-neutral-white;
+      background-color: $unnnic-color-gray-0;
     }
   }
 }

--- a/src/components/insights/Layout/HeaderDashboardSettings.vue
+++ b/src/components/insights/Layout/HeaderDashboardSettings.vue
@@ -56,24 +56,24 @@ export default {
 $dropdownFixedWidth: 165px;
 :deep(.unnnic-dropdown__trigger) {
   .unnnic-dropdown__content {
-    margin-top: $unnnic-spacing-nano;
+    margin-top: $unnnic-space-1;
     right: 0;
     width: $dropdownFixedWidth;
-    padding: $unnnic-spacing-xs;
-    gap: $unnnic-spacing-nano;
+    padding: $unnnic-space-2;
+    gap: $unnnic-space-1;
 
     .unnnic-dropdown-item {
-      border-radius: $unnnic-border-radius-sm;
+      border-radius: $unnnic-radius-1;
 
-      padding: $unnnic-spacing-xs;
+      padding: $unnnic-space-2;
 
       display: flex;
       align-items: center;
-      gap: $unnnic-spacing-nano;
+      gap: $unnnic-space-1;
 
-      color: $unnnic-color-neutral-darkest;
-      font-family: $unnnic-font-family-secondary;
-      font-size: $unnnic-font-size-body-gt;
+      color: $unnnic-color-gray-12;
+      font-family: $unnnic-font-family;
+      font-size: 14px;
 
       &::before {
         content: none;

--- a/src/components/insights/Layout/HeaderDashboardSettings.vue
+++ b/src/components/insights/Layout/HeaderDashboardSettings.vue
@@ -72,8 +72,7 @@ $dropdownFixedWidth: 165px;
       gap: $unnnic-space-1;
 
       color: $unnnic-color-gray-12;
-      font-family: $unnnic-font-family;
-      font-size: 14px;
+      font: $unnnic-font-body;
 
       &::before {
         content: none;

--- a/src/components/insights/Layout/HeaderFilters/DynamicFilter.vue
+++ b/src/components/insights/Layout/HeaderFilters/DynamicFilter.vue
@@ -176,7 +176,7 @@ export default {
 
   :deep(.unnnic-label__label),
   :deep(.unnnic-form__label) {
-    margin: 0 0 $unnnic-spacing-nano;
+    margin: 0 0 $unnnic-space-1;
   }
 }
 </style>

--- a/src/components/insights/Layout/HeaderFilters/FilterFavoriteTemplateMessage.vue
+++ b/src/components/insights/Layout/HeaderFilters/FilterFavoriteTemplateMessage.vue
@@ -73,10 +73,10 @@ watch(selectedTemplateUuid, (newUuid, oldUuid) => {
   align-items: center;
 
   &__label {
-    font-family: $unnnic-font-family-secondary;
-    font-size: $unnnic-font-size-body-gt;
-    line-height: $unnnic-font-size-body-gt + $unnnic-line-height-md;
-    color: $unnnic-color-neutral-cloudy;
+    font-family: $unnnic-font-family;
+    font-size: 14px;
+    line-height: 14px + 8px;
+    color: $unnnic-color-gray-7;
   }
 }
 </style>

--- a/src/components/insights/Layout/HeaderFilters/FilterFavoriteTemplateMessage.vue
+++ b/src/components/insights/Layout/HeaderFilters/FilterFavoriteTemplateMessage.vue
@@ -74,7 +74,7 @@ watch(selectedTemplateUuid, (newUuid, oldUuid) => {
 
   &__label {
     font: $unnnic-font-body;
-    color: $unnnic-color-gray-7;
+    color: $unnnic-color-fg-muted;
   }
 }
 </style>

--- a/src/components/insights/Layout/HeaderFilters/FilterFavoriteTemplateMessage.vue
+++ b/src/components/insights/Layout/HeaderFilters/FilterFavoriteTemplateMessage.vue
@@ -73,9 +73,7 @@ watch(selectedTemplateUuid, (newUuid, oldUuid) => {
   align-items: center;
 
   &__label {
-    font-family: $unnnic-font-family;
-    font-size: 14px;
-    line-height: 14px + 8px;
+    font: $unnnic-font-body;
     color: $unnnic-color-gray-7;
   }
 }

--- a/src/components/insights/Layout/HeaderFilters/FilterSelectDate.vue
+++ b/src/components/insights/Layout/HeaderFilters/FilterSelectDate.vue
@@ -83,13 +83,13 @@ const updateCurrentDate = (option) => {
 <style lang="scss" scoped>
 .filter-date {
   :deep(.input) {
-    color: $unnnic-color-neutral-darkest;
+    color: $unnnic-color-gray-12;
 
-    font-family: $unnnic-font-family-secondary;
-    font-size: $unnnic-font-size-body-gt;
+    font-family: $unnnic-font-family;
+    font-size: 14px;
     font-style: normal;
     font-weight: $unnnic-font-weight-regular;
-    line-height: $unnnic-line-height-large * 1.375;
+    line-height: 16px * 1.375;
   }
 
   :deep(.dropdown) {
@@ -98,16 +98,16 @@ const updateCurrentDate = (option) => {
 
   :deep(.unnnic-select-smart-option--selectable) {
     &:hover {
-      color: $unnnic-color-weni-600;
+      color: $unnnic-color-teal-8;
       font-weight: $unnnic-font-weight-bold;
     }
 
-    color: $unnnic-color-neutral-darkest;
-    font-family: $unnnic-font-family-secondary;
-    font-size: $unnnic-font-size-body-gt;
+    color: $unnnic-color-gray-12;
+    font-family: $unnnic-font-family;
+    font-size: 14px;
     font-style: normal;
     font-weight: $unnnic-font-weight-regular;
-    line-height: $unnnic-line-height-large * 1.375;
+    line-height: 16px * 1.375;
   }
 }
 </style>

--- a/src/components/insights/Layout/HeaderFilters/FilterSelectDate.vue
+++ b/src/components/insights/Layout/HeaderFilters/FilterSelectDate.vue
@@ -84,12 +84,7 @@ const updateCurrentDate = (option) => {
 .filter-date {
   :deep(.input) {
     color: $unnnic-color-gray-12;
-
-    font-family: $unnnic-font-family;
-    font-size: 14px;
-    font-style: normal;
-    font-weight: $unnnic-font-weight-regular;
-    line-height: 16px * 1.375;
+    font: $unnnic-font-body;
   }
 
   :deep(.dropdown) {
@@ -103,11 +98,7 @@ const updateCurrentDate = (option) => {
     }
 
     color: $unnnic-color-gray-12;
-    font-family: $unnnic-font-family;
-    font-size: 14px;
-    font-style: normal;
-    font-weight: $unnnic-font-weight-regular;
-    line-height: 16px * 1.375;
+    font: $unnnic-font-body;
   }
 }
 </style>

--- a/src/components/insights/Layout/HeaderFilters/LastUpdatedText.vue
+++ b/src/components/insights/Layout/HeaderFilters/LastUpdatedText.vue
@@ -84,16 +84,16 @@ const formattedTime = computed(() => {
 .insights-layout-header-filters_last-updated-at {
   display: flex;
   align-items: center;
-  padding: 0 $unnnic-spacing-sm 0 0;
+  padding: 0 $unnnic-space-4 0 0;
   gap: $unnnic-space-05;
 
   &_text {
-    font-family: $unnnic-font-family-secondary;
-    font-size: $unnnic-font-size-body-gt;
+    font-family: $unnnic-font-family;
+    font-size: 14px;
     font-style: normal;
     font-weight: $unnnic-font-weight-regular;
-    line-height: $unnnic-font-size-body-gt + $unnnic-line-height-md;
-    color: $unnnic-color-neutral-cloudy;
+    line-height: 14px + 8px;
+    color: $unnnic-color-gray-7;
   }
 }
 </style>

--- a/src/components/insights/Layout/HeaderFilters/LastUpdatedText.vue
+++ b/src/components/insights/Layout/HeaderFilters/LastUpdatedText.vue
@@ -88,11 +88,7 @@ const formattedTime = computed(() => {
   gap: $unnnic-space-05;
 
   &_text {
-    font-family: $unnnic-font-family;
-    font-size: 14px;
-    font-style: normal;
-    font-weight: $unnnic-font-weight-regular;
-    line-height: 14px + 8px;
+    font: $unnnic-font-body;
     color: $unnnic-color-gray-7;
   }
 }

--- a/src/components/insights/Layout/HeaderFilters/LastUpdatedText.vue
+++ b/src/components/insights/Layout/HeaderFilters/LastUpdatedText.vue
@@ -89,7 +89,7 @@ const formattedTime = computed(() => {
 
   &_text {
     font: $unnnic-font-body;
-    color: $unnnic-color-gray-7;
+    color: $unnnic-color-fg-muted;
   }
 }
 </style>

--- a/src/components/insights/Layout/HeaderFilters/ModalFilters.vue
+++ b/src/components/insights/Layout/HeaderFilters/ModalFilters.vue
@@ -215,7 +215,7 @@ export default {
 .modal-filters {
   &__form {
     display: grid;
-    gap: $unnnic-spacing-xs $unnnic-spacing-sm;
+    gap: $unnnic-space-2 $unnnic-space-4;
     grid-template-columns: repeat(2, 1fr);
     grid-template-rows: repeat(4, 1fr);
 

--- a/src/components/insights/Layout/HeaderFilters/index.vue
+++ b/src/components/insights/Layout/HeaderFilters/index.vue
@@ -295,7 +295,7 @@ export default {
 .insights-layout-header-filters {
   display: flex;
   flex-direction: row;
-  gap: $unnnic-spacing-xs;
+  gap: $unnnic-space-2;
 
   &_dynamic_container {
     width: 19.75rem;

--- a/src/components/insights/Layout/HeaderGenerateInsights/HeaderGenerateInsightButton.vue
+++ b/src/components/insights/Layout/HeaderGenerateInsights/HeaderGenerateInsightButton.vue
@@ -60,19 +60,19 @@ export default {
   border: none;
 
   display: flex;
-  gap: $unnnic-spacing-nano;
+  gap: $unnnic-space-1;
   justify-content: center;
   align-items: center;
 
-  padding: $unnnic-spacing-ant $unnnic-spacing-sm;
+  padding: $unnnic-space-3 $unnnic-space-4;
 
-  border-radius: $unnnic-border-radius-sm;
-  background: $unnnic-color-neutral-darkest;
+  border-radius: $unnnic-radius-1;
+  background: $unnnic-color-gray-12;
 
-  color: $unnnic-color-weni-300;
+  color: $unnnic-color-teal-5;
 
-  font-family: $unnnic-font-family-secondary;
-  font-size: $unnnic-font-size-body-gt;
+  font-family: $unnnic-font-family;
+  font-size: 14px;
 
   cursor: pointer;
 }

--- a/src/components/insights/Layout/HeaderGenerateInsights/HeaderGenerateInsightButton.vue
+++ b/src/components/insights/Layout/HeaderGenerateInsights/HeaderGenerateInsightButton.vue
@@ -71,8 +71,7 @@ export default {
 
   color: $unnnic-color-teal-5;
 
-  font-family: $unnnic-font-family;
-  font-size: 14px;
+  font: $unnnic-font-body;
 
   cursor: pointer;
 }

--- a/src/components/insights/Layout/HeaderGenerateInsights/HeaderGenerateInsightModal.vue
+++ b/src/components/insights/Layout/HeaderGenerateInsights/HeaderGenerateInsightModal.vue
@@ -324,9 +324,7 @@ export default {
       gap: $unnnic-space-2;
 
       color: $unnnic-color-teal-5;
-      font-family: $unnnic-font-family;
-      font-size: 20px;
-      font-weight: $unnnic-font-weight-bold;
+      font: $unnnic-font-display-2;
     }
 
     .header__close-button {

--- a/src/components/insights/Layout/HeaderGenerateInsights/HeaderGenerateInsightModal.vue
+++ b/src/components/insights/Layout/HeaderGenerateInsights/HeaderGenerateInsightModal.vue
@@ -297,7 +297,7 @@ export default {
   right: 0;
   z-index: 999;
 
-  box-shadow: $unnnic-shadow-2;
+  box-shadow: $unnnic-shadow-1;
   border-radius: $unnnic-radius-1;
   padding: $unnnic-space-6;
 

--- a/src/components/insights/Layout/HeaderGenerateInsights/HeaderGenerateInsightModal.vue
+++ b/src/components/insights/Layout/HeaderGenerateInsights/HeaderGenerateInsightModal.vue
@@ -297,18 +297,18 @@ export default {
   right: 0;
   z-index: 999;
 
-  box-shadow: $unnnic-shadow-level-far;
-  border-radius: $unnnic-border-radius-sm;
-  padding: $unnnic-spacing-md;
+  box-shadow: $unnnic-shadow-2;
+  border-radius: $unnnic-radius-1;
+  padding: $unnnic-space-6;
 
   width: 32vw;
   height: 75vh;
 
   display: grid;
   grid-template-rows: auto 1fr auto;
-  gap: $unnnic-spacing-sm;
+  gap: $unnnic-space-4;
 
-  background: $unnnic-color-neutral-darkest;
+  background: $unnnic-color-gray-12;
 
   cursor: default;
 
@@ -316,16 +316,16 @@ export default {
     display: flex;
     align-items: start;
     justify-content: space-between;
-    gap: $unnnic-spacing-sm;
+    gap: $unnnic-space-4;
 
     .header__title {
       display: flex;
       align-items: center;
-      gap: $unnnic-spacing-xs;
+      gap: $unnnic-space-2;
 
-      color: $unnnic-color-weni-300;
-      font-family: $unnnic-font-family-secondary;
-      font-size: $unnnic-font-size-title-sm;
+      color: $unnnic-color-teal-5;
+      font-family: $unnnic-font-family;
+      font-size: 20px;
       font-weight: $unnnic-font-weight-bold;
     }
 
@@ -336,7 +336,7 @@ export default {
       width: 38px;
       height: 38px;
 
-      padding: $unnnic-spacing-nano;
+      padding: $unnnic-space-1;
       display: flex;
       align-items: center;
       justify-content: center;
@@ -350,8 +350,8 @@ export default {
     flex-direction: column;
     justify-content: space-between;
     overflow-y: overlay;
-    padding-right: $unnnic-spacing-ant;
-    margin-right: -$unnnic-spacing-ant;
+    padding-right: $unnnic-space-3;
+    margin-right: -$unnnic-space-3;
 
     &::-webkit-scrollbar {
       width: 0;
@@ -366,12 +366,12 @@ export default {
     height: 9rem;
     background: linear-gradient(
       359deg,
-      $unnnic-color-neutral-dark 0.54%,
+      $unnnic-color-gray-10 0.54%,
       rgba(59, 65, 77, 0.8) 62.61%,
       rgba(59, 65, 77, 0) 91.82%
     );
     pointer-events: none;
-    border-radius: $unnnic-border-radius-sm;
+    border-radius: $unnnic-radius-1;
   }
 }
 </style>

--- a/src/components/insights/Layout/HeaderGenerateInsights/HeaderGenerateInsightText.vue
+++ b/src/components/insights/Layout/HeaderGenerateInsights/HeaderGenerateInsightText.vue
@@ -84,7 +84,7 @@ export default {
     text-align: start;
 
     color: $unnnic-color-gray-5;
-    font-size: 14px;
+    font: $unnnic-font-body;
 
     @keyframes wave {
       0%,
@@ -120,9 +120,8 @@ export default {
   &__generated {
     text-align: start;
     color: $unnnic-color-gray-0;
-    font-size: $unnnic-font-size;
+    font: $unnnic-font-display-4;
     font-weight: 300;
-    line-height: 16px * 1.4;
   }
 }
 </style>

--- a/src/components/insights/Layout/HeaderGenerateInsights/HeaderGenerateInsightText.vue
+++ b/src/components/insights/Layout/HeaderGenerateInsights/HeaderGenerateInsightText.vue
@@ -83,7 +83,7 @@ export default {
   &__generating {
     text-align: start;
 
-    color: $unnnic-color-gray-5;
+    color: $unnnic-color-fg-muted;
     font: $unnnic-font-body;
 
     @keyframes wave {

--- a/src/components/insights/Layout/HeaderGenerateInsights/HeaderGenerateInsightText.vue
+++ b/src/components/insights/Layout/HeaderGenerateInsights/HeaderGenerateInsightText.vue
@@ -83,8 +83,8 @@ export default {
   &__generating {
     text-align: start;
 
-    color: $unnnic-color-neutral-clean;
-    font-size: $unnnic-font-size-body-gt;
+    color: $unnnic-color-gray-5;
+    font-size: 14px;
 
     @keyframes wave {
       0%,
@@ -104,7 +104,7 @@ export default {
       height: 2px;
       border-radius: 50%;
       margin-right: 2px;
-      background-color: $unnnic-color-neutral-clean;
+      background-color: $unnnic-color-gray-5;
       animation: wave 1.3s linear infinite;
 
       &:nth-child(2) {
@@ -119,10 +119,10 @@ export default {
 
   &__generated {
     text-align: start;
-    color: $unnnic-color-neutral-white;
-    font-size: $unnnic-font-size-body-lg;
-    font-weight: $unnnic-font-weight-light;
-    line-height: $unnnic-line-height-large * 1.4;
+    color: $unnnic-color-gray-0;
+    font-size: $unnnic-font-size;
+    font-weight: 300;
+    line-height: 16px * 1.4;
   }
 }
 </style>

--- a/src/components/insights/Layout/HeaderGenerateInsights/InsightModalFooter.vue
+++ b/src/components/insights/Layout/HeaderGenerateInsights/InsightModalFooter.vue
@@ -168,7 +168,7 @@ export default {
   max-height: 100%;
 
   .footer__description {
-    color: $unnnic-color-gray-5;
+    color: $unnnic-color-fg-muted;
     text-align: right;
     font: $unnnic-font-caption-2;
   }
@@ -195,7 +195,7 @@ export default {
       display: flex;
       align-items: flex-start;
       font: $unnnic-font-body;
-      color: $unnnic-color-gray-5;
+      color: $unnnic-color-fg-muted;
     }
 
     &__container__btns {
@@ -220,10 +220,10 @@ export default {
       align-self: stretch;
 
       &::placeholder {
-        color: $unnnic-color-gray-7;
+        color: $unnnic-color-fg-muted;
       }
 
-      color: $unnnic-color-gray-5;
+      color: $unnnic-color-fg-muted;
 
       font: $unnnic-font-body;
 
@@ -256,7 +256,7 @@ export default {
       }
 
       &:disabled {
-        color: $unnnic-color-gray-7;
+        color: $unnnic-color-fg-muted;
         border: 1px solid $unnnic-color-gray-10;
         background: $unnnic-color-gray-12;
       }
@@ -268,7 +268,7 @@ export default {
   border-radius: $unnnic-radius-1;
   border: 1px solid $unnnic-color-gray-10;
   background: $unnnic-color-gray-12;
-  color: $unnnic-color-gray-5;
+  color: $unnnic-color-fg-muted;
   &:active,
   &:hover {
     background-color: inherit;
@@ -276,11 +276,11 @@ export default {
   }
 
   :deep(.material-symbols-rounded.unnnic-icon-scheme--neutral-dark) {
-    color: $unnnic-color-gray-5;
+    color: $unnnic-color-fg-muted;
   }
 
   &:deep(.unnnic-button__label) {
-    color: $unnnic-color-gray-5;
+    color: $unnnic-color-fg-muted;
   }
 
   &-active {

--- a/src/components/insights/Layout/HeaderGenerateInsights/InsightModalFooter.vue
+++ b/src/components/insights/Layout/HeaderGenerateInsights/InsightModalFooter.vue
@@ -168,17 +168,17 @@ export default {
   max-height: 100%;
 
   .footer__description {
-    color: $unnnic-color-neutral-clean;
+    color: $unnnic-color-gray-5;
     text-align: right;
-    font-size: $unnnic-font-size-body-md;
+    font-size: 12px;
   }
 
   .feedback_sent {
     text-align: start;
-    color: $unnnic-color-neutral-white;
+    color: $unnnic-color-gray-0;
 
-    font-family: $unnnic-font-family-secondary;
-    font-size: $unnnic-font-size-body-lg;
+    font-family: $unnnic-font-family;
+    font-size: $unnnic-font-size;
     font-style: normal;
     font-weight: $unnnic-font-weight-bold;
   }
@@ -188,8 +188,8 @@ export default {
     flex-direction: column;
     overflow-y: auto;
     max-height: 100%;
-    margin-top: $unnnic-spacing-sm;
-    gap: $unnnic-spacing-sm;
+    margin-top: $unnnic-space-4;
+    gap: $unnnic-space-4;
 
     &::-webkit-scrollbar {
       width: 0;
@@ -198,48 +198,48 @@ export default {
     &__text {
       display: flex;
       align-items: flex-start;
-      font-family: $unnnic-font-family-secondary;
-      color: $unnnic-color-neutral-clean;
+      font-family: $unnnic-font-family;
+      color: $unnnic-color-gray-5;
       font-weight: $unnnic-font-weight-regular;
-      font-size: $unnnic-font-size-body-gt;
+      font-size: 14px;
     }
 
     &__container__btns {
       display: flex;
       align-items: flex-start;
-      gap: $unnnic-spacing-ant;
+      gap: $unnnic-space-3;
     }
 
     &__container__area {
       display: flex;
       flex-direction: column;
-      gap: $unnnic-spacing-sm;
+      gap: $unnnic-space-4;
     }
 
     &__textarea {
-      border-radius: $unnnic-border-radius-sm;
-      border: 1px solid $unnnic-color-neutral-dark;
-      background: $unnnic-color-neutral-darkest;
+      border-radius: $unnnic-radius-1;
+      border: 1px solid $unnnic-color-gray-10;
+      background: $unnnic-color-gray-12;
       display: flex;
-      padding: $unnnic-spacing-ant $unnnic-spacing-sm;
+      padding: $unnnic-space-3 $unnnic-space-4;
       align-items: flex-start;
       align-self: stretch;
 
       &::placeholder {
-        color: $unnnic-color-neutral-cloudy;
+        color: $unnnic-color-gray-7;
       }
 
-      color: $unnnic-color-neutral-clean;
+      color: $unnnic-color-gray-5;
 
-      font-family: $unnnic-font-family-secondary;
-      font-size: $unnnic-font-size-body-gt;
+      font-family: $unnnic-font-family;
+      font-size: 14px;
       font-style: normal;
       font-weight: $unnnic-font-weight-regular;
 
       &:focus {
         border-radius: 0.25rem;
-        border: 1px solid $unnnic-color-neutral-cloudy;
-        background: $unnnic-color-neutral-darkest;
+        border: 1px solid $unnnic-color-gray-7;
+        background: $unnnic-color-gray-12;
       }
 
       &:focus-visible {
@@ -250,56 +250,56 @@ export default {
 
     &__btn_send {
       display: flex;
-      padding: $unnnic-spacing-ant $unnnic-spacing-sm;
+      padding: $unnnic-space-3 $unnnic-space-4;
       justify-content: center;
       align-items: center;
-      gap: $unnnic-spacing-nano;
+      gap: $unnnic-space-1;
 
-      border-radius: $unnnic-border-radius-sm;
-      border: 1px solid $unnnic-color-neutral-cloudy;
-      background: $unnnic-color-neutral-dark;
-      color: $unnnic-color-neutral-cleanest;
+      border-radius: $unnnic-radius-1;
+      border: 1px solid $unnnic-color-gray-7;
+      background: $unnnic-color-gray-10;
+      color: $unnnic-color-gray-4;
 
       &:hover {
-        border: 1px solid $unnnic-color-neutral-clean;
+        border: 1px solid $unnnic-color-gray-5;
       }
 
       &:disabled {
-        color: $unnnic-color-neutral-cloudy;
-        border: 1px solid $unnnic-color-neutral-dark;
-        background: $unnnic-color-neutral-darkest;
+        color: $unnnic-color-gray-7;
+        border: 1px solid $unnnic-color-gray-10;
+        background: $unnnic-color-gray-12;
       }
     }
   }
 }
 
 .content__footer .footer__feedback .footer__feedback__btn {
-  border-radius: $unnnic-border-radius-sm;
-  border: 1px solid $unnnic-color-neutral-dark;
-  background: $unnnic-color-neutral-darkest;
-  color: $unnnic-color-neutral-clean;
+  border-radius: $unnnic-radius-1;
+  border: 1px solid $unnnic-color-gray-10;
+  background: $unnnic-color-gray-12;
+  color: $unnnic-color-gray-5;
   &:active,
   &:hover {
     background-color: inherit;
-    border: 1px solid $unnnic-color-neutral-cloudy;
+    border: 1px solid $unnnic-color-gray-7;
   }
 
   :deep(.material-symbols-rounded.unnnic-icon-scheme--neutral-dark) {
-    color: $unnnic-color-neutral-clean;
+    color: $unnnic-color-gray-5;
   }
 
   &:deep(.unnnic-button__label) {
-    color: $unnnic-color-neutral-clean;
+    color: $unnnic-color-gray-5;
   }
 
   &-active {
-    border: 1px solid $unnnic-color-neutral-cloudy;
+    border: 1px solid $unnnic-color-gray-7;
     &:deep(.unnnic-button__label) {
-      color: $unnnic-color-neutral-cleanest;
+      color: $unnnic-color-gray-4;
     }
 
     &:deep(.material-symbols-rounded.unnnic-icon-scheme--neutral-dark) {
-      color: $unnnic-color-neutral-cleanest;
+      color: $unnnic-color-gray-4;
       font-family: Material Symbols Rounded Filled;
     }
   }
@@ -308,7 +308,7 @@ export default {
 .content__footer .footer__feedback .footer__feedback__btn_send {
   &:active,
   &:hover {
-    background: $unnnic-color-neutral-cloudy;
+    background: $unnnic-color-gray-7;
   }
 }
 </style>

--- a/src/components/insights/Layout/HeaderGenerateInsights/InsightModalFooter.vue
+++ b/src/components/insights/Layout/HeaderGenerateInsights/InsightModalFooter.vue
@@ -170,17 +170,13 @@ export default {
   .footer__description {
     color: $unnnic-color-gray-5;
     text-align: right;
-    font-size: 12px;
+    font: $unnnic-font-caption-2;
   }
 
   .feedback_sent {
     text-align: start;
     color: $unnnic-color-gray-0;
-
-    font-family: $unnnic-font-family;
-    font-size: $unnnic-font-size;
-    font-style: normal;
-    font-weight: $unnnic-font-weight-bold;
+    font: $unnnic-font-display-3;
   }
 
   .footer__feedback {
@@ -198,10 +194,8 @@ export default {
     &__text {
       display: flex;
       align-items: flex-start;
-      font-family: $unnnic-font-family;
+      font: $unnnic-font-body;
       color: $unnnic-color-gray-5;
-      font-weight: $unnnic-font-weight-regular;
-      font-size: 14px;
     }
 
     &__container__btns {
@@ -231,10 +225,7 @@ export default {
 
       color: $unnnic-color-gray-5;
 
-      font-family: $unnnic-font-family;
-      font-size: 14px;
-      font-style: normal;
-      font-weight: $unnnic-font-weight-regular;
+      font: $unnnic-font-body;
 
       &:focus {
         border-radius: 0.25rem;

--- a/src/components/insights/Layout/HeaderSelectDashboard/BetaText.vue
+++ b/src/components/insights/Layout/HeaderSelectDashboard/BetaText.vue
@@ -15,19 +15,19 @@
 <style lang="scss" scoped>
 .beta_text_container {
   display: flex;
-  padding: 0 $unnnic-spacing-nano;
+  padding: 0 $unnnic-space-1;
   justify-content: center;
   align-items: center;
   gap: 10px;
 
-  border-radius: $unnnic-border-radius-sm;
-  background: $unnnic-color-weni-50;
+  border-radius: $unnnic-radius-1;
+  background: $unnnic-color-teal-1;
 }
 .beta_text {
-  color: $unnnic-color-weni-600;
-  font-family: $unnnic-font-family-secondary;
-  font-size: $unnnic-font-size-body-md;
+  color: $unnnic-color-teal-8;
+  font-family: $unnnic-font-family;
+  font-size: 12px;
   font-weight: $unnnic-font-weight-bold;
-  line-height: $unnnic-line-height-md + $unnnic-font-size-body-md;
+  line-height: 8px + 12px;
 }
 </style>

--- a/src/components/insights/Layout/HeaderSelectDashboard/BetaText.vue
+++ b/src/components/insights/Layout/HeaderSelectDashboard/BetaText.vue
@@ -25,9 +25,6 @@
 }
 .beta_text {
   color: $unnnic-color-teal-8;
-  font-family: $unnnic-font-family;
-  font-size: 12px;
-  font-weight: $unnnic-font-weight-bold;
-  line-height: 8px + 12px;
+  font: $unnnic-font-caption-1;
 }
 </style>

--- a/src/components/insights/Layout/HeaderSelectDashboard/OptionCreateNewDashboard.vue
+++ b/src/components/insights/Layout/HeaderSelectDashboard/OptionCreateNewDashboard.vue
@@ -19,17 +19,17 @@ export default {
 
 <style lang="scss" scoped>
 .option-create-new-dashboard {
-  padding: $unnnic-spacing-xs;
+  padding: $unnnic-space-2;
 
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: $unnnic-spacing-nano;
+  gap: $unnnic-space-1;
 
-  border-top: $unnnic-border-width-thinner solid $unnnic-color-neutral-light;
+  border-top: 1px solid $unnnic-color-gray-1;
 
-  color: $unnnic-color-neutral-darkest;
-  font-family: $unnnic-font-family-secondary;
-  font-size: $unnnic-font-size-body-gt;
+  color: $unnnic-color-gray-12;
+  font-family: $unnnic-font-family;
+  font-size: 14px;
 }
 </style>

--- a/src/components/insights/Layout/HeaderSelectDashboard/OptionCreateNewDashboard.vue
+++ b/src/components/insights/Layout/HeaderSelectDashboard/OptionCreateNewDashboard.vue
@@ -29,7 +29,6 @@ export default {
   border-top: 1px solid $unnnic-color-gray-1;
 
   color: $unnnic-color-gray-12;
-  font-family: $unnnic-font-family;
-  font-size: 14px;
+  font: $unnnic-font-body;
 }
 </style>

--- a/src/components/insights/Layout/HeaderSelectDashboard/OptionSelectDashboard.vue
+++ b/src/components/insights/Layout/HeaderSelectDashboard/OptionSelectDashboard.vue
@@ -148,8 +148,7 @@ export default {
   gap: $unnnic-space-1;
 
   color: $unnnic-color-gray-12;
-  font-family: $unnnic-font-family;
-  font-size: 14px;
+  font: $unnnic-font-body;
 
   &__content {
     display: flex;

--- a/src/components/insights/Layout/HeaderSelectDashboard/OptionSelectDashboard.vue
+++ b/src/components/insights/Layout/HeaderSelectDashboard/OptionSelectDashboard.vue
@@ -138,38 +138,38 @@ export default {
     content: none;
   }
 
-  border-radius: $unnnic-border-radius-sm;
+  border-radius: $unnnic-radius-1;
 
-  padding: $unnnic-spacing-xs;
+  padding: $unnnic-space-2;
 
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: $unnnic-spacing-nano;
+  gap: $unnnic-space-1;
 
-  color: $unnnic-color-neutral-darkest;
-  font-family: $unnnic-font-family-secondary;
-  font-size: $unnnic-font-size-body-gt;
+  color: $unnnic-color-gray-12;
+  font-family: $unnnic-font-family;
+  font-size: 14px;
 
   &__content {
     display: flex;
     align-items: center;
-    gap: $unnnic-spacing-nano;
+    gap: $unnnic-space-1;
   }
 
   &--active {
-    background-color: $unnnic-color-neutral-lightest;
+    background-color: $unnnic-color-gray-1;
     font-weight: $unnnic-font-weight-bold;
   }
 
   .option-select-dashboard__star-icon:not(
       .option-select-dashboard__star-icon--selected
     ):hover {
-    color: $unnnic-color-weni-500;
+    color: $unnnic-color-teal-7;
   }
 
   .option-select-dashboard__star-icon--selected {
-    color: $unnnic-color-weni-600;
+    color: $unnnic-color-teal-8;
   }
 }
 </style>

--- a/src/components/insights/Layout/HeaderSelectDashboard/__tests__/__snapshots__/HeaderSelectDashboard.spec.js.snap
+++ b/src/components/insights/Layout/HeaderSelectDashboard/__tests__/__snapshots__/HeaderSelectDashboard.spec.js.snap
@@ -49,7 +49,7 @@ exports[`HeaderSelectDashboard > Should match the snapshot 1`] = `
         data-v-054061ac=""
         filled="false"
         icon="expand_more"
-        scheme="neutral-darkest"
+        scheme="fg-emphasized"
         size="md"
       />
     </section>

--- a/src/components/insights/Layout/HeaderSelectDashboard/__tests__/__snapshots__/OptionCreateNewDashboard.spec.js.snap
+++ b/src/components/insights/Layout/HeaderSelectDashboard/__tests__/__snapshots__/OptionCreateNewDashboard.spec.js.snap
@@ -13,7 +13,7 @@ exports[`OptionCreateNewDashboard > Should match the snapshot 1`] = `
     data-v-966a3d2f=""
     filled="false"
     icon="add"
-    scheme="neutral-darkest"
+    scheme="fg-emphasized"
     size="md"
   />
    insights_header.add_new_dashboard

--- a/src/components/insights/Layout/HeaderSelectDashboard/index.vue
+++ b/src/components/insights/Layout/HeaderSelectDashboard/index.vue
@@ -195,10 +195,7 @@ $dropdownFixedWidth: 314px;
       margin: $unnnic-space-1 0;
 
       color: $unnnic-color-gray-12;
-      font-family: $unnnic-font-family;
-      font-size: 20px;
-      font-weight: $unnnic-font-weight-bold;
-      line-height: 16px * 2;
+      font: $unnnic-font-display-2;
       text-wrap: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;

--- a/src/components/insights/Layout/HeaderSelectDashboard/index.vue
+++ b/src/components/insights/Layout/HeaderSelectDashboard/index.vue
@@ -181,24 +181,24 @@ $dropdownFixedWidth: 314px;
   &__title {
     display: flex;
     align-items: center;
-    gap: $unnnic-spacing-nano;
+    gap: $unnnic-space-1;
     cursor: pointer;
   }
 
   &__trigger {
     display: flex;
     align-items: center;
-    gap: $unnnic-spacing-nano;
+    gap: $unnnic-space-1;
     cursor: pointer;
 
     .trigger__title {
-      margin: $unnnic-spacing-nano 0;
+      margin: $unnnic-space-1 0;
 
-      color: $unnnic-color-neutral-darkest;
-      font-family: $unnnic-font-family-primary;
-      font-size: $unnnic-font-size-title-sm;
+      color: $unnnic-color-gray-12;
+      font-family: $unnnic-font-family;
+      font-size: 20px;
       font-weight: $unnnic-font-weight-bold;
-      line-height: $unnnic-line-height-large * 2;
+      line-height: 16px * 2;
       text-wrap: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
@@ -207,25 +207,25 @@ $dropdownFixedWidth: 314px;
   }
 
   &__arrow-back {
-    margin: $unnnic-spacing-xs;
+    margin: $unnnic-space-2;
   }
 
   :deep(.unnnic-dropdown__trigger) {
     display: flex;
-    gap: $unnnic-spacing-ant;
+    gap: $unnnic-space-3;
     align-items: center;
 
     .unnnic-dropdown__content {
       z-index: 9999;
-      margin-top: $unnnic-spacing-nano;
+      margin-top: $unnnic-space-1;
 
       left: 0;
 
       min-width: $dropdownFixedWidth;
       width: 100%;
 
-      padding: $unnnic-spacing-xs;
-      gap: $unnnic-spacing-nano;
+      padding: $unnnic-space-2;
+      gap: $unnnic-space-1;
     }
   }
 }

--- a/src/components/insights/Layout/HeaderTagLive.vue
+++ b/src/components/insights/Layout/HeaderTagLive.vue
@@ -66,7 +66,7 @@ const titleText = computed(() => {
   &__text {
     margin: 0;
 
-    font-size: 14px;
+    font: $unnnic-font-body;
   }
 }
 </style>

--- a/src/components/insights/Layout/HeaderTagLive.vue
+++ b/src/components/insights/Layout/HeaderTagLive.vue
@@ -35,13 +35,13 @@ const titleText = computed(() => {
 
 <style lang="scss">
 .header-tag-live {
-  padding: 0 $unnnic-spacing-xs;
+  padding: 0 $unnnic-space-2;
 
   display: inline-flex;
   align-items: center;
 
-  color: $unnnic-color-neutral-darkest;
-  font-family: $unnnic-font-family-secondary;
+  color: $unnnic-color-gray-12;
+  font-family: $unnnic-font-family;
 
   &__indicator {
     .primary {
@@ -50,7 +50,7 @@ const titleText = computed(() => {
 
     @keyframes pulse {
       0% {
-        fill: $unnnic-color-neutral-soft;
+        fill: $unnnic-color-gray-2;
       }
 
       50% {
@@ -58,7 +58,7 @@ const titleText = computed(() => {
       }
 
       100% {
-        fill: $unnnic-color-neutral-soft;
+        fill: $unnnic-color-gray-2;
       }
     }
   }
@@ -66,7 +66,7 @@ const titleText = computed(() => {
   &__text {
     margin: 0;
 
-    font-size: $unnnic-font-size-body-gt;
+    font-size: 14px;
   }
 }
 </style>

--- a/src/components/insights/cards/CardBase.vue
+++ b/src/components/insights/cards/CardBase.vue
@@ -13,7 +13,7 @@ export default {
 <style lang="scss" scoped>
 .card-base {
   background-color: $unnnic-color-gray-0;
-  box-shadow: $unnnic-shadow-2;
+  box-shadow: $unnnic-shadow-1;
   border: 1px solid $unnnic-color-gray-2;
   border-radius: $unnnic-radius-1;
 }

--- a/src/components/insights/cards/CardBase.vue
+++ b/src/components/insights/cards/CardBase.vue
@@ -12,9 +12,9 @@ export default {
 
 <style lang="scss" scoped>
 .card-base {
-  background-color: $unnnic-color-neutral-white;
-  box-shadow: $unnnic-shadow-level-far;
-  border: $unnnic-border-width-thinner solid $unnnic-color-neutral-soft;
-  border-radius: $unnnic-border-radius-sm;
+  background-color: $unnnic-color-gray-0;
+  box-shadow: $unnnic-shadow-2;
+  border: 1px solid $unnnic-color-gray-2;
+  border-radius: $unnnic-radius-1;
 }
 </style>

--- a/src/components/insights/cards/CardConversations.vue
+++ b/src/components/insights/cards/CardConversations.vue
@@ -120,30 +120,30 @@ defineEmits<{
 <style scoped lang="scss">
 .card-conversations {
   display: flex;
-  padding: $unnnic-spacing-md;
+  padding: $unnnic-space-6;
   flex-direction: column;
   align-items: flex-start;
-  gap: $unnnic-spacing-xs;
+  gap: $unnnic-space-2;
   flex: 1 0 0;
   align-self: stretch;
 
-  border: 1px solid $unnnic-color-neutral-soft;
-  background: $unnnic-color-neutral-white;
+  border: 1px solid $unnnic-color-gray-2;
+  background: $unnnic-color-gray-0;
 
   &--clickable {
     cursor: pointer;
   }
 
   &--border-full {
-    border-radius: $unnnic-border-radius-md;
+    border-radius: $unnnic-radius-2;
   }
 
   &--border-left {
-    border-radius: $unnnic-border-radius-md 0 0 $unnnic-border-radius-md;
+    border-radius: $unnnic-radius-2 0 0 $unnnic-radius-2;
   }
 
   &--border-right {
-    border-radius: 0 $unnnic-border-radius-md $unnnic-border-radius-md 0;
+    border-radius: 0 $unnnic-radius-2 $unnnic-radius-2 0;
     border-left: none;
   }
 
@@ -156,7 +156,7 @@ defineEmits<{
     display: flex;
     width: 100%;
     align-items: center;
-    gap: $unnnic-spacing-sm;
+    gap: $unnnic-space-4;
   }
 
   &__text {
@@ -165,13 +165,13 @@ defineEmits<{
     -webkit-line-clamp: 1;
     flex: 1 0 0;
     overflow: hidden;
-    color: $unnnic-color-neutral-darkest;
+    color: $unnnic-color-gray-12;
     text-overflow: ellipsis;
-    font-family: $unnnic-font-family-secondary;
-    font-size: $unnnic-font-size-body-lg;
+    font-family: $unnnic-font-family;
+    font-size: $unnnic-font-size;
     font-style: normal;
     font-weight: $unnnic-font-weight-regular;
-    line-height: $unnnic-font-size-body-lg + $unnnic-line-height-md;
+    line-height: $unnnic-font-size + 8px;
   }
 
   &__info-icon {
@@ -189,7 +189,7 @@ defineEmits<{
 
   &__value {
     display: flex;
-    gap: $unnnic-spacing-xs;
+    gap: $unnnic-space-2;
     align-items: end;
 
     &--enable-time-icon {
@@ -198,30 +198,30 @@ defineEmits<{
   }
 
   &__number {
-    color: $unnnic-color-neutral-black;
-    font-family: $unnnic-font-family-secondary;
-    font-size: $unnnic-font-size-title-md;
+    color: $unnnic-color-gray-13;
+    font-family: $unnnic-font-family;
+    font-size: 24px;
     font-style: normal;
     font-weight: $unnnic-font-weight-bold;
-    line-height: $unnnic-font-size-title-md + $unnnic-line-height-md;
+    line-height: 24px + 8px;
   }
 
   &__value-description {
-    color: $unnnic-color-neutral-cloudy;
-    font-family: $unnnic-font-family-secondary;
-    font-size: $unnnic-font-size-body-lg;
+    color: $unnnic-color-gray-7;
+    font-family: $unnnic-font-family;
+    font-size: $unnnic-font-size;
     font-style: normal;
     font-weight: $unnnic-font-weight-bold;
-    line-height: $unnnic-font-size-body-lg + $unnnic-line-height-md;
+    line-height: $unnnic-font-size + 8px;
   }
 
   &__description {
-    color: $unnnic-color-neutral-cloudy;
-    font-family: $unnnic-font-family-secondary;
-    font-size: $unnnic-font-size-body-md;
+    color: $unnnic-color-gray-7;
+    font-family: $unnnic-font-family;
+    font-size: 12px;
     font-style: normal;
     font-weight: $unnnic-font-weight-regular;
-    line-height: $unnnic-font-size-body-md + $unnnic-line-height-md;
+    line-height: 12px + 8px;
   }
 
   &__skeleton {

--- a/src/components/insights/cards/CardConversations.vue
+++ b/src/components/insights/cards/CardConversations.vue
@@ -167,11 +167,7 @@ defineEmits<{
     overflow: hidden;
     color: $unnnic-color-gray-12;
     text-overflow: ellipsis;
-    font-family: $unnnic-font-family;
-    font-size: $unnnic-font-size;
-    font-style: normal;
-    font-weight: $unnnic-font-weight-regular;
-    line-height: $unnnic-font-size + 8px;
+    font: $unnnic-font-display-4;
   }
 
   &__info-icon {
@@ -199,29 +195,17 @@ defineEmits<{
 
   &__number {
     color: $unnnic-color-gray-13;
-    font-family: $unnnic-font-family;
-    font-size: 24px;
-    font-style: normal;
-    font-weight: $unnnic-font-weight-bold;
-    line-height: 24px + 8px;
+    font: $unnnic-font-display-1;
   }
 
   &__value-description {
     color: $unnnic-color-gray-7;
-    font-family: $unnnic-font-family;
-    font-size: $unnnic-font-size;
-    font-style: normal;
-    font-weight: $unnnic-font-weight-bold;
-    line-height: $unnnic-font-size + 8px;
+    font: $unnnic-font-display-3;
   }
 
   &__description {
     color: $unnnic-color-gray-7;
-    font-family: $unnnic-font-family;
-    font-size: 12px;
-    font-style: normal;
-    font-weight: $unnnic-font-weight-regular;
-    line-height: 12px + 8px;
+    font: $unnnic-font-caption-2;
   }
 
   &__skeleton {

--- a/src/components/insights/cards/CardConversations.vue
+++ b/src/components/insights/cards/CardConversations.vue
@@ -33,7 +33,7 @@
           icon="info"
           size="sm"
           filled
-          scheme="neutral-cleanest"
+          scheme="fg-muted"
         />
       </UnnnicToolTip>
     </section>
@@ -199,12 +199,12 @@ defineEmits<{
   }
 
   &__value-description {
-    color: $unnnic-color-gray-7;
+    color: $unnnic-color-fg-muted;
     font: $unnnic-font-display-3;
   }
 
   &__description {
-    color: $unnnic-color-gray-7;
+    color: $unnnic-color-fg-muted;
     font: $unnnic-font-caption-2;
   }
 

--- a/src/components/insights/cards/CardDashboard.vue
+++ b/src/components/insights/cards/CardDashboard.vue
@@ -190,8 +190,7 @@ export default {
     gap: $unnnic-space-1;
 
     .content-error {
-      font-size: 14px;
-      line-height: 8px * 3;
+      font: $unnnic-font-body;
     }
     .content-metric {
       display: flex;
@@ -205,14 +204,13 @@ export default {
         white-space: nowrap;
       }
       &__friendly-id {
-        font-size: 24px;
+        font: $unnnic-font-display-1;
+        font-weight: $unnnic-font-weight-regular;
         padding-bottom: $unnnic-space-1 * 1.5;
       }
       &__value {
-        font-family: $unnnic-font-family;
+        font: $unnnic-font-display-1;
         font-size: 32px;
-        line-height: 16px * 3;
-        font-weight: $unnnic-font-weight-bold;
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
@@ -225,8 +223,7 @@ export default {
       flex-wrap: wrap;
       overflow: hidden;
       &__text {
-        font-size: $unnnic-font-size;
-        line-height: 8px * 3;
+        font: $unnnic-font-display-4;
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;

--- a/src/components/insights/cards/CardDashboard.vue
+++ b/src/components/insights/cards/CardDashboard.vue
@@ -78,6 +78,7 @@
               <UnnnicIcon
                 icon="info"
                 size="avatar-nano"
+                scheme="fg-muted"
               />
             </UnnnicToolTip>
           </section>
@@ -175,7 +176,7 @@ export default {
 
   &.not-configured {
     .card__content {
-      color: $unnnic-color-gray-7;
+      color: $unnnic-color-fg-muted;
     }
 
     .card-dashboard__button-config {

--- a/src/components/insights/cards/CardDashboard.vue
+++ b/src/components/insights/cards/CardDashboard.vue
@@ -152,14 +152,14 @@ export default {
 
 <style scoped lang="scss">
 .card-dashboard {
-  padding: $unnnic-spacing-md;
+  padding: $unnnic-space-6;
   width: 100%;
   height: 100%;
 
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: $unnnic-spacing-xs;
+  gap: $unnnic-space-2;
 
   overflow: hidden;
 
@@ -168,14 +168,14 @@ export default {
   }
 
   &.clickable:not(.loading):hover {
-    background-color: $unnnic-color-weni-50;
+    background-color: $unnnic-color-teal-1;
 
     cursor: pointer;
   }
 
   &.not-configured {
     .card__content {
-      color: $unnnic-color-neutral-cloudy;
+      color: $unnnic-color-gray-7;
     }
 
     .card-dashboard__button-config {
@@ -185,13 +185,13 @@ export default {
 
   .card__content {
     width: 100%;
-    color: $unnnic-color-neutral-darkest;
+    color: $unnnic-color-gray-12;
     display: grid;
-    gap: $unnnic-spacing-nano;
+    gap: $unnnic-space-1;
 
     .content-error {
-      font-size: $unnnic-font-size-body-gt;
-      line-height: $unnnic-line-height-medium * 3;
+      font-size: 14px;
+      line-height: 8px * 3;
     }
     .content-metric {
       display: flex;
@@ -200,18 +200,18 @@ export default {
       &__container {
         display: flex;
         align-items: center;
-        gap: $unnnic-spacing-ant;
+        gap: $unnnic-space-3;
         overflow: hidden;
         white-space: nowrap;
       }
       &__friendly-id {
-        font-size: $unnnic-font-size-title-md;
-        padding-bottom: $unnnic-spacing-nano * 1.5;
+        font-size: 24px;
+        padding-bottom: $unnnic-space-1 * 1.5;
       }
       &__value {
-        font-family: $unnnic-font-family-primary;
-        font-size: $unnnic-font-size-title-lg;
-        line-height: $unnnic-line-height-large * 3;
+        font-family: $unnnic-font-family;
+        font-size: 32px;
+        line-height: 16px * 3;
         font-weight: $unnnic-font-weight-bold;
         overflow: hidden;
         text-overflow: ellipsis;
@@ -221,18 +221,18 @@ export default {
     .content-description {
       display: flex;
       align-items: center;
-      gap: $unnnic-spacing-nano;
+      gap: $unnnic-space-1;
       flex-wrap: wrap;
       overflow: hidden;
       &__text {
-        font-size: $unnnic-font-size-body-lg;
-        line-height: $unnnic-line-height-medium * 3;
+        font-size: $unnnic-font-size;
+        line-height: 8px * 3;
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
       }
       &__tooltip {
-        margin-top: $unnnic-spacing-nano;
+        margin-top: $unnnic-space-1;
       }
     }
   }

--- a/src/components/insights/cards/CardEmpty.vue
+++ b/src/components/insights/cards/CardEmpty.vue
@@ -68,9 +68,8 @@ export default {
       .not-configured__text {
         padding-bottom: $unnnic-space-4;
         color: $unnnic-color-gray-7;
-        font-size: $unnnic-font-size;
+        font: $unnnic-font-display-4;
         text-align: center;
-        line-height: 4px * 6;
       }
     }
   }

--- a/src/components/insights/cards/CardEmpty.vue
+++ b/src/components/insights/cards/CardEmpty.vue
@@ -43,12 +43,12 @@ export default {
   min-height: 310px;
   height: 100%;
 
-  padding: $unnnic-spacing-sm;
+  padding: $unnnic-space-4;
 
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: $unnnic-spacing-sm;
+  gap: $unnnic-space-4;
 
   &__content {
     overflow: hidden;
@@ -66,11 +66,11 @@ export default {
       align-items: center;
 
       .not-configured__text {
-        padding-bottom: $unnnic-spacing-sm;
-        color: $unnnic-color-neutral-cloudy;
-        font-size: $unnnic-font-size-body-lg;
+        padding-bottom: $unnnic-space-4;
+        color: $unnnic-color-gray-7;
+        font-size: $unnnic-font-size;
         text-align: center;
-        line-height: $unnnic-line-height-small * 6;
+        line-height: 4px * 6;
       }
     }
   }

--- a/src/components/insights/cards/CardEmpty.vue
+++ b/src/components/insights/cards/CardEmpty.vue
@@ -67,7 +67,7 @@ export default {
 
       .not-configured__text {
         padding-bottom: $unnnic-space-4;
-        color: $unnnic-color-gray-7;
+        color: $unnnic-color-fg-muted;
         font: $unnnic-font-display-4;
         text-align: center;
       }

--- a/src/components/insights/cards/CardFunnel.vue
+++ b/src/components/insights/cards/CardFunnel.vue
@@ -131,10 +131,7 @@ export default {
       padding: $unnnic-space-1 0;
 
       color: $unnnic-color-gray-12;
-      font-family: $unnnic-font-family;
-      font-size: 20px;
-      font-weight: $unnnic-font-weight-bold;
-      line-height: 4px * 7.5;
+      font: $unnnic-font-display-2;
     }
   }
 
@@ -156,9 +153,8 @@ export default {
 
       .not-configured__text {
         color: $unnnic-color-gray-7;
-        font-size: $unnnic-font-size;
+        font: $unnnic-font-display-4;
         text-align: center;
-        line-height: 4px * 6;
       }
     }
   }

--- a/src/components/insights/cards/CardFunnel.vue
+++ b/src/components/insights/cards/CardFunnel.vue
@@ -106,16 +106,16 @@ export default {
   height: 100%;
   width: 100%;
 
-  padding: $unnnic-spacing-md;
+  padding: $unnnic-space-6;
 
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: $unnnic-spacing-sm;
+  gap: $unnnic-space-4;
 
   &--not-configured {
     .card-funnel__header .header__title {
-      color: $unnnic-color-neutral-cloudy;
+      color: $unnnic-color-gray-7;
     }
   }
 
@@ -125,16 +125,16 @@ export default {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding-bottom: $unnnic-spacing-md;
+    padding-bottom: $unnnic-space-6;
 
     .header__title {
-      padding: $unnnic-spacing-nano 0;
+      padding: $unnnic-space-1 0;
 
-      color: $unnnic-color-neutral-darkest;
-      font-family: $unnnic-font-family-primary;
-      font-size: $unnnic-font-size-title-sm;
+      color: $unnnic-color-gray-12;
+      font-family: $unnnic-font-family;
+      font-size: 20px;
       font-weight: $unnnic-font-weight-bold;
-      line-height: $unnnic-line-height-small * 7.5;
+      line-height: 4px * 7.5;
     }
   }
 
@@ -152,13 +152,13 @@ export default {
       flex-direction: column;
       justify-content: center;
       align-items: center;
-      gap: $unnnic-spacing-sm;
+      gap: $unnnic-space-4;
 
       .not-configured__text {
-        color: $unnnic-color-neutral-cloudy;
-        font-size: $unnnic-font-size-body-lg;
+        color: $unnnic-color-gray-7;
+        font-size: $unnnic-font-size;
         text-align: center;
-        line-height: $unnnic-line-height-small * 6;
+        line-height: 4px * 6;
       }
     }
   }

--- a/src/components/insights/cards/CardFunnel.vue
+++ b/src/components/insights/cards/CardFunnel.vue
@@ -22,7 +22,7 @@
         <UnnnicIcon
           size="lg"
           icon="filter_alt"
-          scheme="neutral-cloudy"
+          scheme="fg-muted"
         />
         <p class="not-configured__text">
           {{ $t('widgets.graph_funnel.not_configured_description') }}
@@ -115,7 +115,7 @@ export default {
 
   &--not-configured {
     .card-funnel__header .header__title {
-      color: $unnnic-color-gray-7;
+      color: $unnnic-color-fg-muted;
     }
   }
 
@@ -152,7 +152,7 @@ export default {
       gap: $unnnic-space-4;
 
       .not-configured__text {
-        color: $unnnic-color-gray-7;
+        color: $unnnic-color-fg-muted;
         font: $unnnic-font-display-4;
         text-align: center;
       }

--- a/src/components/insights/cards/CardRecurrence.vue
+++ b/src/components/insights/cards/CardRecurrence.vue
@@ -168,11 +168,7 @@ export default {
 
   &__link {
     color: $unnnic-color-gray-7;
-    font-family: $unnnic-font-family;
-    font-size: 14px;
-    font-style: normal;
-    font-weight: $unnnic-font-weight-bold;
-    line-height: 8px * 3;
+    font: $unnnic-font-action;
     text-decoration-line: underline;
     text-decoration-style: solid;
     text-decoration-skip-ink: none;
@@ -201,10 +197,7 @@ export default {
     .header__title {
       padding: $unnnic-space-1 0;
 
-      font-family: $unnnic-font-family;
-      font-size: 20px;
-      font-weight: $unnnic-font-weight-bold;
-      line-height: 4px * 7.5;
+      font: $unnnic-font-display-2;
     }
   }
 
@@ -277,11 +270,7 @@ export default {
           display: inline-block;
 
           color: $unnnic-color-gray-7;
-          font-family: $unnnic-font-family;
-          font-size: $unnnic-font-size;
-          font-style: normal;
-          font-weight: $unnnic-font-weight-regular;
-          line-height: 8px * 3;
+          font: $unnnic-font-display-4;
         }
       }
     }
@@ -294,9 +283,8 @@ export default {
 
       .not-configured__text {
         color: $unnnic-color-gray-7;
-        font-size: $unnnic-font-size;
+        font: $unnnic-font-display-4;
         text-align: center;
-        line-height: 4px * 6;
       }
     }
   }
@@ -332,8 +320,7 @@ export default {
   }
 
   :deep(.unnnic-progress-bar.primary .progress-bar-container .percentage) {
-    font-size: $unnnic-font-size;
-    line-height: $unnnic-font-size * 2;
+    font: $unnnic-font-display-4;
     min-width: $unnnic-space-8;
   }
 }

--- a/src/components/insights/cards/CardRecurrence.vue
+++ b/src/components/insights/cards/CardRecurrence.vue
@@ -149,9 +149,9 @@ export default {
 
 <style lang="scss" scoped>
 .divider {
-  margin-top: $unnnic-spacing-md;
+  margin-top: $unnnic-space-6;
   height: 1px;
-  background-color: $unnnic-color-neutral-light;
+  background-color: $unnnic-color-gray-1;
   width: 100%;
 }
 
@@ -159,20 +159,20 @@ export default {
   min-height: 310px;
   height: 100%;
 
-  padding: $unnnic-spacing-md;
+  padding: $unnnic-space-6;
 
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: $unnnic-spacing-sm;
+  gap: $unnnic-space-4;
 
   &__link {
-    color: $unnnic-color-neutral-cloudy;
-    font-family: $unnnic-font-family-secondary;
-    font-size: $unnnic-font-size-body-gt;
+    color: $unnnic-color-gray-7;
+    font-family: $unnnic-font-family;
+    font-size: 14px;
     font-style: normal;
     font-weight: $unnnic-font-weight-bold;
-    line-height: $unnnic-font-size-body-sm * 3;
+    line-height: 8px * 3;
     text-decoration-line: underline;
     text-decoration-style: solid;
     text-decoration-skip-ink: none;
@@ -183,7 +183,7 @@ export default {
 
   &--not-data {
     .card-recurrence__header .header__title {
-      color: $unnnic-color-neutral-cloudy;
+      color: $unnnic-color-gray-7;
     }
   }
 
@@ -199,12 +199,12 @@ export default {
     justify-content: space-between;
 
     .header__title {
-      padding: $unnnic-spacing-nano 0;
+      padding: $unnnic-space-1 0;
 
-      font-family: $unnnic-font-family-primary;
-      font-size: $unnnic-font-size-title-sm;
+      font-family: $unnnic-font-family;
+      font-size: 20px;
       font-weight: $unnnic-font-weight-bold;
-      line-height: $unnnic-line-height-small * 7.5;
+      line-height: 4px * 7.5;
     }
   }
 
@@ -221,25 +221,25 @@ export default {
       height: 100%;
       display: grid;
       grid-template-rows: repeat(5, 1fr);
-      gap: $unnnic-spacing-sm;
-      background-color: $unnnic-color-neutral-white;
-      padding: $unnnic-spacing-sm;
+      gap: $unnnic-space-4;
+      background-color: $unnnic-color-gray-0;
+      padding: $unnnic-space-4;
 
       &-group {
         cursor: pointer;
-        min-height: $unnnic-avatar-size-sm;
+        min-height: 40px;
         display: flex;
         flex-direction: column;
         justify-content: center;
 
         &:empty {
-          background: $unnnic-color-neutral-lightest;
-          border-radius: $unnnic-border-radius-sm;
+          background: $unnnic-color-gray-1;
+          border-radius: $unnnic-radius-1;
         }
 
         &:not(:last-child) {
-          border-bottom: 1px solid $unnnic-color-neutral-light;
-          padding-bottom: $unnnic-spacing-sm;
+          border-bottom: 1px solid $unnnic-color-gray-1;
+          padding-bottom: $unnnic-space-4;
         }
       }
 
@@ -276,12 +276,12 @@ export default {
           max-width: 100%;
           display: inline-block;
 
-          color: $unnnic-color-neutral-cloudy;
-          font-family: $unnnic-font-family-secondary;
-          font-size: $unnnic-font-size-body-lg;
+          color: $unnnic-color-gray-7;
+          font-family: $unnnic-font-family;
+          font-size: $unnnic-font-size;
           font-style: normal;
           font-weight: $unnnic-font-weight-regular;
-          line-height: $unnnic-font-size-body-sm * 3;
+          line-height: 8px * 3;
         }
       }
     }
@@ -293,10 +293,10 @@ export default {
       align-items: center;
 
       .not-configured__text {
-        color: $unnnic-color-neutral-cloudy;
-        font-size: $unnnic-font-size-body-lg;
+        color: $unnnic-color-gray-7;
+        font-size: $unnnic-font-size;
         text-align: center;
-        line-height: $unnnic-line-height-small * 6;
+        line-height: 4px * 6;
       }
     }
   }
@@ -322,19 +322,19 @@ export default {
       .bar
   ) {
     border-radius: 37.5rem;
-    background-color: $unnnic-color-weni-600;
+    background-color: $unnnic-color-teal-8;
   }
 
   :deep(
     .unnnic-progress-bar.primary .progress-bar-container .progress-container
   ) {
-    background-color: $unnnic-color-weni-100;
+    background-color: $unnnic-color-teal-2;
   }
 
   :deep(.unnnic-progress-bar.primary .progress-bar-container .percentage) {
-    font-size: $unnnic-font-size-body-lg;
-    line-height: $unnnic-font-size-body-lg * 2;
-    min-width: $unnnic-spacing-lg;
+    font-size: $unnnic-font-size;
+    line-height: $unnnic-font-size * 2;
+    min-width: $unnnic-space-8;
   }
 }
 </style>

--- a/src/components/insights/cards/CardRecurrence.vue
+++ b/src/components/insights/cards/CardRecurrence.vue
@@ -167,7 +167,7 @@ export default {
   gap: $unnnic-space-4;
 
   &__link {
-    color: $unnnic-color-gray-7;
+    color: $unnnic-color-fg-muted;
     font: $unnnic-font-action;
     text-decoration-line: underline;
     text-decoration-style: solid;
@@ -179,7 +179,7 @@ export default {
 
   &--not-data {
     .card-recurrence__header .header__title {
-      color: $unnnic-color-gray-7;
+      color: $unnnic-color-fg-muted;
     }
   }
 
@@ -269,7 +269,7 @@ export default {
           max-width: 100%;
           display: inline-block;
 
-          color: $unnnic-color-gray-7;
+          color: $unnnic-color-fg-muted;
           font: $unnnic-font-display-4;
         }
       }
@@ -282,7 +282,7 @@ export default {
       align-items: center;
 
       .not-configured__text {
-        color: $unnnic-color-gray-7;
+        color: $unnnic-color-fg-muted;
         font: $unnnic-font-display-4;
         text-align: center;
       }

--- a/src/components/insights/cards/CardTitleError.vue
+++ b/src/components/insights/cards/CardTitleError.vue
@@ -21,14 +21,14 @@ export default {
 <style lang="scss" scoped>
 .card-title-error {
   display: flex;
-  gap: $unnnic-spacing-xs;
+  gap: $unnnic-space-2;
   align-items: center;
 
   &__title {
-    color: $unnnic-color-neutral-darkest;
-    font-family: $unnnic-font-family-secondary;
+    color: $unnnic-color-gray-12;
+    font-family: $unnnic-font-family;
     font-weight: $unnnic-font-weight-bold;
-    line-height: $unnnic-line-height-small * 6;
+    line-height: 4px * 6;
   }
 }
 </style>

--- a/src/components/insights/cards/CardVtexConversions.vue
+++ b/src/components/insights/cards/CardVtexConversions.vue
@@ -165,10 +165,7 @@ defineEmits(['open-config']);
   }
   &__title {
     color: $unnnic-color-gray-12;
-    font-family: $unnnic-font-family;
-    font-size: $unnnic-font-size;
-    font-weight: $unnnic-font-weight-bold;
-    line-height: $unnnic-font-size + 8px;
+    font: $unnnic-font-display-3;
   }
 
   &__vtex {
@@ -184,18 +181,11 @@ defineEmits(['open-config']);
       width: 100%;
       &-value {
         color: $unnnic-color-gray-12;
-        font-family: $unnnic-font-family;
-        font-size: $unnnic-font-size;
-        font-style: normal;
-        font-weight: $unnnic-font-weight-bold;
-        line-height: $unnnic-font-size + 8px;
+        font: $unnnic-font-display-3;
       }
       &-label {
         color: $unnnic-color-gray-7;
-
-        font-family: $unnnic-font-family;
-        font-size: 12px;
-        line-height: 12px + 8px;
+        font: $unnnic-font-caption-2;
       }
       &-divider {
         background: $unnnic-color-gray-1;
@@ -238,9 +228,8 @@ defineEmits(['open-config']);
     justify-content: center;
 
     color: $unnnic-color-gray-7;
-    font-size: $unnnic-font-size;
+    font: $unnnic-font-display-4;
     text-align: center;
-    line-height: 4px * 6;
 
     &-description {
       font-weight: $unnnic-font-weight-bold;

--- a/src/components/insights/cards/CardVtexConversions.vue
+++ b/src/components/insights/cards/CardVtexConversions.vue
@@ -149,8 +149,8 @@ defineEmits(['open-config']);
 .vtex-conversions-widget {
   display: flex;
   flex-direction: column;
-  padding: $unnnic-spacing-md;
-  gap: $unnnic-spacing-md;
+  padding: $unnnic-space-6;
+  gap: $unnnic-space-6;
 
   &__loading {
     display: flex;
@@ -164,18 +164,18 @@ defineEmits(['open-config']);
     justify-content: space-between;
   }
   &__title {
-    color: $unnnic-color-neutral-darkest;
-    font-family: $unnnic-font-family-primary;
-    font-size: $unnnic-font-size-body-lg;
+    color: $unnnic-color-gray-12;
+    font-family: $unnnic-font-family;
+    font-size: $unnnic-font-size;
     font-weight: $unnnic-font-weight-bold;
-    line-height: $unnnic-font-size-body-lg + $unnnic-line-height-medium;
+    line-height: $unnnic-font-size + 8px;
   }
 
   &__vtex {
     &-container {
       display: flex;
       align-items: flex-start;
-      gap: $unnnic-spacing-md;
+      gap: $unnnic-space-6;
       align-self: stretch;
     }
     &-data {
@@ -183,24 +183,24 @@ defineEmits(['open-config']);
       flex-direction: column;
       width: 100%;
       &-value {
-        color: $unnnic-color-neutral-darkest;
-        font-family: $unnnic-font-family-primary;
-        font-size: $unnnic-font-size-body-lg;
+        color: $unnnic-color-gray-12;
+        font-family: $unnnic-font-family;
+        font-size: $unnnic-font-size;
         font-style: normal;
         font-weight: $unnnic-font-weight-bold;
-        line-height: $unnnic-font-size-body-lg + $unnnic-line-height-medium;
+        line-height: $unnnic-font-size + 8px;
       }
       &-label {
-        color: $unnnic-color-neutral-cloudy;
+        color: $unnnic-color-gray-7;
 
-        font-family: $unnnic-font-family-secondary;
-        font-size: $unnnic-font-size-body-md;
-        line-height: $unnnic-font-size-body-md + $unnnic-line-height-medium;
+        font-family: $unnnic-font-family;
+        font-size: 12px;
+        line-height: 12px + 8px;
       }
       &-divider {
-        background: $unnnic-color-neutral-light;
+        background: $unnnic-color-gray-1;
         height: 100%;
-        border: 1px solid $unnnic-color-neutral-light;
+        border: 1px solid $unnnic-color-gray-1;
       }
     }
   }
@@ -224,7 +224,7 @@ defineEmits(['open-config']);
           bottom: 0;
           right: 0;
           width: calc(100%);
-          border-bottom: 1px solid $unnnic-color-neutral-soft;
+          border-bottom: 1px solid $unnnic-color-gray-2;
         }
       }
     }
@@ -237,14 +237,14 @@ defineEmits(['open-config']);
     align-items: center;
     justify-content: center;
 
-    color: $unnnic-color-neutral-cloudy;
-    font-size: $unnnic-font-size-body-lg;
+    color: $unnnic-color-gray-7;
+    font-size: $unnnic-font-size;
     text-align: center;
-    line-height: $unnnic-line-height-small * 6;
+    line-height: 4px * 6;
 
     &-description {
       font-weight: $unnnic-font-weight-bold;
-      padding-bottom: $unnnic-spacing-sm;
+      padding-bottom: $unnnic-space-4;
     }
   }
 }

--- a/src/components/insights/cards/CardVtexConversions.vue
+++ b/src/components/insights/cards/CardVtexConversions.vue
@@ -184,7 +184,7 @@ defineEmits(['open-config']);
         font: $unnnic-font-display-3;
       }
       &-label {
-        color: $unnnic-color-gray-7;
+        color: $unnnic-color-fg-muted;
         font: $unnnic-font-caption-2;
       }
       &-divider {
@@ -227,7 +227,7 @@ defineEmits(['open-config']);
     align-items: center;
     justify-content: center;
 
-    color: $unnnic-color-gray-7;
+    color: $unnnic-color-fg-muted;
     font: $unnnic-font-display-4;
     text-align: center;
 

--- a/src/components/insights/cards/CardVtexConversions.vue
+++ b/src/components/insights/cards/CardVtexConversions.vue
@@ -92,11 +92,11 @@ import CardBase from './CardBase.vue';
 import i18n from '@/utils/plugins/i18n';
 import { formatPercentage, formatValue } from '@/utils/numbers';
 import {
-  colorPurple300,
-  colorGreen300,
-  colorBlue300,
-  colorOrange300,
-  colorRed600,
+  colorPurple4,
+  colorGreen4,
+  colorBlue5,
+  colorOrange4,
+  colorRed10,
 } from '@weni/unnnic-system/tokens/colors';
 
 const props = defineProps({
@@ -125,11 +125,11 @@ const metaData = computed(() => {
   if (!graphData) return [];
   const keysOrdend = ['sent', 'delivered', 'read', 'clicked', 'orders'];
   const colors = [
-    colorPurple300,
-    colorGreen300,
-    colorBlue300,
-    colorOrange300,
-    colorRed600,
+    colorPurple4,
+    colorGreen4,
+    colorBlue5,
+    colorOrange4,
+    colorRed10,
   ];
   return keysOrdend.map((key, index) => ({
     title:

--- a/src/components/insights/cards/CardVtexOrder.vue
+++ b/src/components/insights/cards/CardVtexOrder.vue
@@ -152,24 +152,24 @@ export default {
   min-height: 310px;
   height: 100%;
 
-  padding: $unnnic-spacing-md;
+  padding: $unnnic-space-6;
 
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: $unnnic-spacing-sm;
+  gap: $unnnic-space-4;
 
   :deep(.unnnic-avatar-icon.aux-red-500) {
-    background: $unnnic-color-aux-red-100;
+    background: $unnnic-color-red-2;
   }
 
   :deep(.material-symbols-rounded.unnnic-icon-scheme--aux-red-500) {
-    color: $unnnic-color-aux-red-600;
+    color: $unnnic-color-red-8;
   }
 
   &--not-data {
     .card-vtex-order__header .header__title {
-      color: $unnnic-color-neutral-cloudy;
+      color: $unnnic-color-gray-7;
     }
   }
 
@@ -185,13 +185,13 @@ export default {
     justify-content: space-between;
 
     .header__title {
-      padding: $unnnic-spacing-nano 0;
+      padding: $unnnic-space-1 0;
 
-      color: $unnnic-color-aux-red-600;
-      font-family: $unnnic-font-family-primary;
-      font-size: $unnnic-font-size-title-sm;
+      color: $unnnic-color-red-8;
+      font-family: $unnnic-font-family;
+      font-size: 20px;
       font-weight: $unnnic-font-weight-bold;
-      line-height: $unnnic-line-height-small * 7.5;
+      line-height: 4px * 7.5;
     }
   }
 
@@ -208,39 +208,39 @@ export default {
       height: 100%;
       width: 100%;
       display: grid;
-      row-gap: $unnnic-spacing-awesome;
+      row-gap: $unnnic-space-20;
       align-items: center;
     }
 
     .content__orders {
       display: flex;
       align-items: flex-start;
-      gap: $unnnic-spacing-xs;
+      gap: $unnnic-space-2;
 
       &__container-item {
         display: flex;
         flex-direction: column;
         justify-content: center;
         align-items: flex-start;
-        gap: $unnnic-spacing-nano;
+        gap: $unnnic-space-1;
         flex: 1 0 0;
 
         &-value {
-          color: $unnnic-color-neutral-darkest;
+          color: $unnnic-color-gray-12;
           text-align: right;
 
-          font-family: $unnnic-font-family-primary;
-          font-size: $unnnic-font-size-title-lg;
+          font-family: $unnnic-font-family;
+          font-size: 32px;
           font-style: normal;
           font-weight: $unnnic-font-weight-bold;
           line-height: 2.5rem;
         }
 
         &-text {
-          color: $unnnic-color-neutral-darkest;
+          color: $unnnic-color-gray-12;
 
-          font-family: $unnnic-font-family-secondary;
-          font-size: $unnnic-font-size-body-lg;
+          font-family: $unnnic-font-family;
+          font-size: $unnnic-font-size;
           font-style: normal;
           font-weight: $unnnic-font-weight-regular;
           line-height: 1.5rem;
@@ -255,14 +255,14 @@ export default {
       align-items: center;
 
       .not-configured__text {
-        color: $unnnic-color-neutral-cloudy;
-        font-size: $unnnic-font-size-body-lg;
+        color: $unnnic-color-gray-7;
+        font-size: $unnnic-font-size;
         text-align: center;
-        line-height: $unnnic-line-height-small * 6;
+        line-height: 4px * 6;
 
         &--bold {
           font-weight: $unnnic-font-weight-bold;
-          padding-bottom: $unnnic-spacing-sm;
+          padding-bottom: $unnnic-space-4;
         }
       }
     }

--- a/src/components/insights/cards/CardVtexOrder.vue
+++ b/src/components/insights/cards/CardVtexOrder.vue
@@ -169,7 +169,7 @@ export default {
 
   &--not-data {
     .card-vtex-order__header .header__title {
-      color: $unnnic-color-gray-7;
+      color: $unnnic-color-fg-muted;
     }
   }
 
@@ -244,7 +244,7 @@ export default {
       align-items: center;
 
       .not-configured__text {
-        color: $unnnic-color-gray-7;
+        color: $unnnic-color-fg-muted;
         font: $unnnic-font-display-4;
         text-align: center;
 

--- a/src/components/insights/cards/CardVtexOrder.vue
+++ b/src/components/insights/cards/CardVtexOrder.vue
@@ -188,10 +188,7 @@ export default {
       padding: $unnnic-space-1 0;
 
       color: $unnnic-color-red-8;
-      font-family: $unnnic-font-family;
-      font-size: 20px;
-      font-weight: $unnnic-font-weight-bold;
-      line-height: 4px * 7.5;
+      font: $unnnic-font-display-2;
     }
   }
 
@@ -229,21 +226,13 @@ export default {
           color: $unnnic-color-gray-12;
           text-align: right;
 
-          font-family: $unnnic-font-family;
+          font: $unnnic-font-display-1;
           font-size: 32px;
-          font-style: normal;
-          font-weight: $unnnic-font-weight-bold;
-          line-height: 2.5rem;
         }
 
         &-text {
           color: $unnnic-color-gray-12;
-
-          font-family: $unnnic-font-family;
-          font-size: $unnnic-font-size;
-          font-style: normal;
-          font-weight: $unnnic-font-weight-regular;
-          line-height: 1.5rem;
+          font: $unnnic-font-display-4;
         }
       }
     }
@@ -256,9 +245,8 @@ export default {
 
       .not-configured__text {
         color: $unnnic-color-gray-7;
-        font-size: $unnnic-font-size;
+        font: $unnnic-font-display-4;
         text-align: center;
-        line-height: 4px * 6;
 
         &--bold {
           font-weight: $unnnic-font-weight-bold;

--- a/src/components/insights/charts/BarChart.vue
+++ b/src/components/insights/charts/BarChart.vue
@@ -124,7 +124,7 @@ export default {
 
 <style lang="scss" scoped>
 .bar-chart {
-  box-shadow: $unnnic-shadow-2;
+  box-shadow: $unnnic-shadow-1;
 
   padding: $unnnic-space-3;
 

--- a/src/components/insights/charts/BarChart.vue
+++ b/src/components/insights/charts/BarChart.vue
@@ -142,21 +142,14 @@ export default {
     display: flex;
     justify-content: space-between;
 
-    .header__title {
-      font-family: $unnnic-font-family;
-      font-weight: $unnnic-font-weight-bold;
-    }
-
     .header__see-more {
-      font-family: Lato;
-      font-weight: $unnnic-font-weight-bold;
       text-decoration-line: underline;
       text-underline-position: under;
     }
 
     .header__title,
     .header__see-more {
-      font-size: 14px;
+      font: $unnnic-font-action;
       color: $unnnic-color-gray-10;
     }
   }

--- a/src/components/insights/charts/BarChart.vue
+++ b/src/components/insights/charts/BarChart.vue
@@ -53,7 +53,7 @@ import {
   colorBgTealStrong,
   colorBgTealPlain,
   colorTeal12,
-  colorGray0,
+  colorFgInverted,
 } from '@weni/unnnic-system/tokens/colors';
 
 export default {
@@ -103,7 +103,7 @@ export default {
           tooltip: false,
           datalabels: {
             color: function (context) {
-              return context.active ? colorTeal12 : colorGray0;
+              return context.active ? colorTeal12 : colorFgInverted;
             },
             anchor: 'end',
             align: 'start',

--- a/src/components/insights/charts/BarChart.vue
+++ b/src/components/insights/charts/BarChart.vue
@@ -50,8 +50,8 @@ import { ref } from 'vue';
 
 import { deepMerge } from '@/utils/object';
 import {
-  colorTeal8,
-  colorTeal7,
+  colorBgTealStrong,
+  colorBgTealPlain,
   colorTeal12,
   colorGray0,
 } from '@weni/unnnic-system/tokens/colors';
@@ -97,8 +97,8 @@ export default {
     },
     chartOptions() {
       return {
-        backgroundColor: colorTeal8,
-        hoverBackgroundColor: colorTeal7,
+        backgroundColor: colorBgTealStrong,
+        hoverBackgroundColor: colorBgTealPlain,
         plugins: {
           tooltip: false,
           datalabels: {

--- a/src/components/insights/charts/BarChart.vue
+++ b/src/components/insights/charts/BarChart.vue
@@ -124,9 +124,9 @@ export default {
 
 <style lang="scss" scoped>
 .bar-chart {
-  box-shadow: $unnnic-shadow-level-far;
+  box-shadow: $unnnic-shadow-2;
 
-  padding: $unnnic-spacing-ant;
+  padding: $unnnic-space-3;
 
   height: 100%;
   width: 100%;
@@ -134,7 +134,7 @@ export default {
   overflow: hidden;
 
   display: grid;
-  gap: $unnnic-spacing-ant;
+  gap: $unnnic-space-3;
 
   &__header {
     width: 100%;
@@ -143,7 +143,7 @@ export default {
     justify-content: space-between;
 
     .header__title {
-      font-family: $unnnic-font-family-primary;
+      font-family: $unnnic-font-family;
       font-weight: $unnnic-font-weight-bold;
     }
 
@@ -156,8 +156,8 @@ export default {
 
     .header__title,
     .header__see-more {
-      font-size: $unnnic-font-size-body-gt;
-      color: $unnnic-color-neutral-dark;
+      font-size: 14px;
+      color: $unnnic-color-gray-10;
     }
   }
 

--- a/src/components/insights/charts/BarChart.vue
+++ b/src/components/insights/charts/BarChart.vue
@@ -50,10 +50,10 @@ import { ref } from 'vue';
 
 import { deepMerge } from '@/utils/object';
 import {
-  colorTeal600,
-  colorTeal500,
-  colorTeal900,
-  colorWhite,
+  colorTeal8,
+  colorTeal7,
+  colorTeal12,
+  colorGray0,
 } from '@weni/unnnic-system/tokens/colors';
 
 export default {
@@ -97,13 +97,13 @@ export default {
     },
     chartOptions() {
       return {
-        backgroundColor: colorTeal600,
-        hoverBackgroundColor: colorTeal500,
+        backgroundColor: colorTeal8,
+        hoverBackgroundColor: colorTeal7,
         plugins: {
           tooltip: false,
           datalabels: {
             color: function (context) {
-              return context.active ? colorTeal900 : colorWhite;
+              return context.active ? colorTeal12 : colorGray0;
             },
             anchor: 'end',
             align: 'start',

--- a/src/components/insights/charts/BaseChart.vue
+++ b/src/components/insights/charts/BaseChart.vue
@@ -120,7 +120,7 @@ export default {
 
   created() {
     const pluginsToRegister = [...defaultPlugins, ...this.plugins];
-    ChartJS.defaults.font.family = 'Lato, sans-serif';
+    ChartJS.defaults.font.family = 'Inter, sans-serif';
     ChartJS.register(...pluginsToRegister);
   },
 

--- a/src/components/insights/charts/FunnelChart.vue
+++ b/src/components/insights/charts/FunnelChart.vue
@@ -43,11 +43,11 @@
 <script>
 import IconLoading from '@/components/IconLoading.vue';
 import {
-  colorYellow4,
-  colorOrange4,
-  colorPurple4,
-  colorBlue5,
-  colorGreen4,
+  colorYellowPlain,
+  colorOrangePlain,
+  colorPurplePlain,
+  colorBluePlain,
+  colorGreenPlain,
 } from '@weni/unnnic-system/tokens/colors';
 
 export default {
@@ -69,11 +69,11 @@ export default {
   computed: {
     formattedChartData() {
       const arrayColors = [
-        colorYellow4,
-        colorOrange4,
-        colorPurple4,
-        colorBlue5,
-        colorGreen4,
+        colorYellowPlain,
+        colorOrangePlain,
+        colorPurplePlain,
+        colorBluePlain,
+        colorGreenPlain,
       ];
 
       if (!Array.isArray(this.chartData)) return [];

--- a/src/components/insights/charts/FunnelChart.vue
+++ b/src/components/insights/charts/FunnelChart.vue
@@ -115,7 +115,7 @@ export default {
     align-items: center;
     justify-content: center;
 
-    color: $unnnic-color-gray-7;
+    color: $unnnic-color-fg-muted;
     font: $unnnic-font-display-4;
     text-align: center;
 

--- a/src/components/insights/charts/FunnelChart.vue
+++ b/src/components/insights/charts/FunnelChart.vue
@@ -116,9 +116,8 @@ export default {
     justify-content: center;
 
     color: $unnnic-color-gray-7;
-    font-size: $unnnic-font-size;
+    font: $unnnic-font-display-4;
     text-align: center;
-    line-height: 4px * 6;
 
     &-description {
       font-weight: $unnnic-font-weight-bold;

--- a/src/components/insights/charts/FunnelChart.vue
+++ b/src/components/insights/charts/FunnelChart.vue
@@ -43,11 +43,11 @@
 <script>
 import IconLoading from '@/components/IconLoading.vue';
 import {
-  colorYellow300,
-  colorOrange300,
-  colorPurple300,
-  colorBlue300,
-  colorGreen300,
+  colorYellow4,
+  colorOrange4,
+  colorPurple4,
+  colorBlue5,
+  colorGreen4,
 } from '@weni/unnnic-system/tokens/colors';
 
 export default {
@@ -69,11 +69,11 @@ export default {
   computed: {
     formattedChartData() {
       const arrayColors = [
-        colorYellow300,
-        colorOrange300,
-        colorPurple300,
-        colorBlue300,
-        colorGreen300,
+        colorYellow4,
+        colorOrange4,
+        colorPurple4,
+        colorBlue5,
+        colorGreen4,
       ];
 
       if (!Array.isArray(this.chartData)) return [];

--- a/src/components/insights/charts/FunnelChart.vue
+++ b/src/components/insights/charts/FunnelChart.vue
@@ -115,14 +115,14 @@ export default {
     align-items: center;
     justify-content: center;
 
-    color: $unnnic-color-neutral-cloudy;
-    font-size: $unnnic-font-size-body-lg;
+    color: $unnnic-color-gray-7;
+    font-size: $unnnic-font-size;
     text-align: center;
-    line-height: $unnnic-line-height-small * 6;
+    line-height: 4px * 6;
 
     &-description {
       font-weight: $unnnic-font-weight-bold;
-      padding-bottom: $unnnic-spacing-sm;
+      padding-bottom: $unnnic-space-4;
     }
   }
 
@@ -137,7 +137,7 @@ export default {
       bottom: -1px;
       width: 100%;
       height: 1px;
-      background-color: $unnnic-color-neutral-soft;
+      background-color: $unnnic-color-gray-2;
       z-index: 1;
     }
 

--- a/src/components/insights/charts/HorizontalBarChart.vue
+++ b/src/components/insights/charts/HorizontalBarChart.vue
@@ -61,8 +61,8 @@ import { ref } from 'vue';
 import {
   colorBgTealStrong,
   colorBgTealPlain,
-  colorGray8,
-  colorGray3,
+  colorFgMuted,
+  colorBorderBase,
 } from '@weni/unnnic-system/tokens/colors';
 
 export default {
@@ -235,7 +235,7 @@ export default {
 
             ctx.textBaseline = 'middle';
             ctx.font = 'bold 16px Inter';
-            ctx.fillStyle = colorGray8;
+            ctx.fillStyle = colorFgMuted;
 
             // chartLeftMargin is the margin between the chart and the left edge of the chart area (labels space)
             // 4px is the margin between the chart and the text
@@ -258,7 +258,7 @@ export default {
             };
 
             ctx.font = 'normal 14px Inter';
-            ctx.fillStyle = colorGray3;
+            ctx.fillStyle = colorBorderBase;
 
             ctx.fillText(
               `| ${fullValues[index]}`,

--- a/src/components/insights/charts/HorizontalBarChart.vue
+++ b/src/components/insights/charts/HorizontalBarChart.vue
@@ -293,9 +293,9 @@ export default {
 
 <style lang="scss" scoped>
 .bar-chart {
-  box-shadow: $unnnic-shadow-level-far;
+  box-shadow: $unnnic-shadow-2;
 
-  padding: $unnnic-spacing-ant;
+  padding: $unnnic-space-3;
 
   height: 100%;
   width: 100%;
@@ -304,7 +304,7 @@ export default {
 
   display: flex;
   flex-direction: column;
-  gap: $unnnic-spacing-ant;
+  gap: $unnnic-space-3;
 
   &__header {
     width: 100%;
@@ -313,19 +313,19 @@ export default {
     justify-content: space-between;
 
     .header__title {
-      font-size: $unnnic-font-size-title-sm;
-      font-family: $unnnic-font-family-primary;
+      font-size: 20px;
+      font-family: $unnnic-font-family;
       font-weight: $unnnic-font-weight-bold;
-      color: $unnnic-color-neutral-dark;
+      color: $unnnic-color-gray-10;
     }
 
     .header__see-more {
-      font-size: $unnnic-font-size-body-gt;
+      font-size: 14px;
       font-family: Lato;
       font-weight: $unnnic-font-weight-bold;
       text-decoration-line: underline;
       text-underline-position: under;
-      color: $unnnic-color-neutral-dark;
+      color: $unnnic-color-gray-10;
     }
   }
 

--- a/src/components/insights/charts/HorizontalBarChart.vue
+++ b/src/components/insights/charts/HorizontalBarChart.vue
@@ -313,16 +313,12 @@ export default {
     justify-content: space-between;
 
     .header__title {
-      font-size: 20px;
-      font-family: $unnnic-font-family;
-      font-weight: $unnnic-font-weight-bold;
+      font: $unnnic-font-display-2;
       color: $unnnic-color-gray-10;
     }
 
     .header__see-more {
-      font-size: 14px;
-      font-family: Lato;
-      font-weight: $unnnic-font-weight-bold;
+      font: $unnnic-font-action;
       text-decoration-line: underline;
       text-underline-position: under;
       color: $unnnic-color-gray-10;

--- a/src/components/insights/charts/HorizontalBarChart.vue
+++ b/src/components/insights/charts/HorizontalBarChart.vue
@@ -293,7 +293,7 @@ export default {
 
 <style lang="scss" scoped>
 .bar-chart {
-  box-shadow: $unnnic-shadow-2;
+  box-shadow: $unnnic-shadow-1;
 
   padding: $unnnic-space-3;
 

--- a/src/components/insights/charts/HorizontalBarChart.vue
+++ b/src/components/insights/charts/HorizontalBarChart.vue
@@ -59,11 +59,11 @@ import { deepMerge } from '@/utils/object';
 import { useElementSize } from '@vueuse/core';
 import { ref } from 'vue';
 import {
-  colorTeal600,
-  colorTeal500,
-  colorTeal100,
-  colorGray500,
-  colorGray300,
+  colorTeal8,
+  colorTeal7,
+  colorTeal2,
+  colorGray9,
+  colorGray5,
 } from '@weni/unnnic-system/tokens/colors';
 
 export default {
@@ -150,8 +150,8 @@ export default {
             },
           },
         },
-        backgroundColor: colorTeal600,
-        hoverBackgroundColor: colorTeal500,
+        backgroundColor: colorTeal8,
+        hoverBackgroundColor: colorTeal7,
         plugins: {
           datalabels: {
             display: false,
@@ -160,7 +160,7 @@ export default {
             datalabelsSuffix: this.datalabelsSuffix,
           },
           horizontalBackgroundColorPlugin: {
-            backgroundColor: colorTeal100,
+            backgroundColor: colorTeal2,
           },
           tooltip: {
             enabled: true,
@@ -236,7 +236,7 @@ export default {
 
             ctx.textBaseline = 'middle';
             ctx.font = 'bold 16px Lato';
-            ctx.fillStyle = colorGray500;
+            ctx.fillStyle = colorGray9;
 
             // chartLeftMargin is the margin between the chart and the left edge of the chart area (labels space)
             // 4px is the margin between the chart and the text
@@ -259,7 +259,7 @@ export default {
             };
 
             ctx.font = 'normal 14px Lato';
-            ctx.fillStyle = colorGray300;
+            ctx.fillStyle = colorGray5;
 
             ctx.fillText(
               `| ${fullValues[index]}`,

--- a/src/components/insights/charts/HorizontalBarChart.vue
+++ b/src/components/insights/charts/HorizontalBarChart.vue
@@ -59,11 +59,10 @@ import { deepMerge } from '@/utils/object';
 import { useElementSize } from '@vueuse/core';
 import { ref } from 'vue';
 import {
-  colorTeal8,
-  colorTeal7,
-  colorTeal2,
-  colorGray9,
-  colorGray5,
+  colorBgTealStrong,
+  colorBgTealPlain,
+  colorGray8,
+  colorGray3,
 } from '@weni/unnnic-system/tokens/colors';
 
 export default {
@@ -150,8 +149,8 @@ export default {
             },
           },
         },
-        backgroundColor: colorTeal8,
-        hoverBackgroundColor: colorTeal7,
+        backgroundColor: colorBgTealStrong,
+        hoverBackgroundColor: colorBgTealPlain,
         plugins: {
           datalabels: {
             display: false,
@@ -160,7 +159,7 @@ export default {
             datalabelsSuffix: this.datalabelsSuffix,
           },
           horizontalBackgroundColorPlugin: {
-            backgroundColor: colorTeal2,
+            backgroundColor: colorBgTealPlain,
           },
           tooltip: {
             enabled: true,
@@ -235,8 +234,8 @@ export default {
             const { data, fullValues } = datasets[0];
 
             ctx.textBaseline = 'middle';
-            ctx.font = 'bold 16px Lato';
-            ctx.fillStyle = colorGray9;
+            ctx.font = 'bold 16px Inter';
+            ctx.fillStyle = colorGray8;
 
             // chartLeftMargin is the margin between the chart and the left edge of the chart area (labels space)
             // 4px is the margin between the chart and the text
@@ -258,8 +257,8 @@ export default {
               5: 60,
             };
 
-            ctx.font = 'normal 14px Lato';
-            ctx.fillStyle = colorGray5;
+            ctx.font = 'normal 14px Inter';
+            ctx.fillStyle = colorGray3;
 
             ctx.fillText(
               `| ${fullValues[index]}`,

--- a/src/components/insights/charts/LineChart.vue
+++ b/src/components/insights/charts/LineChart.vue
@@ -50,7 +50,10 @@ import { ref } from 'vue';
 
 import { deepMerge } from '@/utils/object';
 import { Tooltip } from 'chart.js';
-import { colorTeal8, colorGray12 } from '@weni/unnnic-system/tokens/colors';
+import {
+  colorBgTealStrong,
+  colorGray12,
+} from '@weni/unnnic-system/tokens/colors';
 
 export default {
   name: 'LineChart',
@@ -87,7 +90,7 @@ export default {
     mergedData() {
       const configData = {
         fill: true,
-        borderColor: colorTeal8,
+        borderColor: colorBgTealStrong,
         pointRadius: 0,
         hoverRadius: 3,
         pointStyle: 'circle',
@@ -104,7 +107,7 @@ export default {
             chartArea.bottom,
           );
 
-          gradient.addColorStop(0, colorTeal8);
+          gradient.addColorStop(0, colorBgTealStrong);
           gradient.addColorStop(1, 'rgba(255, 255, 255, 0)');
 
           return gradient;

--- a/src/components/insights/charts/LineChart.vue
+++ b/src/components/insights/charts/LineChart.vue
@@ -205,14 +205,9 @@ export default {
     }
 
     .header__see-more {
-      font-family: Lato;
-      font-weight: $unnnic-font-weight-bold;
+      font: $unnnic-font-action;
       text-decoration-line: underline;
       text-underline-position: under;
-    }
-
-    .header__see-more {
-      font-size: 14px;
       color: $unnnic-color-gray-10;
     }
   }

--- a/src/components/insights/charts/LineChart.vue
+++ b/src/components/insights/charts/LineChart.vue
@@ -123,8 +123,8 @@ export default {
     },
     chartOptions() {
       return {
-        backgroundColor: colorTeal8,
-        hoverBackgroundColor: colorTeal8,
+        backgroundColor: colorBgTealStrong,
+        hoverBackgroundColor: colorBgTealStrong,
         pointStyle: false,
         layout: {
           padding: 10,

--- a/src/components/insights/charts/LineChart.vue
+++ b/src/components/insights/charts/LineChart.vue
@@ -181,8 +181,8 @@ export default {
 <style lang="scss" scoped>
 .line-chart {
   border-radius: $unnnic-space-2;
-  border: 1px solid $unnnic-color-neutral-soft;
-  background: $unnnic-color-neutral-white;
+  border: 1px solid $unnnic-color-gray-2;
+  background: $unnnic-color-gray-0;
 
   padding: $unnnic-space-6;
 
@@ -212,8 +212,8 @@ export default {
     }
 
     .header__see-more {
-      font-size: $unnnic-font-size-body-gt;
-      color: $unnnic-color-neutral-dark;
+      font-size: 14px;
+      color: $unnnic-color-gray-10;
     }
   }
 

--- a/src/components/insights/charts/LineChart.vue
+++ b/src/components/insights/charts/LineChart.vue
@@ -50,7 +50,7 @@ import { ref } from 'vue';
 
 import { deepMerge } from '@/utils/object';
 import { Tooltip } from 'chart.js';
-import { colorTeal600, colorGray950 } from '@weni/unnnic-system/tokens/colors';
+import { colorTeal8, colorGray12 } from '@weni/unnnic-system/tokens/colors';
 
 export default {
   name: 'LineChart',
@@ -87,7 +87,7 @@ export default {
     mergedData() {
       const configData = {
         fill: true,
-        borderColor: colorTeal600,
+        borderColor: colorTeal8,
         pointRadius: 0,
         hoverRadius: 3,
         pointStyle: 'circle',
@@ -104,7 +104,7 @@ export default {
             chartArea.bottom,
           );
 
-          gradient.addColorStop(0, colorTeal600);
+          gradient.addColorStop(0, colorTeal8);
           gradient.addColorStop(1, 'rgba(255, 255, 255, 0)');
 
           return gradient;
@@ -120,8 +120,8 @@ export default {
     },
     chartOptions() {
       return {
-        backgroundColor: colorTeal600,
-        hoverBackgroundColor: colorTeal600,
+        backgroundColor: colorTeal8,
+        hoverBackgroundColor: colorTeal8,
         pointStyle: false,
         layout: {
           padding: 10,
@@ -146,7 +146,7 @@ export default {
         plugins: {
           tooltip: {
             enabled: true,
-            backgroundColor: colorGray950,
+            backgroundColor: colorGray12,
             displayColors: false,
             font: {
               size: '16',

--- a/src/components/insights/charts/MultipleLineChart.vue
+++ b/src/components/insights/charts/MultipleLineChart.vue
@@ -65,19 +65,19 @@ import { getPercentageOf } from '@/utils/numbers';
 import i18n from '@/utils/plugins/i18n';
 import weniLoading from '@/assets/images/weni-loading.svg';
 import {
-  colorPurple300,
-  colorGreen300,
-  colorBlue300,
-  colorOrange300,
-  colorGray300,
-  colorGray800,
+  colorPurple4,
+  colorGreen4,
+  colorBlue5,
+  colorOrange4,
+  colorGray5,
+  colorGray11,
 } from '@weni/unnnic-system/tokens/colors';
 
 const colorsMapper = {
-  'aux-purple-300': colorPurple300,
-  'aux-green-300': colorGreen300,
-  'aux-blue-300': colorBlue300,
-  'aux-orange-300': colorOrange300,
+  'aux-purple-300': colorPurple4,
+  'aux-green-300': colorGreen4,
+  'aux-blue-300': colorBlue5,
+  'aux-orange-300': colorOrange4,
 };
 
 const props = defineProps({
@@ -119,13 +119,13 @@ const options = computed(() => ({
       suggestedMin: 0,
       display: true,
       ticks: {
-        color: colorGray300,
+        color: colorGray5,
       },
     },
     x: {
       ticks: {
         padding: -1,
-        color: colorGray300,
+        color: colorGray5,
       },
       grid: {
         display: true,
@@ -135,7 +135,7 @@ const options = computed(() => ({
   plugins: {
     tooltip: {
       enabled: true,
-      backgroundColor: colorGray800,
+      backgroundColor: colorGray11,
       displayColors: false,
       font: {
         size: '16',

--- a/src/components/insights/charts/MultipleLineChart.vue
+++ b/src/components/insights/charts/MultipleLineChart.vue
@@ -65,19 +65,19 @@ import { getPercentageOf } from '@/utils/numbers';
 import i18n from '@/utils/plugins/i18n';
 import weniLoading from '@/assets/images/weni-loading.svg';
 import {
-  colorPurple4,
-  colorGreen4,
-  colorBlue5,
-  colorOrange4,
+  colorPurplePlain,
+  colorGreenPlain,
+  colorBluePlain,
+  colorOrangePlain,
   colorGray5,
   colorGray11,
 } from '@weni/unnnic-system/tokens/colors';
 
 const colorsMapper = {
-  'aux-purple-300': colorPurple4,
-  'aux-green-300': colorGreen4,
-  'aux-blue-300': colorBlue5,
-  'aux-orange-300': colorOrange4,
+  'aux-purple-300': colorPurplePlain,
+  'aux-green-300': colorGreenPlain,
+  'aux-blue-300': colorBluePlain,
+  'aux-orange-300': colorOrangePlain,
 };
 
 const props = defineProps({

--- a/src/components/insights/charts/MultipleLineChart.vue
+++ b/src/components/insights/charts/MultipleLineChart.vue
@@ -69,8 +69,8 @@ import {
   colorGreenPlain,
   colorBluePlain,
   colorOrangePlain,
-  colorGray5,
-  colorGray11,
+  colorFgMuted,
+  colorGray12,
 } from '@weni/unnnic-system/tokens/colors';
 
 const colorsMapper = {
@@ -119,13 +119,13 @@ const options = computed(() => ({
       suggestedMin: 0,
       display: true,
       ticks: {
-        color: colorGray5,
+        color: colorFgMuted,
       },
     },
     x: {
       ticks: {
         padding: -1,
-        color: colorGray5,
+        color: colorFgMuted,
       },
       grid: {
         display: true,
@@ -135,7 +135,7 @@ const options = computed(() => ({
   plugins: {
     tooltip: {
       enabled: true,
-      backgroundColor: colorGray11,
+      backgroundColor: colorGray12,
       displayColors: false,
       font: {
         size: '16',
@@ -197,7 +197,7 @@ const plugins = computed(() => [Tooltip]);
       }
       &-percentage {
         font: $unnnic-font-display-4;
-        color: $unnnic-color-gray-7;
+        color: $unnnic-color-fg-muted;
       }
     }
   }

--- a/src/components/insights/charts/MultipleLineChart.vue
+++ b/src/components/insights/charts/MultipleLineChart.vue
@@ -182,10 +182,8 @@ const plugins = computed(() => [Tooltip]);
     &-label {
       display: flex;
       align-items: center;
-      font-family: $unnnic-font-family;
-      font-size: $unnnic-font-size;
+      font: $unnnic-font-display-4;
       color: $unnnic-color-gray-10;
-      line-height: 16px + 8px;
     }
     &-total {
       display: flex;
@@ -194,19 +192,12 @@ const plugins = computed(() => [Tooltip]);
       gap: $unnnic-space-2;
       align-items: flex-end;
       &-value {
-        font-family: $unnnic-font-family;
-        font-size: 24px;
+        font: $unnnic-font-display-1;
         color: $unnnic-color-gray-10;
-        font-style: normal;
-        font-weight: $unnnic-font-weight-bold;
-        line-height: 16px * 2;
       }
       &-percentage {
-        font-family: $unnnic-font-family;
-        font-size: $unnnic-font-size;
+        font: $unnnic-font-display-4;
         color: $unnnic-color-gray-7;
-        font-style: normal;
-        line-height: 16px + 8px;
       }
     }
   }

--- a/src/components/insights/charts/MultipleLineChart.vue
+++ b/src/components/insights/charts/MultipleLineChart.vue
@@ -155,10 +155,10 @@ const plugins = computed(() => [Tooltip]);
 .multiple-line-chart {
   display: flex;
   flex-direction: column;
-  padding: $unnnic-spacing-md;
-  border-radius: $unnnic-border-radius-sm;
-  border: 1px solid $unnnic-color-neutral-soft;
-  gap: $unnnic-spacing-sm;
+  padding: $unnnic-space-6;
+  border-radius: $unnnic-radius-1;
+  border: 1px solid $unnnic-color-gray-2;
+  gap: $unnnic-space-4;
   width: 100%;
   min-height: 280px;
 
@@ -182,31 +182,31 @@ const plugins = computed(() => [Tooltip]);
     &-label {
       display: flex;
       align-items: center;
-      font-family: $unnnic-font-family-secondary;
-      font-size: $unnnic-font-size-body-lg;
-      color: $unnnic-color-neutral-dark;
-      line-height: $unnnic-line-height-large + $unnnic-line-height-medium;
+      font-family: $unnnic-font-family;
+      font-size: $unnnic-font-size;
+      color: $unnnic-color-gray-10;
+      line-height: 16px + 8px;
     }
     &-total {
       display: flex;
-      margin-left: $unnnic-spacing-ant;
-      margin-top: $unnnic-spacing-xs;
-      gap: $unnnic-spacing-xs;
+      margin-left: $unnnic-space-3;
+      margin-top: $unnnic-space-2;
+      gap: $unnnic-space-2;
       align-items: flex-end;
       &-value {
-        font-family: $unnnic-font-family-primary;
-        font-size: $unnnic-font-size-title-md;
-        color: $unnnic-color-neutral-dark;
+        font-family: $unnnic-font-family;
+        font-size: 24px;
+        color: $unnnic-color-gray-10;
         font-style: normal;
         font-weight: $unnnic-font-weight-bold;
-        line-height: $unnnic-line-height-large * 2;
+        line-height: 16px * 2;
       }
       &-percentage {
-        font-family: $unnnic-font-family-primary;
-        font-size: $unnnic-font-size-body-lg;
-        color: $unnnic-color-neutral-cloudy;
+        font-family: $unnnic-font-family;
+        font-size: $unnnic-font-size;
+        color: $unnnic-color-gray-7;
         font-style: normal;
-        line-height: $unnnic-line-height-large + $unnnic-line-height-medium;
+        line-height: 16px + 8px;
       }
     }
   }

--- a/src/components/insights/charts/NativeProgress.vue
+++ b/src/components/insights/charts/NativeProgress.vue
@@ -26,8 +26,8 @@
 import { computed } from 'vue';
 import { UnnnicToolTip } from '@weni/unnnic-system';
 import {
-  colorBlueStrong,
-  colorBaseSoft,
+  colorBgBlueStrong,
+  colorBgBaseSoft,
 } from '@weni/unnnic-system/tokens/colors';
 
 interface Props {
@@ -41,8 +41,8 @@ interface Props {
 
 const props = withDefaults(defineProps<Props>(), {
   progress: 0,
-  color: colorBlueStrong,
-  backgroundColor: colorBaseSoft,
+  color: colorBgBlueStrong,
+  backgroundColor: colorBgBaseSoft,
   height: 8,
   tooltip: '',
   maxProgressValue: 100,

--- a/src/components/insights/charts/NativeProgress.vue
+++ b/src/components/insights/charts/NativeProgress.vue
@@ -68,7 +68,7 @@ const progressBarStyles = computed(() => ({
 <style scoped lang="scss">
 .native-progress {
   width: 100%;
-  border-radius: $unnnic-border-radius-sm;
+  border-radius: $unnnic-radius-1;
   overflow: hidden;
   position: relative;
   display: grid;

--- a/src/components/insights/charts/NativeProgress.vue
+++ b/src/components/insights/charts/NativeProgress.vue
@@ -25,7 +25,10 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import { UnnnicToolTip } from '@weni/unnnic-system';
-import { colorBlue8, colorGray1 } from '@weni/unnnic-system/tokens/colors';
+import {
+  colorBlueStrong,
+  colorBaseSoft,
+} from '@weni/unnnic-system/tokens/colors';
 
 interface Props {
   progress: number;
@@ -38,8 +41,8 @@ interface Props {
 
 const props = withDefaults(defineProps<Props>(), {
   progress: 0,
-  color: colorBlue8,
-  backgroundColor: colorGray1,
+  color: colorBlueStrong,
+  backgroundColor: colorBaseSoft,
   height: 8,
   tooltip: '',
   maxProgressValue: 100,

--- a/src/components/insights/charts/NativeProgress.vue
+++ b/src/components/insights/charts/NativeProgress.vue
@@ -25,7 +25,7 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import { UnnnicToolTip } from '@weni/unnnic-system';
-import { colorBlue500, colorGray50 } from '@weni/unnnic-system/tokens/colors';
+import { colorBlue8, colorGray1 } from '@weni/unnnic-system/tokens/colors';
 
 interface Props {
   progress: number;
@@ -38,8 +38,8 @@ interface Props {
 
 const props = withDefaults(defineProps<Props>(), {
   progress: 0,
-  color: colorBlue500,
-  backgroundColor: colorGray50,
+  color: colorBlue8,
+  backgroundColor: colorGray1,
   height: 8,
   tooltip: '',
   maxProgressValue: 100,

--- a/src/components/insights/charts/TreemapChart.vue
+++ b/src/components/insights/charts/TreemapChart.vue
@@ -56,7 +56,7 @@ import i18n from '@/utils/plugins/i18n';
 import { useI18n } from 'vue-i18n';
 import { colorGray11 } from '@weni/unnnic-system/tokens/colors';
 
-ChartJS.defaults.font.family = 'Lato, sans-serif';
+ChartJS.defaults.font.family = 'Inter, sans-serif';
 ChartJS.register(TreemapController, TreemapElement, LinearScale, Tooltip);
 
 const treemapCanvas = ref<HTMLCanvasElement | null>(null);
@@ -156,11 +156,11 @@ const createOrUpdateChart = () => {
               font: [
                 {
                   size: 16,
-                  family: 'Lato, sans-serif',
+                  family: 'Inter, sans-serif',
                   lineHeight: '26px',
                   weight: 'bold',
                 },
-                { size: 14, family: 'Lato, sans-serif', lineHeight: '24px' },
+                { size: 14, family: 'Inter, sans-serif', lineHeight: '24px' },
               ],
               position: 'middle',
             },
@@ -199,10 +199,10 @@ const createOrUpdateChart = () => {
             mode: 'index',
             titleFont: {
               size: 12,
-              family: 'Lato, sans-serif',
+              family: 'Inter, sans-serif',
               weight: 'bold',
             },
-            bodyFont: { size: 12, family: 'Lato, sans-serif' },
+            bodyFont: { size: 12, family: 'Inter, sans-serif' },
             yAlign: 'bottom',
             callbacks: {
               title: function (ctx: any) {

--- a/src/components/insights/charts/TreemapChart.vue
+++ b/src/components/insights/charts/TreemapChart.vue
@@ -314,18 +314,13 @@ watch(locale, () => {
     align-items: center;
 
     .no-data__title {
-      font-size: 20px;
-      font-family: $unnnic-font-family;
-      font-weight: $unnnic-font-weight-bold;
+      font: $unnnic-font-display-2;
       color: $unnnic-color-gray-12;
-      line-height: 20px + 8px;
     }
 
     .no-data__description {
-      font-size: $unnnic-font-size;
-      font-family: $unnnic-font-family;
+      font: $unnnic-font-display-4;
       color: $unnnic-color-gray-7;
-      line-height: $unnnic-font-size + 8px;
     }
   }
 

--- a/src/components/insights/charts/TreemapChart.vue
+++ b/src/components/insights/charts/TreemapChart.vue
@@ -268,12 +268,12 @@ watch(locale, () => {
     display: grid;
     grid-template-columns: repeat(8, 1fr);
     grid-template-rows: repeat(2, 1fr);
-    gap: $unnnic-spacing-xs;
+    gap: $unnnic-space-2;
 
     height: 100%;
 
     .loading__skeleton {
-      border-radius: $unnnic-border-radius-md;
+      border-radius: $unnnic-radius-2;
       height: 100%;
       width: 100%;
 
@@ -309,23 +309,23 @@ watch(locale, () => {
 
     display: flex;
     flex-direction: column;
-    gap: $unnnic-spacing-ant;
+    gap: $unnnic-space-3;
     justify-content: center;
     align-items: center;
 
     .no-data__title {
-      font-size: $unnnic-font-size-title-sm;
-      font-family: $unnnic-font-family-secondary;
+      font-size: 20px;
+      font-family: $unnnic-font-family;
       font-weight: $unnnic-font-weight-bold;
-      color: $unnnic-color-neutral-darkest;
-      line-height: $unnnic-font-size-title-sm + $unnnic-line-height-md;
+      color: $unnnic-color-gray-12;
+      line-height: 20px + 8px;
     }
 
     .no-data__description {
-      font-size: $unnnic-font-size-body-lg;
-      font-family: $unnnic-font-family-secondary;
-      color: $unnnic-color-neutral-cloudy;
-      line-height: $unnnic-font-size-body-lg + $unnnic-line-height-md;
+      font-size: $unnnic-font-size;
+      font-family: $unnnic-font-family;
+      color: $unnnic-color-gray-7;
+      line-height: $unnnic-font-size + 8px;
     }
   }
 

--- a/src/components/insights/charts/TreemapChart.vue
+++ b/src/components/insights/charts/TreemapChart.vue
@@ -54,7 +54,7 @@ import type { topicDistributionMetric } from '@/services/api/resources/conversat
 import { addColors, prepareTopData } from '@/utils/treemap';
 import i18n from '@/utils/plugins/i18n';
 import { useI18n } from 'vue-i18n';
-import { colorGray11 } from '@weni/unnnic-system/tokens/colors';
+import { colorFgBase } from '@weni/unnnic-system/tokens/colors';
 
 ChartJS.defaults.font.family = 'Inter, sans-serif';
 ChartJS.register(TreemapController, TreemapElement, LinearScale, Tooltip);
@@ -151,8 +151,8 @@ const createOrUpdateChart = () => {
                   `${padding}${data.value} ${i18n.global.t('conversations_dashboard.conversations')}${padding}`,
                 ];
               },
-              color: colorGray11,
-              hoverColor: colorGray11,
+              color: colorFgBase,
+              hoverColor: colorFgBase,
               font: [
                 {
                   size: 16,
@@ -188,7 +188,7 @@ const createOrUpdateChart = () => {
           },
           tooltip: {
             enabled: true,
-            backgroundColor: colorGray11,
+            backgroundColor: colorFgBase,
             displayColors: false,
             position: 'nearest',
             caretPadding: (ctx: any) => {

--- a/src/components/insights/charts/TreemapChart.vue
+++ b/src/components/insights/charts/TreemapChart.vue
@@ -54,10 +54,7 @@ import type { topicDistributionMetric } from '@/services/api/resources/conversat
 import { addColors, prepareTopData } from '@/utils/treemap';
 import i18n from '@/utils/plugins/i18n';
 import { useI18n } from 'vue-i18n';
-import {
-  colorGray700,
-  colorGray800,
-} from '@weni/unnnic-system/tokens/colors';
+import { colorGray11 } from '@weni/unnnic-system/tokens/colors';
 
 ChartJS.defaults.font.family = 'Lato, sans-serif';
 ChartJS.register(TreemapController, TreemapElement, LinearScale, Tooltip);
@@ -154,8 +151,8 @@ const createOrUpdateChart = () => {
                   `${padding}${data.value} ${i18n.global.t('conversations_dashboard.conversations')}${padding}`,
                 ];
               },
-              color: colorGray700,
-              hoverColor: colorGray700,
+              color: colorGray11,
+              hoverColor: colorGray11,
               font: [
                 {
                   size: 16,
@@ -191,7 +188,7 @@ const createOrUpdateChart = () => {
           },
           tooltip: {
             enabled: true,
-            backgroundColor: colorGray800,
+            backgroundColor: colorGray11,
             displayColors: false,
             position: 'nearest',
             caretPadding: (ctx: any) => {

--- a/src/components/insights/charts/TreemapChart.vue
+++ b/src/components/insights/charts/TreemapChart.vue
@@ -320,7 +320,7 @@ watch(locale, () => {
 
     .no-data__description {
       font: $unnnic-font-display-4;
-      color: $unnnic-color-gray-7;
+      color: $unnnic-color-fg-muted;
     }
   }
 

--- a/src/components/insights/charts/__tests__/Barchart.spec.js
+++ b/src/components/insights/charts/__tests__/Barchart.spec.js
@@ -65,7 +65,7 @@ describe('BarChart', () => {
     const inactiveContext = { active: false };
 
     expect(chartOptions.plugins.datalabels.color(activeContext)).toBe(
-      '#0D5453', // colorTeal900
+      '#0D504D', // colorTeal900
     );
 
     expect(chartOptions.plugins.datalabels.color(inactiveContext)).toBe(

--- a/src/components/insights/charts/__tests__/BaseChart.spec.js
+++ b/src/components/insights/charts/__tests__/BaseChart.spec.js
@@ -137,7 +137,7 @@ describe('BaseChart', () => {
 
     it('should set Chart.js default font family', () => {
       createWrapper();
-      expect(ChartJS.defaults.font.family).toBe('Lato, sans-serif');
+      expect(ChartJS.defaults.font.family).toBe('Inter, sans-serif');
     });
 
     it('should initialize Chart.js with correct config on mount', () => {

--- a/src/components/insights/charts/__tests__/LineChart.spec.js
+++ b/src/components/insights/charts/__tests__/LineChart.spec.js
@@ -76,7 +76,7 @@ describe('LineChart', () => {
   describe('Chart Configuration', () => {
     it('should merge default chart configuration with provided data', () => {
       const { mergedData } = wrapper.vm;
-      expect(mergedData.datasets[0]).toHaveProperty('borderColor', '#00A49F');
+      expect(mergedData.datasets[0]).toHaveProperty('borderColor', '#01A29B');
       expect(mergedData.datasets[0]).toHaveProperty('pointRadius', 0);
       expect(mergedData.datasets[0]).toHaveProperty('hoverRadius', 3);
       expect(mergedData.datasets[0]).toHaveProperty('pointStyle', 'circle');
@@ -85,7 +85,7 @@ describe('LineChart', () => {
 
     it('should have correct chart options configuration', () => {
       const { chartOptions } = wrapper.vm;
-      expect(chartOptions.backgroundColor).toBe('#00A49F');
+      expect(chartOptions.backgroundColor).toBe('#01A29B');
       expect(chartOptions.scales.y.beginAtZero).toBe(true);
       expect(chartOptions.interaction.intersect).toBe(false);
       expect(chartOptions.interaction.mode).toBe('index');
@@ -95,7 +95,7 @@ describe('LineChart', () => {
       const { chartOptions } = wrapper.vm;
       const tooltipConfig = chartOptions.plugins.tooltip;
       expect(tooltipConfig.enabled).toBe(true);
-      expect(tooltipConfig.backgroundColor).toBe('#23262E'); // colorGray950
+      expect(tooltipConfig.backgroundColor).toBe('#1F1F1F'); // colorGray950
       expect(tooltipConfig.displayColors).toBe(false);
     });
 

--- a/src/components/insights/charts/__tests__/NativeProgress.spec.js
+++ b/src/components/insights/charts/__tests__/NativeProgress.spec.js
@@ -69,8 +69,8 @@ describe('NativeProgress.vue', () => {
 
   describe('Default Props', () => {
     const defaultValues = [
-      { prop: 'color', expected: '#3182CE' }, // colorBlue500
-      { prop: 'backgroundColor', expected: '#F6F7F9' }, // colorGray50
+      { prop: 'color', expected: '#3993F4' }, // colorBlue500
+      { prop: 'backgroundColor', expected: '#F5F5F5' }, // colorGray50
       { prop: 'height', expected: 8 },
     ];
 

--- a/src/components/insights/charts/__tests__/NativeProgress.spec.js
+++ b/src/components/insights/charts/__tests__/NativeProgress.spec.js
@@ -69,8 +69,8 @@ describe('NativeProgress.vue', () => {
 
   describe('Default Props', () => {
     const defaultValues = [
-      { prop: 'color', expected: '#3993F4' }, // colorBlue500
-      { prop: 'backgroundColor', expected: '#F5F5F5' }, // colorGray50
+      { prop: 'color', expected: '#3993F4' }, // colorBgBlueStrong
+      { prop: 'backgroundColor', expected: '#F5F5F5' }, // colorBgBaseSoft
       { prop: 'height', expected: 8 },
     ];
 

--- a/src/components/insights/charts/__tests__/TreemapChart.spec.js
+++ b/src/components/insights/charts/__tests__/TreemapChart.spec.js
@@ -29,7 +29,7 @@ vi.mock('chart.js', () => {
     destroy: vi.fn(),
   }));
   Chart.defaults = {
-    font: { family: 'Lato, sans-serif' },
+    font: { family: 'Inter, sans-serif' },
   };
   Chart.register = vi.fn();
 

--- a/src/components/insights/charts/loadings/SkeletonBarChart.vue
+++ b/src/components/insights/charts/loadings/SkeletonBarChart.vue
@@ -47,12 +47,12 @@ const totalBars = computed(() => parseInt(props.width / BAR_WIDTH) || 36);
   height: 100%;
   display: flex;
   justify-content: center;
-  gap: $unnnic-spacing-nano;
+  gap: $unnnic-space-1;
   &__bar {
     display: flex;
     flex-direction: column;
     justify-content: end;
-    gap: $unnnic-spacing-nano;
+    gap: $unnnic-space-1;
     max-height: 100%;
   }
 }

--- a/src/components/insights/charts/loadings/SkeletonHorizontalBarChart.vue
+++ b/src/components/insights/charts/loadings/SkeletonHorizontalBarChart.vue
@@ -49,12 +49,12 @@ const totalBars = computed(() => parseInt(props.height / BAR_HEIGHT) || 14);
   height: 100%;
   display: flex;
   flex-direction: column;
-  gap: $unnnic-spacing-nano;
+  gap: $unnnic-space-1;
   overflow: hidden;
   &__bar {
     display: flex;
     align-items: center;
-    gap: $unnnic-spacing-sm;
+    gap: $unnnic-space-4;
   }
 }
 </style>

--- a/src/components/insights/conversations/AddWidget.vue
+++ b/src/components/insights/conversations/AddWidget.vue
@@ -39,8 +39,8 @@ defineProps<{
   width: 100%;
   height: 100%;
 
-  border-radius: $unnnic-border-radius-md;
-  border: $unnnic-border-width-thinner dashed $unnnic-color-neutral-soft;
+  border-radius: $unnnic-radius-2;
+  border: 1px dashed $unnnic-color-gray-2;
   background: rgba(255, 255, 255, 0.8);
 
   backdrop-filter: blur(5px);

--- a/src/components/insights/conversations/BaseConversationWidget.vue
+++ b/src/components/insights/conversations/BaseConversationWidget.vue
@@ -79,7 +79,7 @@
 </template>
 
 <script setup lang="ts">
-import { defineProps, computed } from 'vue';
+import { computed } from 'vue';
 import ShortTab from '@/components/ShortTab.vue';
 import i18n from '@/utils/plugins/i18n';
 

--- a/src/components/insights/conversations/BaseConversationWidget.vue
+++ b/src/components/insights/conversations/BaseConversationWidget.vue
@@ -150,11 +150,7 @@ const handleTabChange = (tab: Tab) => {
 
     .header__title {
       color: $unnnic-color-gray-12;
-      font-family: $unnnic-font-family;
-      font-size: 20px;
-      font-weight: $unnnic-font-weight-bold;
-      font-style: normal;
-      line-height: 20px + 8px;
+      font: $unnnic-font-display-2;
 
       overflow: hidden;
       text-overflow: ellipsis;
@@ -191,9 +187,7 @@ const handleTabChange = (tab: Tab) => {
           gap: $unnnic-space-2;
 
           .action__text {
-            font-family: $unnnic-font-family;
-            font-size: 12px;
-            line-height: 12px + 8px;
+            font: $unnnic-font-caption-2;
             white-space: nowrap;
           }
 

--- a/src/components/insights/conversations/BaseConversationWidget.vue
+++ b/src/components/insights/conversations/BaseConversationWidget.vue
@@ -132,16 +132,16 @@ const handleTabChange = (tab: Tab) => {
   width: 100%;
   height: 100%;
   display: flex;
-  padding: $unnnic-spacing-md;
+  padding: $unnnic-space-6;
   flex-direction: column;
   justify-content: space-between;
-  gap: $unnnic-spacing-sm;
+  gap: $unnnic-space-4;
   flex: 1 0 0;
   align-self: stretch;
 
-  border-radius: $unnnic-spacing-xs;
-  border: 1px solid $unnnic-color-neutral-soft;
-  background: $unnnic-color-neutral-white;
+  border-radius: $unnnic-space-2;
+  border: 1px solid $unnnic-color-gray-2;
+  background: $unnnic-color-gray-0;
 
   &__header {
     display: flex;
@@ -149,24 +149,24 @@ const handleTabChange = (tab: Tab) => {
     align-items: center;
 
     .header__title {
-      color: $unnnic-color-neutral-darkest;
-      font-family: $unnnic-font-family-secondary;
-      font-size: $unnnic-font-size-title-sm;
+      color: $unnnic-color-gray-12;
+      font-family: $unnnic-font-family;
+      font-size: 20px;
       font-weight: $unnnic-font-weight-bold;
       font-style: normal;
-      line-height: $unnnic-font-size-title-sm + $unnnic-line-height-md;
+      line-height: 20px + 8px;
 
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
       max-width: 500px;
-      margin-right: $unnnic-spacing-xs;
+      margin-right: $unnnic-space-2;
     }
 
     .header__actions {
       display: flex;
       align-items: center;
-      gap: $unnnic-spacing-xs;
+      gap: $unnnic-space-2;
 
       .actions__dropdown {
         display: flex;
@@ -180,20 +180,20 @@ const handleTabChange = (tab: Tab) => {
         }
 
         :deep(.unnnic-dropdown__content) {
-          padding: $unnnic-spacing-sm;
+          padding: $unnnic-space-4;
 
-          gap: $unnnic-spacing-sm;
+          gap: $unnnic-space-4;
         }
 
         .dropdown__action {
           display: flex;
           align-items: center;
-          gap: $unnnic-spacing-xs;
+          gap: $unnnic-space-2;
 
           .action__text {
-            font-family: $unnnic-font-family-secondary;
-            font-size: $unnnic-font-size-body-md;
-            line-height: $unnnic-font-size-body-md + $unnnic-line-height-md;
+            font-family: $unnnic-font-family;
+            font-size: 12px;
+            line-height: 12px + 8px;
             white-space: nowrap;
           }
 

--- a/src/components/insights/conversations/BaseConversationWidget.vue
+++ b/src/components/insights/conversations/BaseConversationWidget.vue
@@ -44,7 +44,7 @@
             <UnnnicIcon
               icon="more_vert"
               size="ant"
-              scheme="neutral-cloudy"
+              scheme="fg-muted"
             />
           </template>
 

--- a/src/components/insights/conversations/CustomizableWidget/ConfigCustomizableForm.vue
+++ b/src/components/insights/conversations/CustomizableWidget/ConfigCustomizableForm.vue
@@ -35,14 +35,14 @@ defineProps<{
   gap: $unnnic-space-5;
 
   &__title {
-    color: $unnnic-color-neutral-black;
+    color: $unnnic-color-gray-13;
     font-weight: $unnnic-font-weight-bold;
   }
 
   &__title {
-    font-size: $unnnic-font-size-body-lg;
-    font-family: $unnnic-font-family-secondary;
-    line-height: $unnnic-font-size-body-lg + $unnnic-line-height-md;
+    font-size: $unnnic-font-size;
+    font-family: $unnnic-font-family;
+    line-height: $unnnic-font-size + 8px;
   }
 }
 </style>

--- a/src/components/insights/conversations/CustomizableWidget/ConfigCustomizableForm.vue
+++ b/src/components/insights/conversations/CustomizableWidget/ConfigCustomizableForm.vue
@@ -36,13 +36,7 @@ defineProps<{
 
   &__title {
     color: $unnnic-color-gray-13;
-    font-weight: $unnnic-font-weight-bold;
-  }
-
-  &__title {
-    font-size: $unnnic-font-size;
-    font-family: $unnnic-font-family;
-    line-height: $unnnic-font-size + 8px;
+    font: $unnnic-font-display-3;
   }
 }
 </style>

--- a/src/components/insights/conversations/CustomizableWidget/CustomizableDrawer.vue
+++ b/src/components/insights/conversations/CustomizableWidget/CustomizableDrawer.vue
@@ -417,7 +417,7 @@ const isDisabledPrimaryButton = computed(() => {
 <style scoped lang="scss">
 .add-widget-drawer {
   &__section-title {
-    color: $unnnic-color-gray-7;
+    color: $unnnic-color-fg-muted;
     font: $unnnic-font-display-4;
   }
 
@@ -451,7 +451,7 @@ const isDisabledPrimaryButton = computed(() => {
       }
 
       .item__description {
-        color: $unnnic-color-gray-7;
+        color: $unnnic-color-fg-muted;
         font: $unnnic-font-body;
       }
     }

--- a/src/components/insights/conversations/CustomizableWidget/CustomizableDrawer.vue
+++ b/src/components/insights/conversations/CustomizableWidget/CustomizableDrawer.vue
@@ -417,49 +417,49 @@ const isDisabledPrimaryButton = computed(() => {
 <style scoped lang="scss">
 .add-widget-drawer {
   &__section-title {
-    color: $unnnic-color-neutral-cloudy;
-    font-family: $unnnic-font-family-secondary;
-    font-size: $unnnic-font-size-body-lg;
+    color: $unnnic-color-gray-7;
+    font-family: $unnnic-font-family;
+    font-size: $unnnic-font-size;
     font-weight: $unnnic-font-weight-regular;
-    line-height: $unnnic-font-size-body-lg + $unnnic-line-height-md;
+    line-height: $unnnic-font-size + 8px;
   }
 
   &__section {
     display: flex;
     flex-direction: column;
-    gap: $unnnic-spacing-sm;
+    gap: $unnnic-space-4;
   }
 
   &__widget-list {
     display: flex;
     flex-direction: column;
-    gap: $unnnic-spacing-sm;
+    gap: $unnnic-space-4;
 
     .widget-list__item {
-      padding: $unnnic-spacing-md;
+      padding: $unnnic-space-6;
 
       display: flex;
       flex-direction: column;
       justify-content: center;
-      gap: $unnnic-spacing-nano;
+      gap: $unnnic-space-1;
 
-      border-radius: $unnnic-border-radius-md;
-      border: $unnnic-border-width-thinner solid $unnnic-color-neutral-soft;
+      border-radius: $unnnic-radius-2;
+      border: 1px solid $unnnic-color-gray-2;
 
       cursor: pointer;
 
       .item__title {
-        color: $unnnic-color-neutral-darkest;
-        font-family: $unnnic-font-family-secondary;
-        font-size: $unnnic-font-size-body-lg;
+        color: $unnnic-color-gray-12;
+        font-family: $unnnic-font-family;
+        font-size: $unnnic-font-size;
         font-weight: $unnnic-font-weight-bold;
-        line-height: $unnnic-font-size-body-lg + $unnnic-line-height-md;
+        line-height: $unnnic-font-size + 8px;
       }
 
       .item__description {
-        color: $unnnic-color-neutral-cloudy;
-        font-size: $unnnic-font-size-body-gt;
-        line-height: $unnnic-font-size-body-gt + $unnnic-line-height-md;
+        color: $unnnic-color-gray-7;
+        font-size: 14px;
+        line-height: 14px + 8px;
       }
     }
   }

--- a/src/components/insights/conversations/CustomizableWidget/CustomizableDrawer.vue
+++ b/src/components/insights/conversations/CustomizableWidget/CustomizableDrawer.vue
@@ -418,10 +418,7 @@ const isDisabledPrimaryButton = computed(() => {
 .add-widget-drawer {
   &__section-title {
     color: $unnnic-color-gray-7;
-    font-family: $unnnic-font-family;
-    font-size: $unnnic-font-size;
-    font-weight: $unnnic-font-weight-regular;
-    line-height: $unnnic-font-size + 8px;
+    font: $unnnic-font-display-4;
   }
 
   &__section {
@@ -450,16 +447,12 @@ const isDisabledPrimaryButton = computed(() => {
 
       .item__title {
         color: $unnnic-color-gray-12;
-        font-family: $unnnic-font-family;
-        font-size: $unnnic-font-size;
-        font-weight: $unnnic-font-weight-bold;
-        line-height: $unnnic-font-size + 8px;
+        font: $unnnic-font-display-3;
       }
 
       .item__description {
         color: $unnnic-color-gray-7;
-        font-size: 14px;
-        line-height: 14px + 8px;
+        font: $unnnic-font-body;
       }
     }
   }

--- a/src/components/insights/conversations/CustomizableWidget/Forms/CrosstabForm.vue
+++ b/src/components/insights/conversations/CustomizableWidget/Forms/CrosstabForm.vue
@@ -135,9 +135,9 @@ onUnmounted(() => {
   }
 
   &__divider {
-    background: $unnnic-color-neutral-light;
+    background: $unnnic-color-gray-1;
     height: 100%;
-    border: 1px solid $unnnic-color-neutral-light;
+    border: 1px solid $unnnic-color-gray-1;
   }
   :deep(.crosstab-form__disclaimer) {
     .unnnic-disclaimer__icon {

--- a/src/components/insights/conversations/CustomizableWidget/Forms/CustomizedForm.vue
+++ b/src/components/insights/conversations/CustomizableWidget/Forms/CustomizedForm.vue
@@ -141,6 +141,6 @@ const handleChangeKey = (key: string) => {
 .customized-form {
   display: flex;
   flex-direction: column;
-  gap: $unnnic-spacing-sm;
+  gap: $unnnic-space-4;
 }
 </style>

--- a/src/components/insights/conversations/CustomizableWidget/Forms/SentimentAnalysisForm.vue
+++ b/src/components/insights/conversations/CustomizableWidget/Forms/SentimentAnalysisForm.vue
@@ -197,22 +197,22 @@ onBeforeMount(() => {
 .sentiment-analysis-form__section {
   display: flex;
   flex-direction: column;
-  gap: $unnnic-spacing-sm;
+  gap: $unnnic-space-4;
 }
 
 .sentiment-analysis-form {
   &__section {
     :deep(.unnnic-label__label) {
       margin: 0;
-      margin-bottom: $unnnic-spacing-nano;
+      margin-bottom: $unnnic-space-1;
     }
   }
 
   &__agent-active {
-    color: $unnnic-color-neutral-cloudy;
-    font-size: $unnnic-font-size-body-md;
-    font-family: $unnnic-font-family-secondary;
-    line-height: $unnnic-font-size-body-md + $unnnic-line-height-md;
+    color: $unnnic-color-gray-7;
+    font-size: 12px;
+    font-family: $unnnic-font-family;
+    line-height: 12px + 8px;
   }
 }
 </style>

--- a/src/components/insights/conversations/CustomizableWidget/Forms/SentimentAnalysisForm.vue
+++ b/src/components/insights/conversations/CustomizableWidget/Forms/SentimentAnalysisForm.vue
@@ -209,7 +209,7 @@ onBeforeMount(() => {
   }
 
   &__agent-active {
-    color: $unnnic-color-gray-7;
+    color: $unnnic-color-fg-muted;
     font: $unnnic-font-caption-2;
   }
 }

--- a/src/components/insights/conversations/CustomizableWidget/Forms/SentimentAnalysisForm.vue
+++ b/src/components/insights/conversations/CustomizableWidget/Forms/SentimentAnalysisForm.vue
@@ -210,9 +210,7 @@ onBeforeMount(() => {
 
   &__agent-active {
     color: $unnnic-color-gray-7;
-    font-size: 12px;
-    font-family: $unnnic-font-family;
-    line-height: 12px + 8px;
+    font: $unnnic-font-caption-2;
   }
 }
 </style>

--- a/src/components/insights/conversations/CustomizableWidget/ModalAttention.vue
+++ b/src/components/insights/conversations/CustomizableWidget/ModalAttention.vue
@@ -88,6 +88,6 @@ const primaryButtonText = computed(() => {
 .modal-topic {
   display: flex;
   flex-direction: column;
-  gap: $unnnic-spacing-md;
+  gap: $unnnic-space-6;
 }
 </style>

--- a/src/components/insights/conversations/CustomizableWidget/ModalRemoveWidget.vue
+++ b/src/components/insights/conversations/CustomizableWidget/ModalRemoveWidget.vue
@@ -110,7 +110,7 @@ const handleRemoveWidget = async () => {
 
   &__description {
     font: $unnnic-font-body;
-    color: $unnnic-color-gray-7;
+    color: $unnnic-color-fg-muted;
   }
 
   :deep(.unnnic-modal-dialog__container__content) {

--- a/src/components/insights/conversations/CustomizableWidget/ModalRemoveWidget.vue
+++ b/src/components/insights/conversations/CustomizableWidget/ModalRemoveWidget.vue
@@ -109,7 +109,7 @@ const handleRemoveWidget = async () => {
   gap: $unnnic-space-6;
 
   &__description {
-    font-size: 14px;
+    font: $unnnic-font-body;
     color: $unnnic-color-gray-7;
   }
 

--- a/src/components/insights/conversations/CustomizableWidget/ModalRemoveWidget.vue
+++ b/src/components/insights/conversations/CustomizableWidget/ModalRemoveWidget.vue
@@ -106,19 +106,19 @@ const handleRemoveWidget = async () => {
 .modal-remove-widget {
   display: flex;
   flex-direction: column;
-  gap: $unnnic-spacing-md;
+  gap: $unnnic-space-6;
 
   &__description {
-    font-size: $unnnic-font-size-body-gt;
-    color: $unnnic-color-neutral-cloudy;
+    font-size: 14px;
+    color: $unnnic-color-gray-7;
   }
 
   :deep(.unnnic-modal-dialog__container__content) {
-    padding-bottom: $unnnic-spacing-sm;
+    padding-bottom: $unnnic-space-4;
   }
 
   :deep(.unnnic-modal-dialog__container__actions) {
-    padding-top: $unnnic-spacing-sm;
+    padding-top: $unnnic-space-4;
   }
 }
 </style>

--- a/src/components/insights/conversations/CustomizableWidget/SeeAllDrawer.vue
+++ b/src/components/insights/conversations/CustomizableWidget/SeeAllDrawer.vue
@@ -27,10 +27,10 @@ import type {
 
 import { getWidgetCrosstabTooltip } from '@/utils/widget';
 import {
-  colorBlue8,
-  colorBlue2,
-  colorOrange7,
-  colorGray1,
+  colorBgBlueStrong,
+  colorBgBluePlain,
+  colorBgOrangeStrong,
+  colorBgBaseSoft,
 } from '@weni/unnnic-system/tokens/colors';
 
 const { formatPercentage, formatNumber } = useWidgetFormatting();
@@ -46,16 +46,20 @@ const emit = defineEmits<{
   (_e: 'update:modelValue', _value: boolean): void;
 }>();
 
-const defaultColor = colorBlue8;
-const defaultBackgroundColor = props.isCrosstab ? colorOrange7 : colorBlue2;
+const defaultColor = colorBgBlueStrong;
+const defaultBackgroundColor = props.isCrosstab
+  ? colorBgOrangeStrong
+  : colorBgBluePlain;
 
 const formattedCrosstabData = computed(() => {
   return (props.data as CrosstabResultItem[]).map((item) => {
     const eventsKeys = Object.keys(item.events);
     return {
       label: item.title,
-      color: colorBlue8,
-      backgroundColor: eventsKeys.length ? colorOrange7 : colorGray1,
+      color: colorBgBlueStrong,
+      backgroundColor: eventsKeys.length
+        ? colorBgOrangeStrong
+        : colorBgBaseSoft,
       description: `${item.total}`,
       value: item.events[eventsKeys[0]]?.value || 0,
       tooltip: getWidgetCrosstabTooltip(item.events),

--- a/src/components/insights/conversations/CustomizableWidget/SeeAllDrawer.vue
+++ b/src/components/insights/conversations/CustomizableWidget/SeeAllDrawer.vue
@@ -27,10 +27,10 @@ import type {
 
 import { getWidgetCrosstabTooltip } from '@/utils/widget';
 import {
-  colorBlue500,
-  colorBlue100,
-  colorOrange500,
-  colorGray50,
+  colorBlue8,
+  colorBlue2,
+  colorOrange7,
+  colorGray1,
 } from '@weni/unnnic-system/tokens/colors';
 
 const { formatPercentage, formatNumber } = useWidgetFormatting();
@@ -46,16 +46,16 @@ const emit = defineEmits<{
   (_e: 'update:modelValue', _value: boolean): void;
 }>();
 
-const defaultColor = colorBlue500;
-const defaultBackgroundColor = props.isCrosstab ? colorOrange500 : colorBlue100;
+const defaultColor = colorBlue8;
+const defaultBackgroundColor = props.isCrosstab ? colorOrange7 : colorBlue2;
 
 const formattedCrosstabData = computed(() => {
   return (props.data as CrosstabResultItem[]).map((item) => {
     const eventsKeys = Object.keys(item.events);
     return {
       label: item.title,
-      color: colorBlue500,
-      backgroundColor: eventsKeys.length ? colorOrange500 : colorGray50,
+      color: colorBlue8,
+      backgroundColor: eventsKeys.length ? colorOrange7 : colorGray1,
       description: `${item.total}`,
       value: item.events[eventsKeys[0]]?.value || 0,
       tooltip: getWidgetCrosstabTooltip(item.events),

--- a/src/components/insights/conversations/CustomizableWidget/__tests__/SeeAllDrawer.spec.js
+++ b/src/components/insights/conversations/CustomizableWidget/__tests__/SeeAllDrawer.spec.js
@@ -116,24 +116,24 @@ describe('SeeAllDrawer', () => {
           label: 'Satisfied',
           value: 75.5,
           description: '75.5% (302)',
-          backgroundColor: '#E5EEF9', // colorBlue100
-          color: '#3182CE', // colorBlue500
+          backgroundColor: '#E1F3FF', // colorBlue100
+          color: '#3993F4', // colorBlue500
           subItems: [],
         },
         {
           label: 'Neutral',
           value: 15.2,
           description: '15.2% (61)',
-          backgroundColor: '#E5EEF9', // colorBlue100
-          color: '#3182CE', // colorBlue500
+          backgroundColor: '#E1F3FF', // colorBlue100
+          color: '#3993F4', // colorBlue500
           subItems: [],
         },
         {
           label: 'Unsatisfied',
           value: 9.3,
           description: '9.3% (37)',
-          backgroundColor: '#E5EEF9', // colorBlue100
-          color: '#3182CE', // colorBlue500
+          backgroundColor: '#E1F3FF', // colorBlue100
+          color: '#3993F4', // colorBlue500
           subItems: [],
         },
       ];

--- a/src/components/insights/conversations/CustomizableWidget/__tests__/SeeAllDrawer.spec.js
+++ b/src/components/insights/conversations/CustomizableWidget/__tests__/SeeAllDrawer.spec.js
@@ -116,24 +116,24 @@ describe('SeeAllDrawer', () => {
           label: 'Satisfied',
           value: 75.5,
           description: '75.5% (302)',
-          backgroundColor: '#E1F3FF', // colorBlue100
-          color: '#3993F4', // colorBlue500
+          backgroundColor: '#CBE9FF', // colorBgBluePlain
+          color: '#3993F4', // colorBgBlueStrong
           subItems: [],
         },
         {
           label: 'Neutral',
           value: 15.2,
           description: '15.2% (61)',
-          backgroundColor: '#E1F3FF', // colorBlue100
-          color: '#3993F4', // colorBlue500
+          backgroundColor: '#CBE9FF', // colorBgBluePlain
+          color: '#3993F4', // colorBgBlueStrong
           subItems: [],
         },
         {
           label: 'Unsatisfied',
           value: 9.3,
           description: '9.3% (37)',
-          backgroundColor: '#E1F3FF', // colorBlue100
-          color: '#3993F4', // colorBlue500
+          backgroundColor: '#CBE9FF', // colorBgBluePlain
+          color: '#3993F4', // colorBgBlueStrong
           subItems: [],
         },
       ];

--- a/src/components/insights/conversations/DashboardHeader.vue
+++ b/src/components/insights/conversations/DashboardHeader.vue
@@ -245,7 +245,7 @@ $min-height: 134px;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: $unnnic-spacing-sm;
+  gap: $unnnic-space-4;
 
   width: 100%;
 

--- a/src/components/insights/conversations/MostTalkedAboutTopicsWidget/index.vue
+++ b/src/components/insights/conversations/MostTalkedAboutTopicsWidget/index.vue
@@ -170,7 +170,7 @@ onMounted(() => {
 .most-talked-about-topics {
   position: relative;
 
-  padding-bottom: $unnnic-spacing-sm;
+  padding-bottom: $unnnic-space-4;
 
   overflow: hidden;
 
@@ -180,7 +180,7 @@ onMounted(() => {
   &__conversation-widget {
     height: 100%;
 
-    gap: $unnnic-spacing-ant;
+    gap: $unnnic-space-3;
   }
 
   &__add-widget {

--- a/src/components/insights/conversations/SetupWidget.vue
+++ b/src/components/insights/conversations/SetupWidget.vue
@@ -63,7 +63,7 @@ defineProps<{
 
     max-width: 600px;
 
-    color: $unnnic-color-gray-7;
+    color: $unnnic-color-fg-muted;
     font: $unnnic-font-emphasis;
     text-align: center;
   }

--- a/src/components/insights/conversations/SetupWidget.vue
+++ b/src/components/insights/conversations/SetupWidget.vue
@@ -46,7 +46,7 @@ defineProps<{
 
   display: flex;
   flex-direction: column;
-  gap: $unnnic-spacing-ant;
+  gap: $unnnic-space-3;
   justify-content: center;
   align-items: center;
 
@@ -54,16 +54,16 @@ defineProps<{
   height: 100%;
 
   &__title {
-    color: $unnnic-color-neutral-darkest;
+    color: $unnnic-color-gray-12;
     font: $unnnic-font-display-2;
   }
 
   &__description {
-    padding: 0 $unnnic-spacing-sm;
+    padding: 0 $unnnic-space-4;
 
     max-width: 600px;
 
-    color: $unnnic-color-neutral-cloudy;
+    color: $unnnic-color-gray-7;
     font: $unnnic-font-emphasis;
     text-align: center;
   }

--- a/src/components/insights/conversations/WidgetError.vue
+++ b/src/components/insights/conversations/WidgetError.vue
@@ -60,7 +60,7 @@ const handleClick = () => {
 
   &__description {
     font: $unnnic-font-body;
-    color: $unnnic-color-gray-7;
+    color: $unnnic-color-fg-muted;
   }
 
   &__title {

--- a/src/components/insights/conversations/WidgetError.vue
+++ b/src/components/insights/conversations/WidgetError.vue
@@ -65,11 +65,9 @@ const handleClick = () => {
 
   &__title {
     color: $unnnic-color-gray-12;
-    font-family: $unnnic-font-family;
-    text-align: center;
-    font-size: 20px;
+    font: $unnnic-font-display-2;
     font-weight: 900;
-    line-height: 20px + 8px;
+    text-align: center;
   }
 }
 </style>

--- a/src/components/insights/conversations/WidgetError.vue
+++ b/src/components/insights/conversations/WidgetError.vue
@@ -60,16 +60,16 @@ const handleClick = () => {
 
   &__description {
     font: $unnnic-font-body;
-    color: $unnnic-color-neutral-cloudy;
+    color: $unnnic-color-gray-7;
   }
 
   &__title {
-    color: $unnnic-color-neutral-darkest;
-    font-family: $unnnic-font-family-secondary;
+    color: $unnnic-color-gray-12;
+    font-family: $unnnic-font-family;
     text-align: center;
-    font-size: $unnnic-font-size-title-sm;
-    font-weight: $unnnic-font-weight-black;
-    line-height: $unnnic-font-size-title-sm + $unnnic-line-height-md;
+    font-size: 20px;
+    font-weight: 900;
+    line-height: 20px + 8px;
   }
 }
 </style>

--- a/src/components/insights/conversations/topics/DrawerTopics.vue
+++ b/src/components/insights/conversations/topics/DrawerTopics.vue
@@ -80,6 +80,6 @@ onMounted(() => {
 }
 
 .drawer-topics-disclaimer {
-  margin-bottom: $unnnic-spacing-sm;
+  margin-bottom: $unnnic-space-4;
 }
 </style>

--- a/src/components/insights/conversations/topics/Form/FormTopic.vue
+++ b/src/components/insights/conversations/topics/Form/FormTopic.vue
@@ -115,9 +115,9 @@ const handleAddSubTopic = (topicIndex: number) => {
   &__divider {
     width: 100%;
     height: 1px;
-    margin-top: $unnnic-spacing-md;
-    margin-bottom: $unnnic-spacing-md;
-    background-color: $unnnic-color-neutral-soft;
+    margin-top: $unnnic-space-6;
+    margin-bottom: $unnnic-space-6;
+    background-color: $unnnic-color-gray-2;
   }
 
   &__body {
@@ -129,8 +129,8 @@ const handleAddSubTopic = (topicIndex: number) => {
   &__skeleton {
     display: flex;
     flex-direction: column;
-    gap: $unnnic-spacing-sm;
-    margin-top: $unnnic-spacing-md;
+    gap: $unnnic-space-4;
+    margin-top: $unnnic-space-6;
   }
 }
 </style>

--- a/src/components/insights/conversations/topics/Form/FormTopicCard.vue
+++ b/src/components/insights/conversations/topics/Form/FormTopicCard.vue
@@ -163,11 +163,7 @@ const toggleTopics = () => {
 
       &__title {
         color: $unnnic-color-gray-12;
-        font-family: $unnnic-font-family;
-        font-size: $unnnic-font-size;
-        font-style: normal;
-        font-weight: $unnnic-font-weight-bold;
-        line-height: $unnnic-font-size + 8px;
+        font: $unnnic-font-display-3;
       }
 
       &__delete-button {
@@ -206,11 +202,7 @@ const toggleTopics = () => {
 
         &__text {
           color: $unnnic-color-gray-7;
-          font-family: $unnnic-font-family;
-          font-size: 12px;
-          font-style: normal;
-          font-weight: $unnnic-font-weight-regular;
-          line-height: 12px + 8px;
+          font: $unnnic-font-caption-2;
         }
       }
     }
@@ -233,11 +225,7 @@ const toggleTopics = () => {
 
         &__title {
           color: $unnnic-color-gray-12;
-          font-family: $unnnic-font-family;
-          font-size: $unnnic-font-size;
-          font-style: normal;
-          font-weight: $unnnic-font-weight-regular;
-          line-height: $unnnic-font-size + 8px;
+          font: $unnnic-font-display-4;
         }
 
         &__description {
@@ -247,11 +235,7 @@ const toggleTopics = () => {
           text-overflow: ellipsis;
           overflow: hidden;
           color: $unnnic-color-gray-7;
-          font-family: $unnnic-font-family;
-          font-size: 14px;
-          font-style: normal;
-          font-weight: $unnnic-font-weight-regular;
-          line-height: 14px + 8px;
+          font: $unnnic-font-body;
         }
       }
     }

--- a/src/components/insights/conversations/topics/Form/FormTopicCard.vue
+++ b/src/components/insights/conversations/topics/Form/FormTopicCard.vue
@@ -201,7 +201,7 @@ const toggleTopics = () => {
         align-items: center;
 
         &__text {
-          color: $unnnic-color-gray-7;
+          color: $unnnic-color-fg-muted;
           font: $unnnic-font-caption-2;
         }
       }
@@ -234,7 +234,7 @@ const toggleTopics = () => {
           -webkit-line-clamp: 1;
           text-overflow: ellipsis;
           overflow: hidden;
-          color: $unnnic-color-gray-7;
+          color: $unnnic-color-fg-muted;
           font: $unnnic-font-body;
         }
       }

--- a/src/components/insights/conversations/topics/Form/FormTopicCard.vue
+++ b/src/components/insights/conversations/topics/Form/FormTopicCard.vue
@@ -157,25 +157,25 @@ const toggleTopics = () => {
 
       :deep(.unnnic-button--icon-on-center.unnnic-button--size-small) {
         padding: 0;
-        width: $unnnic-icon-size-ant;
-        height: $unnnic-icon-size-ant;
+        width: $unnnic-icon-size-5;
+        height: $unnnic-icon-size-5;
       }
 
       &__title {
-        color: $unnnic-color-neutral-darkest;
-        font-family: $unnnic-font-family-secondary;
-        font-size: $unnnic-font-size-body-lg;
+        color: $unnnic-color-gray-12;
+        font-family: $unnnic-font-family;
+        font-size: $unnnic-font-size;
         font-style: normal;
         font-weight: $unnnic-font-weight-bold;
-        line-height: $unnnic-font-size-body-lg + $unnnic-line-height-md;
+        line-height: $unnnic-font-size + 8px;
       }
 
       &__delete-button {
         :deep(.unnnic-icon__size--md) {
-          width: $unnnic-icon-size-ant;
-          height: $unnnic-icon-size-ant;
-          min-width: $unnnic-icon-size-ant;
-          min-height: $unnnic-icon-size-ant;
+          width: $unnnic-icon-size-5;
+          height: $unnnic-icon-size-5;
+          min-width: $unnnic-icon-size-5;
+          min-height: $unnnic-icon-size-5;
         }
       }
     }
@@ -183,21 +183,21 @@ const toggleTopics = () => {
     &__form {
       display: flex;
       flex-direction: column;
-      gap: $unnnic-spacing-xs;
+      gap: $unnnic-space-2;
       width: 100%;
     }
 
     &__input {
       width: 100%;
       :deep(.unnnic-form__label) {
-        margin: 0 0 $unnnic-spacing-nano 0;
+        margin: 0 0 $unnnic-space-1 0;
       }
     }
 
     &__context {
       display: flex;
       flex-direction: column;
-      gap: $unnnic-spacing-nano;
+      gap: $unnnic-space-1;
 
       &__description {
         display: flex;
@@ -205,12 +205,12 @@ const toggleTopics = () => {
         align-items: center;
 
         &__text {
-          color: $unnnic-color-neutral-cloudy;
-          font-family: $unnnic-font-family-secondary;
-          font-size: $unnnic-font-size-body-md;
+          color: $unnnic-color-gray-7;
+          font-family: $unnnic-font-family;
+          font-size: 12px;
           font-style: normal;
           font-weight: $unnnic-font-weight-regular;
-          line-height: $unnnic-font-size-body-md + $unnnic-line-height-md;
+          line-height: 12px + 8px;
         }
       }
     }
@@ -224,20 +224,20 @@ const toggleTopics = () => {
     &__content {
       display: flex;
       align-items: center;
-      gap: $unnnic-spacing-sm;
+      gap: $unnnic-space-4;
 
       &__container {
         display: flex;
         flex-direction: column;
-        gap: $unnnic-spacing-nano;
+        gap: $unnnic-space-1;
 
         &__title {
-          color: $unnnic-color-neutral-darkest;
-          font-family: $unnnic-font-family-secondary;
-          font-size: $unnnic-font-size-body-lg;
+          color: $unnnic-color-gray-12;
+          font-family: $unnnic-font-family;
+          font-size: $unnnic-font-size;
           font-style: normal;
           font-weight: $unnnic-font-weight-regular;
-          line-height: $unnnic-font-size-body-lg + $unnnic-line-height-md;
+          line-height: $unnnic-font-size + 8px;
         }
 
         &__description {
@@ -246,12 +246,12 @@ const toggleTopics = () => {
           -webkit-line-clamp: 1;
           text-overflow: ellipsis;
           overflow: hidden;
-          color: $unnnic-color-neutral-cloudy;
-          font-family: $unnnic-font-family-secondary;
-          font-size: $unnnic-font-size-body-gt;
+          color: $unnnic-color-gray-7;
+          font-family: $unnnic-font-family;
+          font-size: 14px;
           font-style: normal;
           font-weight: $unnnic-font-weight-regular;
-          line-height: $unnnic-font-size-body-gt + $unnnic-line-height-md;
+          line-height: 14px + 8px;
         }
       }
     }

--- a/src/components/insights/conversations/topics/Form/FormTopicItem.vue
+++ b/src/components/insights/conversations/topics/Form/FormTopicItem.vue
@@ -270,7 +270,7 @@ const handleFormatDate = (date: string) => {
       cursor: pointer;
 
       &__title {
-        color: $unnnic-color-gray-7;
+        color: $unnnic-color-fg-muted;
         font: $unnnic-font-body;
       }
 
@@ -295,7 +295,7 @@ const handleFormatDate = (date: string) => {
 
     &__title {
       overflow: hidden;
-      color: $unnnic-color-gray-7;
+      color: $unnnic-color-fg-muted;
       text-align: right;
       text-overflow: ellipsis;
       font: $unnnic-font-caption-2;

--- a/src/components/insights/conversations/topics/Form/FormTopicItem.vue
+++ b/src/components/insights/conversations/topics/Form/FormTopicItem.vue
@@ -234,21 +234,21 @@ const handleFormatDate = (date: string) => {
 <style lang="scss" scoped>
 .form-topic-item {
   display: flex;
-  padding: $unnnic-spacing-sm;
+  padding: $unnnic-space-4;
   flex-direction: column;
   align-items: flex-start;
 
   &-gap {
-    gap: $unnnic-spacing-sm;
+    gap: $unnnic-space-4;
   }
 
   &-xs-gap {
-    gap: $unnnic-spacing-xs;
+    gap: $unnnic-space-2;
   }
 
   align-self: stretch;
-  border-radius: $unnnic-spacing-xs;
-  border: 1px solid $unnnic-color-neutral-soft;
+  border-radius: $unnnic-space-2;
+  border: 1px solid $unnnic-color-gray-2;
 
   &__footer {
     display: flex;
@@ -258,9 +258,9 @@ const handleFormatDate = (date: string) => {
     &__divider {
       width: 100%;
       height: 1px;
-      margin-top: $unnnic-spacing-sm;
-      margin-bottom: $unnnic-spacing-sm;
-      background-color: $unnnic-color-neutral-soft;
+      margin-top: $unnnic-space-4;
+      margin-bottom: $unnnic-space-4;
+      background-color: $unnnic-color-gray-2;
     }
 
     &__sub_topics {
@@ -270,16 +270,16 @@ const handleFormatDate = (date: string) => {
       cursor: pointer;
 
       &__title {
-        color: $unnnic-color-neutral-cloudy;
-        font-family: $unnnic-font-family-secondary;
-        font-size: $unnnic-font-size-body-gt;
+        color: $unnnic-color-gray-7;
+        font-family: $unnnic-font-family;
+        font-size: 14px;
         font-style: normal;
         font-weight: $unnnic-font-weight-regular;
-        line-height: $unnnic-font-size-body-gt + $unnnic-line-height-md;
+        line-height: 14px + 8px;
       }
 
       &-padding-bottom {
-        padding-bottom: $unnnic-spacing-xs;
+        padding-bottom: $unnnic-space-2;
       }
     }
   }
@@ -295,19 +295,19 @@ const handleFormatDate = (date: string) => {
     align-items: end;
     justify-content: end;
     width: 100%;
-    padding-bottom: $unnnic-spacing-sm;
+    padding-bottom: $unnnic-space-4;
 
     &__title {
       overflow: hidden;
-      color: $unnnic-color-neutral-cloudy;
+      color: $unnnic-color-gray-7;
       text-align: right;
       text-overflow: ellipsis;
-      font-family: $unnnic-font-family-secondary;
-      font-size: $unnnic-font-size-body-md;
+      font-family: $unnnic-font-family;
+      font-size: 12px;
       font-weight: $unnnic-font-weight-regular;
-      line-height: $unnnic-font-size-body-md + $unnnic-line-height-md;
+      line-height: 12px + 8px;
       font-style: italic;
-      padding-right: $unnnic-spacing-nano;
+      padding-right: $unnnic-space-1;
     }
   }
 }

--- a/src/components/insights/conversations/topics/Form/FormTopicItem.vue
+++ b/src/components/insights/conversations/topics/Form/FormTopicItem.vue
@@ -271,11 +271,7 @@ const handleFormatDate = (date: string) => {
 
       &__title {
         color: $unnnic-color-gray-7;
-        font-family: $unnnic-font-family;
-        font-size: 14px;
-        font-style: normal;
-        font-weight: $unnnic-font-weight-regular;
-        line-height: 14px + 8px;
+        font: $unnnic-font-body;
       }
 
       &-padding-bottom {
@@ -302,10 +298,7 @@ const handleFormatDate = (date: string) => {
       color: $unnnic-color-gray-7;
       text-align: right;
       text-overflow: ellipsis;
-      font-family: $unnnic-font-family;
-      font-size: 12px;
-      font-weight: $unnnic-font-weight-regular;
-      line-height: 12px + 8px;
+      font: $unnnic-font-caption-2;
       font-style: italic;
       padding-right: $unnnic-space-1;
     }

--- a/src/components/insights/conversations/topics/ModalTopic.vue
+++ b/src/components/insights/conversations/topics/ModalTopic.vue
@@ -118,6 +118,6 @@ const primaryButtonClick = () => {
 .modal-topic {
   display: flex;
   flex-direction: column;
-  gap: $unnnic-spacing-md;
+  gap: $unnnic-space-6;
 }
 </style>

--- a/src/components/insights/dashboards/Conversational.vue
+++ b/src/components/insights/dashboards/Conversational.vue
@@ -212,7 +212,7 @@ onUnmounted(() => {
 </script>
 
 <style lang="scss" scoped>
-$layout-gap: $unnnic-spacing-sm;
+$layout-gap: $unnnic-space-4;
 
 .dashboard-conversational {
   display: flex;

--- a/src/components/insights/dashboards/DashboardCustom.vue
+++ b/src/components/insights/dashboards/DashboardCustom.vue
@@ -214,7 +214,7 @@ export default {
   height: 100%;
 
   display: grid;
-  gap: $unnnic-spacing-sm;
+  gap: $unnnic-space-4;
   &__loading {
     width: 100vw;
     height: 85vh;

--- a/src/components/insights/dashboards/DrawerDashboardConfig.vue
+++ b/src/components/insights/dashboards/DrawerDashboardConfig.vue
@@ -262,19 +262,19 @@ export default {
 
 .config-form {
   display: grid;
-  gap: $unnnic-spacing-sm;
+  gap: $unnnic-space-4;
   &__input-hint {
-    font-family: $unnnic-font-family-secondary;
-    font-size: $unnnic-font-size-body-md;
+    font-family: $unnnic-font-family;
+    font-size: 12px;
     font-weight: $unnnic-font-weight-regular;
-    line-height: $unnnic-line-height-large * 1.25; // 20px
-    margin-top: $unnnic-spacing-nano;
+    line-height: 16px * 1.25; // 20px
+    margin-top: $unnnic-space-1;
   }
 
   &__layout {
     display: flex;
     flex-direction: column;
-    gap: $unnnic-spacing-xs;
+    gap: $unnnic-space-2;
   }
 }
 

--- a/src/components/insights/dashboards/DrawerDashboardConfig.vue
+++ b/src/components/insights/dashboards/DrawerDashboardConfig.vue
@@ -264,10 +264,7 @@ export default {
   display: grid;
   gap: $unnnic-space-4;
   &__input-hint {
-    font-family: $unnnic-font-family;
-    font-size: 12px;
-    font-weight: $unnnic-font-weight-regular;
-    line-height: 16px * 1.25; // 20px
+    font: $unnnic-font-caption-2;
     margin-top: $unnnic-space-1;
   }
 

--- a/src/components/insights/dashboards/HumanSupport.vue
+++ b/src/components/insights/dashboards/HumanSupport.vue
@@ -121,7 +121,7 @@ const handleChangeTab = (tab: ActiveTab) => {
     align-items: center;
     aspect-ratio: 1/1;
     border-radius: $unnnic-radius-full;
-    border: 1px solid $unnnic-color-neutral-cloudy;
+    border: 1px solid $unnnic-color-gray-7;
   }
 }
 </style>

--- a/src/components/insights/dashboards/ModalDeleteDashboard.vue
+++ b/src/components/insights/dashboards/ModalDeleteDashboard.vue
@@ -118,9 +118,6 @@ export default {
 
 <style lang="scss" scoped>
 .delete-notice {
-  font-family: $unnnic-font-family;
-  font-size: 14px;
-  font-weight: $unnnic-font-weight-regular;
-  line-height: 16px * 1.375;
+  font: $unnnic-font-body;
 }
 </style>

--- a/src/components/insights/dashboards/ModalDeleteDashboard.vue
+++ b/src/components/insights/dashboards/ModalDeleteDashboard.vue
@@ -118,9 +118,9 @@ export default {
 
 <style lang="scss" scoped>
 .delete-notice {
-  font-family: $unnnic-font-family-secondary;
-  font-size: $unnnic-font-size-body-gt;
+  font-family: $unnnic-font-family;
+  font-size: 14px;
   font-weight: $unnnic-font-weight-regular;
-  line-height: $unnnic-line-height-large * 1.375;
+  line-height: 16px * 1.375;
 }
 </style>

--- a/src/components/insights/dashboards/TemplateMessageMeta.vue
+++ b/src/components/insights/dashboards/TemplateMessageMeta.vue
@@ -544,7 +544,7 @@ const unfavoriteTemplate = async () => {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    margin-bottom: $unnnic-spacing-md;
+    margin-bottom: $unnnic-space-6;
 
     :deep(.template-message-meta-dashboard__api-select) {
       min-width: 250px;
@@ -559,16 +559,16 @@ const unfavoriteTemplate = async () => {
 
   &__tab {
     cursor: pointer;
-    font-family: $unnnic-font-family-secondary;
+    font-family: $unnnic-font-family;
     font-weight: $unnnic-font-weight-regular;
-    font-size: $unnnic-font-size-body-gt;
-    line-height: $unnnic-font-size-body-gt + $unnnic-line-height-medium;
+    font-size: 14px;
+    line-height: 14px + 8px;
     text-decoration: underline solid;
-    color: $unnnic-color-neutral-cloudy;
+    color: $unnnic-color-gray-7;
 
     &--active {
-      color: $unnnic-color-neutral-dark;
-      font-weight: $unnnic-font-weight-black;
+      color: $unnnic-color-gray-10;
+      font-weight: 900;
       text-decoration: none;
     }
   }
@@ -579,11 +579,11 @@ const unfavoriteTemplate = async () => {
     overflow: auto;
     height: 100%;
     &-title {
-      font-family: $unnnic-font-family-secondary;
+      font-family: $unnnic-font-family;
       font-weight: $unnnic-font-weight-bold;
-      font-size: $unnnic-font-size-body-lg;
-      line-height: $unnnic-font-size-body-lg + $unnnic-line-height-medium;
-      color: $unnnic-color-neutral-dark;
+      font-size: $unnnic-font-size;
+      line-height: $unnnic-font-size + 8px;
+      color: $unnnic-color-gray-10;
       margin-bottom: 10px;
     }
   }
@@ -601,11 +601,11 @@ const unfavoriteTemplate = async () => {
       max-height: 202px;
     }
     &-text {
-      color: $unnnic-color-neutral-cloudy;
+      color: $unnnic-color-gray-7;
       text-align: center;
-      font-family: $unnnic-font-family-secondary;
-      font-size: $unnnic-font-size-body-lg;
-      line-height: $unnnic-font-size-body-lg + $unnnic-line-height-medium;
+      font-family: $unnnic-font-family;
+      font-size: $unnnic-font-size;
+      line-height: $unnnic-font-size + 8px;
     }
   }
 

--- a/src/components/insights/dashboards/TemplateMessageMeta.vue
+++ b/src/components/insights/dashboards/TemplateMessageMeta.vue
@@ -561,7 +561,7 @@ const unfavoriteTemplate = async () => {
     cursor: pointer;
     font: $unnnic-font-body;
     text-decoration: underline solid;
-    color: $unnnic-color-gray-7;
+    color: $unnnic-color-fg-muted;
 
     &--active {
       color: $unnnic-color-gray-10;
@@ -595,7 +595,7 @@ const unfavoriteTemplate = async () => {
       max-height: 202px;
     }
     &-text {
-      color: $unnnic-color-gray-7;
+      color: $unnnic-color-fg-muted;
       text-align: center;
       font: $unnnic-font-display-4;
     }

--- a/src/components/insights/dashboards/TemplateMessageMeta.vue
+++ b/src/components/insights/dashboards/TemplateMessageMeta.vue
@@ -559,10 +559,7 @@ const unfavoriteTemplate = async () => {
 
   &__tab {
     cursor: pointer;
-    font-family: $unnnic-font-family;
-    font-weight: $unnnic-font-weight-regular;
-    font-size: 14px;
-    line-height: 14px + 8px;
+    font: $unnnic-font-body;
     text-decoration: underline solid;
     color: $unnnic-color-gray-7;
 
@@ -579,10 +576,7 @@ const unfavoriteTemplate = async () => {
     overflow: auto;
     height: 100%;
     &-title {
-      font-family: $unnnic-font-family;
-      font-weight: $unnnic-font-weight-bold;
-      font-size: $unnnic-font-size;
-      line-height: $unnnic-font-size + 8px;
+      font: $unnnic-font-display-3;
       color: $unnnic-color-gray-10;
       margin-bottom: 10px;
     }
@@ -603,9 +597,7 @@ const unfavoriteTemplate = async () => {
     &-text {
       color: $unnnic-color-gray-7;
       text-align: center;
-      font-family: $unnnic-font-family;
-      font-size: $unnnic-font-size;
-      line-height: $unnnic-font-size + 8px;
+      font: $unnnic-font-display-4;
     }
   }
 

--- a/src/components/insights/dashboards/layout/DynamicGrid.vue
+++ b/src/components/insights/dashboards/layout/DynamicGrid.vue
@@ -69,10 +69,10 @@ const getBoxClass = (index: number) => {
 
 .box {
   border-radius: 0.1025rem;
-  background-color: $unnnic-color-neutral-cleanest;
+  background-color: $unnnic-color-gray-4;
 
   &-active {
-    background-color: $unnnic-color-weni-600;
+    background-color: $unnnic-color-teal-8;
   }
 }
 

--- a/src/components/insights/dashboards/layout/LayoutSelector.vue
+++ b/src/components/insights/dashboards/layout/LayoutSelector.vue
@@ -45,7 +45,7 @@ function selectLayout(layout: number) {
 <style scoped lang="scss">
 .layout_selector {
   display: flex;
-  gap: $unnnic-spacing-sm;
+  gap: $unnnic-space-4;
 }
 
 .layout_button {
@@ -53,33 +53,33 @@ function selectLayout(layout: number) {
   max-width: 118px;
   aspect-ratio: 1.6;
   cursor: pointer;
-  border-radius: $unnnic-spacing-nano;
-  padding: $unnnic-spacing-nano;
-  border: 1px solid $unnnic-color-neutral-light;
-  background-color: $unnnic-color-background-white;
+  border-radius: $unnnic-space-1;
+  padding: $unnnic-space-1;
+  border: 1px solid $unnnic-color-gray-1;
+  background-color: $unnnic-color-gray-0;
 
   &:hover {
-    border-color: $unnnic-color-neutral-soft;
+    border-color: $unnnic-color-gray-2;
     box-shadow: 0px 4px 8px 0px rgba(0, 0, 0, 0.1);
   }
 
   &_container {
     background-color: white;
-    padding: $unnnic-spacing-nano 0.1875rem;
-    border: 1.5px solid $unnnic-color-neutral-cleanest;
+    padding: $unnnic-space-1 0.1875rem;
+    border: 1.5px solid $unnnic-color-gray-4;
     border-radius: 0.0625rem;
     width: 100%;
     height: 100%;
 
     &-active {
-      border-color: $unnnic-color-weni-600;
-      background-color: $unnnic-color-weni-50;
+      border-color: $unnnic-color-teal-8;
+      background-color: $unnnic-color-teal-1;
     }
   }
 
   &-active {
-    background-color: $unnnic-color-weni-50;
-    border-color: $unnnic-color-neutral-soft;
+    background-color: $unnnic-color-teal-1;
+    border-color: $unnnic-color-gray-2;
     box-shadow: 0px 4px 8px 0px rgba(0, 0, 0, 0.1);
   }
 }

--- a/src/components/insights/drawers/DrawerConfigContentFunnel.vue
+++ b/src/components/insights/drawers/DrawerConfigContentFunnel.vue
@@ -243,10 +243,10 @@ export default {
 <style lang="scss" scoped>
 .metric-form {
   display: grid;
-  gap: $unnnic-spacing-nano;
+  gap: $unnnic-space-1;
 
   .clear-button {
-    margin-top: $unnnic-spacing-nano;
+    margin-top: $unnnic-space-1;
   }
 }
 </style>

--- a/src/components/insights/drawers/DrawerConfigContentRecurrence.vue
+++ b/src/components/insights/drawers/DrawerConfigContentRecurrence.vue
@@ -122,10 +122,10 @@ export default {
 <style lang="scss" scoped>
 .content-recurrence {
   display: grid;
-  gap: $unnnic-spacing-nano;
+  gap: $unnnic-space-1;
 
   .clear-button {
-    margin-top: $unnnic-spacing-nano;
+    margin-top: $unnnic-space-1;
   }
 }
 </style>

--- a/src/components/insights/drawers/DrawerConfigContentVtexConversions.vue
+++ b/src/components/insights/drawers/DrawerConfigContentVtexConversions.vue
@@ -349,18 +349,18 @@ fieldset {
 .vtex-conversions-form {
   display: flex;
   flex-direction: column;
-  gap: $unnnic-spacing-sm;
+  gap: $unnnic-space-4;
 
   &__meta {
     display: flex;
     flex-direction: column;
-    gap: $unnnic-spacing-xs;
+    gap: $unnnic-space-2;
   }
 
   &__vtex {
     display: flex;
     flex-direction: column;
-    gap: $unnnic-spacing-xs;
+    gap: $unnnic-space-2;
   }
 }
 </style>

--- a/src/components/insights/drawers/DrawerConfigGallery/GalleryOption.vue
+++ b/src/components/insights/drawers/DrawerConfigGallery/GalleryOption.vue
@@ -35,37 +35,37 @@ export default {
 <style lang="scss" scoped>
 .gallery-option {
   display: flex;
-  padding: $unnnic-spacing-md;
+  padding: $unnnic-space-6;
   flex-direction: column;
   justify-content: center;
   align-items: flex-start;
-  gap: $unnnic-spacing-nano;
+  gap: $unnnic-space-1;
 
   width: 100%;
 
-  border-radius: $unnnic-border-radius-md;
-  border: $unnnic-border-width-thinner solid $unnnic-color-neutral-soft;
-  background-color: $unnnic-color-neutral-snow;
+  border-radius: $unnnic-radius-2;
+  border: 1px solid $unnnic-color-gray-2;
+  background-color: $unnnic-color-gray-0;
 
   cursor: pointer;
 
-  font-family: $unnnic-font-family-secondary;
+  font-family: $unnnic-font-family;
 
   &:hover {
-    border-color: $unnnic-color-weni-500;
-    background-color: $unnnic-color-weni-50;
+    border-color: $unnnic-color-teal-7;
+    background-color: $unnnic-color-teal-1;
   }
 
   &__title {
-    color: $unnnic-color-neutral-darkest;
-    font-size: $unnnic-font-size-body-lg;
+    color: $unnnic-color-gray-12;
+    font-size: $unnnic-font-size;
     font-weight: $unnnic-font-weight-bold;
-    line-height: $unnnic-line-height-small * 6;
+    line-height: 4px * 6;
   }
   &__description {
-    color: $unnnic-color-neutral-cloudy;
-    font-size: $unnnic-font-size-body-gt;
-    line-height: $unnnic-line-height-small * 5.5;
+    color: $unnnic-color-gray-7;
+    font-size: 14px;
+    line-height: 4px * 5.5;
     text-align: start;
   }
 }

--- a/src/components/insights/drawers/DrawerConfigGallery/GalleryOption.vue
+++ b/src/components/insights/drawers/DrawerConfigGallery/GalleryOption.vue
@@ -58,14 +58,11 @@ export default {
 
   &__title {
     color: $unnnic-color-gray-12;
-    font-size: $unnnic-font-size;
-    font-weight: $unnnic-font-weight-bold;
-    line-height: 4px * 6;
+    font: $unnnic-font-display-3;
   }
   &__description {
     color: $unnnic-color-gray-7;
-    font-size: 14px;
-    line-height: 4px * 5.5;
+    font: $unnnic-font-body;
     text-align: start;
   }
 }

--- a/src/components/insights/drawers/DrawerConfigGallery/GalleryOption.vue
+++ b/src/components/insights/drawers/DrawerConfigGallery/GalleryOption.vue
@@ -61,7 +61,7 @@ export default {
     font: $unnnic-font-display-3;
   }
   &__description {
-    color: $unnnic-color-gray-7;
+    color: $unnnic-color-fg-muted;
     font: $unnnic-font-body;
     text-align: start;
   }

--- a/src/components/insights/drawers/DrawerConfigGallery/index.vue
+++ b/src/components/insights/drawers/DrawerConfigGallery/index.vue
@@ -206,7 +206,7 @@ export default {
 .drawer-config-gallery {
   &__options {
     display: grid;
-    gap: $unnnic-spacing-ant;
+    gap: $unnnic-space-3;
   }
 }
 </style>

--- a/src/components/insights/drawers/DrawerConfigWidgetDynamic.vue
+++ b/src/components/insights/drawers/DrawerConfigWidgetDynamic.vue
@@ -488,12 +488,12 @@ export default {
 .drawer-config-widget-dynamic {
   &__content {
     display: grid;
-    gap: $unnnic-spacing-sm;
+    gap: $unnnic-space-4;
   }
 
   :deep(.unnnic-label__label),
   :deep(.unnnic-form__label) {
-    margin: 0 0 $unnnic-spacing-nano;
+    margin: 0 0 $unnnic-space-1;
   }
 }
 </style>

--- a/src/components/insights/drawers/DrawerForms/Card/FormDataCrossing/SubWidget.vue
+++ b/src/components/insights/drawers/DrawerForms/Card/FormDataCrossing/SubWidget.vue
@@ -166,6 +166,6 @@ export default defineComponent({
 <style lang="scss" scoped>
 .subwidget-form {
   display: grid;
-  gap: $unnnic-spacing-xs;
+  gap: $unnnic-space-2;
 }
 </style>

--- a/src/components/insights/drawers/loadings/SkeletonConfigContentCard.vue
+++ b/src/components/insights/drawers/loadings/SkeletonConfigContentCard.vue
@@ -78,12 +78,12 @@ export default {
 .skeleton-radio {
   display: flex;
   align-items: center;
-  gap: $unnnic-spacing-nano;
+  gap: $unnnic-space-1;
 }
 .skeleton-group-radio {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: $unnnic-spacing-sm;
-  row-gap: $unnnic-spacing-sm;
+  gap: $unnnic-space-4;
+  row-gap: $unnnic-space-4;
 }
 </style>

--- a/src/components/insights/export/Conversational/FormExport.vue
+++ b/src/components/insights/export/Conversational/FormExport.vue
@@ -153,24 +153,24 @@ const updateAcceptTerms = (value: boolean) => {
 .conversational-export-form {
   display: flex;
   flex-direction: column;
-  gap: $unnnic-spacing-sm;
-  background: $unnnic-color-neutral-white;
+  gap: $unnnic-space-4;
+  background: $unnnic-color-gray-0;
 
   &__content {
     display: flex;
     flex-direction: column;
-    gap: $unnnic-spacing-sm;
+    gap: $unnnic-space-4;
     :deep(.unnnic-label__label) {
       margin: 0;
     }
   }
 
   &__description {
-    color: $unnnic-color-neutral-cloudy;
-    font-family: $unnnic-font-family-secondary;
-    font-size: $unnnic-font-size-body-gt;
+    color: $unnnic-color-gray-7;
+    font-family: $unnnic-font-family;
+    font-size: 14px;
     font-weight: $unnnic-font-weight-regular;
-    line-height: $unnnic-font-size-body-gt + $unnnic-line-height-md;
+    line-height: 14px + 8px;
   }
 }
 </style>

--- a/src/components/insights/export/Conversational/FormExport.vue
+++ b/src/components/insights/export/Conversational/FormExport.vue
@@ -167,10 +167,7 @@ const updateAcceptTerms = (value: boolean) => {
 
   &__description {
     color: $unnnic-color-gray-7;
-    font-family: $unnnic-font-family;
-    font-size: 14px;
-    font-weight: $unnnic-font-weight-regular;
-    line-height: 14px + 8px;
+    font: $unnnic-font-body;
   }
 }
 </style>

--- a/src/components/insights/export/Conversational/FormExport.vue
+++ b/src/components/insights/export/Conversational/FormExport.vue
@@ -166,7 +166,7 @@ const updateAcceptTerms = (value: boolean) => {
   }
 
   &__description {
-    color: $unnnic-color-gray-7;
+    color: $unnnic-color-fg-muted;
     font: $unnnic-font-body;
   }
 }

--- a/src/components/insights/export/ConversationalExport.vue
+++ b/src/components/insights/export/ConversationalExport.vue
@@ -140,11 +140,8 @@ watch(
 }
 
 .export-data-feedback__text {
-  font-family: $unnnic-font-family;
+  font: $unnnic-font-body;
   color: $unnnic-color-gray-7;
-  font-size: 14px;
-  font-weight: $unnnic-font-weight-regular;
-  line-height: 14px + 8px;
 }
 
 .export-data-tooltip {

--- a/src/components/insights/export/ConversationalExport.vue
+++ b/src/components/insights/export/ConversationalExport.vue
@@ -140,11 +140,11 @@ watch(
 }
 
 .export-data-feedback__text {
-  font-family: $unnnic-font-family-secondary;
-  color: $unnnic-color-neutral-cloudy;
-  font-size: $unnnic-font-size-body-gt;
+  font-family: $unnnic-font-family;
+  color: $unnnic-color-gray-7;
+  font-size: 14px;
   font-weight: $unnnic-font-weight-regular;
-  line-height: $unnnic-font-size-body-gt + $unnnic-line-height-md;
+  line-height: 14px + 8px;
 }
 
 .export-data-tooltip {

--- a/src/components/insights/export/ConversationalExport.vue
+++ b/src/components/insights/export/ConversationalExport.vue
@@ -141,7 +141,7 @@ watch(
 
 .export-data-feedback__text {
   font: $unnnic-font-body;
-  color: $unnnic-color-gray-7;
+  color: $unnnic-color-fg-muted;
 }
 
 .export-data-tooltip {

--- a/src/components/insights/export/ExportCheckboxs.vue
+++ b/src/components/insights/export/ExportCheckboxs.vue
@@ -222,7 +222,7 @@ const getFieldLabel = (fieldName: string): string => {
     margin-left: $unnnic-space-2;
 
     :deep(.unnnic-checkbox) {
-      font-size: 12px;
+      font: $unnnic-font-caption-2;
       color: $unnnic-color-gray-10;
     }
   }

--- a/src/components/insights/export/ExportCheckboxs.vue
+++ b/src/components/insights/export/ExportCheckboxs.vue
@@ -195,21 +195,21 @@ const getFieldLabel = (fieldName: string): string => {
 .form-checkboxs-data {
   display: flex;
   flex-direction: column;
-  gap: $unnnic-spacing-sm;
+  gap: $unnnic-space-4;
 
   &__models {
     display: flex;
     flex-direction: column;
-    gap: $unnnic-spacing-md;
+    gap: $unnnic-space-6;
   }
 
   &__model {
     &-header {
-      margin-bottom: $unnnic-spacing-xs;
+      margin-bottom: $unnnic-space-2;
 
       :deep(.unnnic-checkbox) {
         font-weight: $unnnic-font-weight-bold;
-        color: $unnnic-color-neutral-darkest;
+        color: $unnnic-color-gray-12;
       }
     }
   }
@@ -217,20 +217,20 @@ const getFieldLabel = (fieldName: string): string => {
   &__fields {
     display: flex;
     flex-direction: column;
-    gap: $unnnic-spacing-xs;
-    padding-left: $unnnic-spacing-md;
-    margin-left: $unnnic-spacing-xs;
+    gap: $unnnic-space-2;
+    padding-left: $unnnic-space-6;
+    margin-left: $unnnic-space-2;
 
     :deep(.unnnic-checkbox) {
-      font-size: $unnnic-font-size-body-md;
-      color: $unnnic-color-neutral-dark;
+      font-size: 12px;
+      color: $unnnic-color-gray-10;
     }
   }
 
   &__loading {
     display: flex;
     flex-direction: column;
-    gap: $unnnic-spacing-sm;
+    gap: $unnnic-space-4;
   }
 }
 </style>

--- a/src/components/insights/export/ExportFilterDate.vue
+++ b/src/components/insights/export/ExportFilterDate.vue
@@ -66,6 +66,6 @@ const handleDateSelect = (value: DateRange): void => {
 .export-filter-date {
   display: flex;
   flex-direction: column;
-  gap: $unnnic-spacing-nano;
+  gap: $unnnic-space-1;
 }
 </style>

--- a/src/components/insights/export/ExportFooter.vue
+++ b/src/components/insights/export/ExportFooter.vue
@@ -96,29 +96,29 @@ const handleAcceptTermsChange = (value: boolean): void => {
 .export-footer {
   display: flex;
   flex-direction: column;
-  gap: $unnnic-spacing-sm;
+  gap: $unnnic-space-4;
 
   &__format {
     display: flex;
     flex-direction: column;
-    gap: $unnnic-spacing-sm;
+    gap: $unnnic-space-4;
   }
 
   &__terms {
     display: flex;
     flex-direction: column;
-    gap: $unnnic-spacing-sm;
+    gap: $unnnic-space-4;
   }
 
   &__terms-warning {
     display: flex;
-    gap: $unnnic-spacing-xs;
+    gap: $unnnic-space-2;
 
-    color: $unnnic-color-neutral-dark;
-    font-family: $unnnic-font-family-secondary;
-    font-size: $unnnic-font-size-body-gt;
+    color: $unnnic-color-gray-10;
+    font-family: $unnnic-font-family;
+    font-size: 14px;
     font-weight: $unnnic-font-weight-regular;
-    line-height: $unnnic-font-size-body-gt + $unnnic-line-height-md;
+    line-height: 14px + 8px;
   }
 }
 </style>

--- a/src/components/insights/export/ExportFooter.vue
+++ b/src/components/insights/export/ExportFooter.vue
@@ -115,10 +115,7 @@ const handleAcceptTermsChange = (value: boolean): void => {
     gap: $unnnic-space-2;
 
     color: $unnnic-color-gray-10;
-    font-family: $unnnic-font-family;
-    font-size: 14px;
-    font-weight: $unnnic-font-weight-regular;
-    line-height: 14px + 8px;
+    font: $unnnic-font-body;
   }
 }
 </style>

--- a/src/components/insights/export/HumanSupport/FormExport.vue
+++ b/src/components/insights/export/HumanSupport/FormExport.vue
@@ -350,7 +350,7 @@ const getMaxDate = (): string => {
   }
 
   &__description {
-    color: $unnnic-color-gray-7;
+    color: $unnnic-color-fg-muted;
     font: $unnnic-font-body;
   }
 

--- a/src/components/insights/export/HumanSupport/FormExport.vue
+++ b/src/components/insights/export/HumanSupport/FormExport.vue
@@ -351,10 +351,7 @@ const getMaxDate = (): string => {
 
   &__description {
     color: $unnnic-color-gray-7;
-    font-family: $unnnic-font-family;
-    font-size: 14px;
-    font-weight: $unnnic-font-weight-regular;
-    line-height: 14px + 8px;
+    font: $unnnic-font-body;
   }
 
   &__filters-container {

--- a/src/components/insights/export/HumanSupport/FormExport.vue
+++ b/src/components/insights/export/HumanSupport/FormExport.vue
@@ -337,44 +337,44 @@ const getMaxDate = (): string => {
 .export-data-form {
   display: flex;
   flex-direction: column;
-  gap: $unnnic-spacing-sm;
-  background: $unnnic-color-neutral-white;
+  gap: $unnnic-space-4;
+  background: $unnnic-color-gray-0;
 
   &__content {
     display: flex;
     flex-direction: column;
-    gap: $unnnic-spacing-sm;
+    gap: $unnnic-space-4;
     :deep(.unnnic-label__label) {
       margin: 0;
     }
   }
 
   &__description {
-    color: $unnnic-color-neutral-cloudy;
-    font-family: $unnnic-font-family-secondary;
-    font-size: $unnnic-font-size-body-gt;
+    color: $unnnic-color-gray-7;
+    font-family: $unnnic-font-family;
+    font-size: 14px;
     font-weight: $unnnic-font-weight-regular;
-    line-height: $unnnic-font-size-body-gt + $unnnic-line-height-md;
+    line-height: 14px + 8px;
   }
 
   &__filters-container {
     display: flex;
     flex-direction: column;
-    gap: $unnnic-spacing-nano;
-    flex: 1 1 calc(50% - #{$unnnic-spacing-sm / 2});
+    gap: $unnnic-space-1;
+    flex: 1 1 calc(50% - #{$unnnic-space-4 / 2});
     min-width: 0;
   }
 
   &__filters {
     display: flex;
     flex-wrap: wrap;
-    gap: $unnnic-spacing-sm;
+    gap: $unnnic-space-4;
   }
 
   &__chats-status {
     display: flex;
     flex-direction: column;
-    gap: $unnnic-spacing-sm;
+    gap: $unnnic-space-4;
   }
 }
 </style>

--- a/src/components/insights/export/HumanSupportExport.vue
+++ b/src/components/insights/export/HumanSupportExport.vue
@@ -147,6 +147,6 @@ watch(
 
 .export-data-feedback__text {
   font: $unnnic-font-body;
-  color: $unnnic-color-gray-7;
+  color: $unnnic-color-fg-muted;
 }
 </style>

--- a/src/components/insights/export/HumanSupportExport.vue
+++ b/src/components/insights/export/HumanSupportExport.vue
@@ -146,10 +146,7 @@ watch(
 }
 
 .export-data-feedback__text {
-  font-family: $unnnic-font-family;
+  font: $unnnic-font-body;
   color: $unnnic-color-gray-7;
-  font-size: 14px;
-  font-weight: $unnnic-font-weight-regular;
-  line-height: 14px + 8px;
 }
 </style>

--- a/src/components/insights/export/HumanSupportExport.vue
+++ b/src/components/insights/export/HumanSupportExport.vue
@@ -146,10 +146,10 @@ watch(
 }
 
 .export-data-feedback__text {
-  font-family: $unnnic-font-family-secondary;
-  color: $unnnic-color-neutral-cloudy;
-  font-size: $unnnic-font-size-body-gt;
+  font-family: $unnnic-font-family;
+  color: $unnnic-color-gray-7;
+  font-size: 14px;
   font-weight: $unnnic-font-weight-regular;
-  line-height: $unnnic-font-size-body-gt + $unnnic-line-height-md;
+  line-height: 14px + 8px;
 }
 </style>

--- a/src/components/insights/export/__tests__/__snapshots__/ExportFooter.spec.js.snap
+++ b/src/components/insights/export/__tests__/__snapshots__/ExportFooter.spec.js.snap
@@ -18,23 +18,23 @@ exports[`ExportFooter > Component structure > should match snapshot 1`] = `
     <section
       class="unnnic-radio"
       data-testid="radio-format-xlsx"
+      data-v-2121c2c4=""
       data-v-4f08a4d6=""
-      data-v-7e12a100=""
     >
       <label
         class="unnnic-radio__input-wrapper"
-        data-v-7e12a100=""
+        data-v-2121c2c4=""
       >
         <input
           checked=""
           class="unnnic-radio__input"
-          data-v-7e12a100=""
+          data-v-2121c2c4=""
           name=""
           type="radio"
         />
         <p
           class="unnnic-radio__label"
-          data-v-7e12a100=""
+          data-v-2121c2c4=""
         >
            
           
@@ -47,22 +47,22 @@ exports[`ExportFooter > Component structure > should match snapshot 1`] = `
     <section
       class="unnnic-radio"
       data-testid="radio-format-csv"
+      data-v-2121c2c4=""
       data-v-4f08a4d6=""
-      data-v-7e12a100=""
     >
       <label
         class="unnnic-radio__input-wrapper"
-        data-v-7e12a100=""
+        data-v-2121c2c4=""
       >
         <input
           class="unnnic-radio__input"
-          data-v-7e12a100=""
+          data-v-2121c2c4=""
           name=""
           type="radio"
         />
         <p
           class="unnnic-radio__label"
-          data-v-7e12a100=""
+          data-v-2121c2c4=""
         >
            
           

--- a/src/components/insights/humanSupport/Analysis/DetailedAnalysis.vue
+++ b/src/components/insights/humanSupport/Analysis/DetailedAnalysis.vue
@@ -135,8 +135,8 @@ const filterType = computed(() => {
   gap: $unnnic-space-6;
 
   border-radius: $unnnic-radius-2;
-  border: 1px solid $unnnic-color-neutral-soft;
-  background: $unnnic-color-background-white;
+  border: 1px solid $unnnic-color-gray-2;
+  background: $unnnic-color-gray-0;
 
   &__title {
     font: $unnnic-font-display-2;

--- a/src/components/insights/humanSupport/Common/Filters/FilterSelect.vue
+++ b/src/components/insights/humanSupport/Common/Filters/FilterSelect.vue
@@ -345,6 +345,6 @@ defineExpose({
 
 <style lang="scss">
 .unnnic-popover {
-  background-color: $unnnic-color-background-snow;
+  background-color: $unnnic-color-gray-0;
 }
 </style>

--- a/src/components/insights/humanSupport/CommonWidgets/BarList/index.vue
+++ b/src/components/insights/humanSupport/CommonWidgets/BarList/index.vue
@@ -156,7 +156,7 @@ const handleTabChange = (tab: string) => {
 
     &__count {
       font: $unnnic-font-body;
-      color: $unnnic-color-gray-5;
+      color: $unnnic-color-fg-muted;
     }
     &__see-more {
       font: $unnnic-font-display-4;

--- a/src/components/insights/humanSupport/CommonWidgets/BarList/index.vue
+++ b/src/components/insights/humanSupport/CommonWidgets/BarList/index.vue
@@ -156,7 +156,7 @@ const handleTabChange = (tab: string) => {
 
     &__count {
       font: $unnnic-font-body;
-      color: $unnnic-color-neutral-clean;
+      color: $unnnic-color-gray-5;
     }
     &__see-more {
       font: $unnnic-font-display-4;

--- a/src/components/insights/humanSupport/CommonWidgets/CsatRatings/AgentCard.vue
+++ b/src/components/insights/humanSupport/CommonWidgets/CsatRatings/AgentCard.vue
@@ -63,17 +63,17 @@ const props = withDefaults(defineProps<AgentCardProps>(), {
   padding: $unnnic-space-2;
   justify-content: space-between;
 
-  border-radius: $unnnic-spacing-xs;
-  border: 1px solid $unnnic-color-border-soft;
-  background: $unnnic-color-neutral-white;
+  border-radius: $unnnic-space-2;
+  border: 1px solid $unnnic-color-border-base;
+  background: $unnnic-color-gray-0;
 
   &.active {
-    border: 1px solid $unnnic-color-border-active;
-    background: $unnnic-color-teal-50;
+    border: 1px solid $unnnic-color-border-accent-strong;
+    background: $unnnic-color-teal-1;
   }
 
   &:hover:not(.active) {
-    background: $unnnic-color-bg-soft;
+    background: $unnnic-color-bg-base-soft;
   }
 
   &__container {
@@ -82,7 +82,7 @@ const props = withDefaults(defineProps<AgentCardProps>(), {
     gap: $unnnic-space-2;
 
     :deep(.user-avatar) {
-      background-color: $unnnic-color-neutral-white;
+      background-color: $unnnic-color-gray-0;
     }
   }
 

--- a/src/components/insights/humanSupport/CommonWidgets/CsatRatings/AgentCard.vue
+++ b/src/components/insights/humanSupport/CommonWidgets/CsatRatings/AgentCard.vue
@@ -17,7 +17,7 @@
               icon="info"
               size="sm"
               filled
-              scheme="neutral-cleanest"
+              scheme="fg-muted"
             />
           </UnnnicToolTip>
         </section>

--- a/src/components/insights/humanSupport/CommonWidgets/CsatRatings/CsatRatings.vue
+++ b/src/components/insights/humanSupport/CommonWidgets/CsatRatings/CsatRatings.vue
@@ -350,12 +350,12 @@ watch(
   width: 100%;
   padding: $unnnic-space-6;
 
-  border-radius: $unnnic-spacing-xs;
-  border: 1px solid $unnnic-color-border-soft;
-  background: $unnnic-color-neutral-white;
+  border-radius: $unnnic-space-2;
+  border: 1px solid $unnnic-color-border-base;
+  background: $unnnic-color-gray-0;
 
   &__title {
-    color: $unnnic-color-neutral-darkest;
+    color: $unnnic-color-gray-12;
     font: $unnnic-font-display-2;
   }
 

--- a/src/components/insights/humanSupport/CommonWidgets/CsatRatings/CsatRatings.vue
+++ b/src/components/insights/humanSupport/CommonWidgets/CsatRatings/CsatRatings.vue
@@ -134,7 +134,10 @@ import {
 import { formatPercentage, formatNumber } from '@/utils/numbers';
 import { redirectToChatsConfig } from '@/utils/redirect';
 
-import { colorPurple2, colorPurple9 } from '@weni/unnnic-system/tokens/colors';
+import {
+  colorBgPurplePlain,
+  colorBgPurpleStrong,
+} from '@weni/unnnic-system/tokens/colors';
 
 defineOptions({
   name: 'CsatRatings',
@@ -251,8 +254,8 @@ const progressItemsRatingsData = computed(() => {
     .reverse()
     .map(([key, value]) => ({
       label: labelMapping[key as keyof typeof labelMapping],
-      backgroundColor: colorPurple2,
-      color: colorPurple9,
+      backgroundColor: colorBgPurplePlain,
+      color: colorBgPurpleStrong,
       value: value.value,
       description: `${formatPercentage(value.value, localeI18n.value)} (${formatNumber(value.full_value)})`,
     }));

--- a/src/components/insights/humanSupport/CommonWidgets/CsatRatings/CsatRatings.vue
+++ b/src/components/insights/humanSupport/CommonWidgets/CsatRatings/CsatRatings.vue
@@ -134,10 +134,7 @@ import {
 import { formatPercentage, formatNumber } from '@/utils/numbers';
 import { redirectToChatsConfig } from '@/utils/redirect';
 
-import {
-  colorPurple100,
-  colorPurple500,
-} from '@weni/unnnic-system/tokens/colors';
+import { colorPurple2, colorPurple9 } from '@weni/unnnic-system/tokens/colors';
 
 defineOptions({
   name: 'CsatRatings',
@@ -254,8 +251,8 @@ const progressItemsRatingsData = computed(() => {
     .reverse()
     .map(([key, value]) => ({
       label: labelMapping[key as keyof typeof labelMapping],
-      backgroundColor: colorPurple100,
-      color: colorPurple500,
+      backgroundColor: colorPurple2,
+      color: colorPurple9,
       value: value.value,
       description: `${formatPercentage(value.value, localeI18n.value)} (${formatNumber(value.full_value)})`,
     }));

--- a/src/components/insights/humanSupport/CommonWidgets/VolumePerTagAndQueue/PerQueue.vue
+++ b/src/components/insights/humanSupport/CommonWidgets/VolumePerTagAndQueue/PerQueue.vue
@@ -5,8 +5,8 @@
     :defaultTab="defaultTab"
     :mock="mock"
     :mockItemsCount="mockItemsCount"
-    :barColor="colorOrange7"
-    :barBackgroundColor="colorOrange2"
+    :barColor="colorBgOrangeStrong"
+    :barBackgroundColor="colorBgOrangePlain"
     itemKey="queues"
     itemLabelKey="queue_name"
     :formatFooterText="formatFooterText"
@@ -33,7 +33,10 @@ import volumePerQueueService from '@/services/api/resources/humanSupport/volumeP
 
 import { redirectToChatsConfig } from '@/utils/redirect';
 
-import { colorOrange7, colorOrange2 } from '@weni/unnnic-system/tokens/colors';
+import {
+  colorBgOrangeStrong,
+  colorBgOrangePlain,
+} from '@weni/unnnic-system/tokens/colors';
 
 import i18n from '@/utils/plugins/i18n';
 const { t, tc } = i18n.global;

--- a/src/components/insights/humanSupport/CommonWidgets/VolumePerTagAndQueue/PerQueue.vue
+++ b/src/components/insights/humanSupport/CommonWidgets/VolumePerTagAndQueue/PerQueue.vue
@@ -5,8 +5,8 @@
     :defaultTab="defaultTab"
     :mock="mock"
     :mockItemsCount="mockItemsCount"
-    :barColor="colorOrange500"
-    :barBackgroundColor="colorOrange100"
+    :barColor="colorOrange7"
+    :barBackgroundColor="colorOrange2"
     itemKey="queues"
     itemLabelKey="queue_name"
     :formatFooterText="formatFooterText"
@@ -33,10 +33,7 @@ import volumePerQueueService from '@/services/api/resources/humanSupport/volumeP
 
 import { redirectToChatsConfig } from '@/utils/redirect';
 
-import {
-  colorOrange500,
-  colorOrange100,
-} from '@weni/unnnic-system/tokens/colors';
+import { colorOrange7, colorOrange2 } from '@weni/unnnic-system/tokens/colors';
 
 import i18n from '@/utils/plugins/i18n';
 const { t, tc } = i18n.global;

--- a/src/components/insights/humanSupport/CommonWidgets/VolumePerTagAndQueue/VolumeBarListWidget.vue
+++ b/src/components/insights/humanSupport/CommonWidgets/VolumePerTagAndQueue/VolumeBarListWidget.vue
@@ -47,6 +47,10 @@ import type {
 import i18n from '@/utils/plugins/i18n';
 import { orderBy } from '@/utils/array';
 import { formatNumber } from '@/utils/numbers';
+import {
+  colorBgBluePlain,
+  colorBgBlueStrong,
+} from '@weni/unnnic-system/tokens/colors';
 
 const { t } = i18n.global;
 
@@ -101,8 +105,8 @@ const props = withDefaults(defineProps<VolumeBarListWidgetProps>(), {
   showConfig: false,
   setupTitle: '',
   setupDescription: '',
-  barColor: '#3182CE',
-  barBackgroundColor: '#E5EEF9',
+  barColor: colorBgBlueStrong,
+  barBackgroundColor: colorBgBluePlain,
 });
 
 const tabsList = computed(() => props.tabs(props.context));

--- a/src/components/insights/humanSupport/Header/FiltersDropdown.vue
+++ b/src/components/insights/humanSupport/Header/FiltersDropdown.vue
@@ -196,7 +196,7 @@ const titleButton = computed(() => {
     width: 400px;
     display: flex;
     flex-wrap: wrap;
-    gap: $unnnic-spacing-md;
+    gap: $unnnic-space-6;
     padding: $unnnic-space-3 $unnnic-space-2;
   }
 
@@ -204,14 +204,14 @@ const titleButton = computed(() => {
     width: 100%;
     display: flex;
     flex-direction: column;
-    gap: $unnnic-spacing-nano;
+    gap: $unnnic-space-1;
   }
 
   &__footer {
     width: 100%;
     display: flex;
     justify-content: space-between;
-    gap: $unnnic-spacing-sm;
+    gap: $unnnic-space-4;
 
     &-button {
       width: 100%;

--- a/src/components/insights/humanSupport/Monitoring/DetailedMonitoring.vue
+++ b/src/components/insights/humanSupport/Monitoring/DetailedMonitoring.vue
@@ -150,8 +150,8 @@ const filterType = computed(() => {
   gap: $unnnic-space-6;
 
   border-radius: $unnnic-radius-2;
-  border: 1px solid $unnnic-color-neutral-soft;
-  background: $unnnic-color-background-white;
+  border: 1px solid $unnnic-color-gray-2;
+  background: $unnnic-color-gray-0;
 
   &__title {
     font: $unnnic-font-display-2;

--- a/src/components/insights/templateMessages/QualityTemplateMessageFlag.vue
+++ b/src/components/insights/templateMessages/QualityTemplateMessageFlag.vue
@@ -36,10 +36,7 @@ const getStatusLabel = () => {
 .quality-template-message-flag {
   display: flex;
   &__text {
-    font-family: $unnnic-font-family;
-    font-size: 14px;
-    font-weight: $unnnic-font-weight-bold;
-    line-height: 22px;
+    font: $unnnic-font-action;
   }
   .info {
     margin-top: $unnnic-space-1;

--- a/src/components/insights/templateMessages/QualityTemplateMessageFlag.vue
+++ b/src/components/insights/templateMessages/QualityTemplateMessageFlag.vue
@@ -36,26 +36,26 @@ const getStatusLabel = () => {
 .quality-template-message-flag {
   display: flex;
   &__text {
-    font-family: $unnnic-font-family-secondary;
+    font-family: $unnnic-font-family;
     font-size: 14px;
     font-weight: $unnnic-font-weight-bold;
     line-height: 22px;
   }
   .info {
-    margin-top: $unnnic-spacing-nano;
-    margin-left: $unnnic-spacing-nano;
+    margin-top: $unnnic-space-1;
+    margin-left: $unnnic-space-1;
   }
   &--approved {
-    color: $unnnic-color-aux-green-500;
+    color: $unnnic-color-green-7;
   }
   &--pending {
-    color: $unnnic-color-aux-orange-500;
+    color: $unnnic-color-orange-7;
   }
   &--rejected {
-    color: $unnnic-color-aux-red-500;
+    color: $unnnic-color-red-7;
   }
   &--disabled {
-    color: $unnnic-color-aux-red-500;
+    color: $unnnic-color-red-7;
   }
 }
 </style>

--- a/src/components/insights/templateMessages/SearchTemplateMessagesModal.vue
+++ b/src/components/insights/templateMessages/SearchTemplateMessagesModal.vue
@@ -218,13 +218,13 @@ onMounted(() => searchTemplates());
 .search-template-messages-modal {
   &__filters-container {
     display: flex;
-    gap: $unnnic-spacing-xs;
+    gap: $unnnic-space-2;
     .filter {
       width: 100%;
     }
   }
   &__table-container {
-    margin-top: $unnnic-spacing-md;
+    margin-top: $unnnic-space-6;
     :deep(.table-pagination) {
       display: none;
     }
@@ -232,8 +232,8 @@ onMounted(() => searchTemplates());
   &__table-pagination {
     display: flex;
     justify-content: end;
-    padding: $unnnic-spacing-xs 0;
-    gap: $unnnic-spacing-nano;
+    padding: $unnnic-space-2 0;
+    gap: $unnnic-space-1;
   }
 }
 </style>

--- a/src/components/insights/widgets/CrosstabWidget.vue
+++ b/src/components/insights/widgets/CrosstabWidget.vue
@@ -64,9 +64,9 @@ import SeeAllDrawer from '../conversations/CustomizableWidget/SeeAllDrawer.vue';
 
 import { getWidgetCrosstabTooltip } from '@/utils/widget';
 import {
-  colorBlue8,
-  colorOrange7,
-  colorGray1,
+  colorBgBlueStrong,
+  colorBgOrangeStrong,
+  colorBgBaseSoft,
 } from '@weni/unnnic-system/tokens/colors';
 
 const customWidgetsStore = useCustomWidgets();
@@ -112,7 +112,7 @@ const legendItems = computed(() => {
   return eventsKeys.map((key, index) => {
     return {
       title: `${key.charAt(0).toUpperCase() + key.slice(1)}`,
-      color: index === 0 ? colorBlue8 : colorOrange7,
+      color: index === 0 ? colorBgBlueStrong : colorBgOrangeStrong,
     };
   });
 });
@@ -122,8 +122,10 @@ const formattedData = computed(() => {
     const eventsKeys = Object.keys(item.events);
     return {
       label: item.title,
-      color: colorBlue8,
-      backgroundColor: eventsKeys.length ? colorOrange7 : colorGray1,
+      color: colorBgBlueStrong,
+      backgroundColor: eventsKeys.length
+        ? colorBgOrangeStrong
+        : colorBgBaseSoft,
       description: `${item.total}`,
       value: item.events[eventsKeys[0]]?.value || 0,
       tooltip: getWidgetCrosstabTooltip(item.events),

--- a/src/components/insights/widgets/CrosstabWidget.vue
+++ b/src/components/insights/widgets/CrosstabWidget.vue
@@ -176,7 +176,7 @@ const formattedData = computed(() => {
 
     &__count {
       font: $unnnic-font-body;
-      color: $unnnic-color-gray-5;
+      color: $unnnic-color-fg-muted;
     }
     &__see-more {
       font: $unnnic-font-display-4;

--- a/src/components/insights/widgets/CrosstabWidget.vue
+++ b/src/components/insights/widgets/CrosstabWidget.vue
@@ -64,9 +64,9 @@ import SeeAllDrawer from '../conversations/CustomizableWidget/SeeAllDrawer.vue';
 
 import { getWidgetCrosstabTooltip } from '@/utils/widget';
 import {
-  colorBlue500,
-  colorOrange500,
-  colorGray50,
+  colorBlue8,
+  colorOrange7,
+  colorGray1,
 } from '@weni/unnnic-system/tokens/colors';
 
 const customWidgetsStore = useCustomWidgets();
@@ -112,7 +112,7 @@ const legendItems = computed(() => {
   return eventsKeys.map((key, index) => {
     return {
       title: `${key.charAt(0).toUpperCase() + key.slice(1)}`,
-      color: index === 0 ? colorBlue500 : colorOrange500,
+      color: index === 0 ? colorBlue8 : colorOrange7,
     };
   });
 });
@@ -122,8 +122,8 @@ const formattedData = computed(() => {
     const eventsKeys = Object.keys(item.events);
     return {
       label: item.title,
-      color: colorBlue500,
-      backgroundColor: eventsKeys.length ? colorOrange500 : colorGray50,
+      color: colorBlue8,
+      backgroundColor: eventsKeys.length ? colorOrange7 : colorGray1,
       description: `${item.total}`,
       value: item.events[eventsKeys[0]]?.value || 0,
       tooltip: getWidgetCrosstabTooltip(item.events),

--- a/src/components/insights/widgets/CrosstabWidget.vue
+++ b/src/components/insights/widgets/CrosstabWidget.vue
@@ -160,7 +160,7 @@ const formattedData = computed(() => {
         &__color {
           width: $unnnic-space-6;
           height: $unnnic-space-2;
-          border-radius: $unnnic-border-radius-pill;
+          border-radius: $unnnic-radius-full;
         }
         &__label {
           color: $unnnic-color-fg-emphasized;
@@ -176,7 +176,7 @@ const formattedData = computed(() => {
 
     &__count {
       font: $unnnic-font-body;
-      color: $unnnic-color-neutral-clean;
+      color: $unnnic-color-gray-5;
     }
     &__see-more {
       font: $unnnic-font-display-4;

--- a/src/components/insights/widgets/ExpansiveWidget.vue
+++ b/src/components/insights/widgets/ExpansiveWidget.vue
@@ -169,14 +169,14 @@ watch(currentExpansiveWidgetFilters, () => {
 
   display: grid;
 
-  gap: $unnnic-spacing-sm;
+  gap: $unnnic-space-4;
 
   & > [class*='chart'] {
-    border-radius: $unnnic-spacing-nano;
-    border: $unnnic-border-width-thinner solid $unnnic-color-neutral-soft;
+    border-radius: $unnnic-space-1;
+    border: 1px solid $unnnic-color-gray-2;
 
     :deep([class*='title']) {
-      font-size: $unnnic-font-size-body-lg;
+      font-size: $unnnic-font-size;
     }
   }
 }

--- a/src/components/insights/widgets/ExpansiveWidget.vue
+++ b/src/components/insights/widgets/ExpansiveWidget.vue
@@ -176,7 +176,7 @@ watch(currentExpansiveWidgetFilters, () => {
     border: 1px solid $unnnic-color-gray-2;
 
     :deep([class*='title']) {
-      font-size: $unnnic-font-size;
+      font: $unnnic-font-display-4;
     }
   }
 }

--- a/src/components/insights/widgets/HumanServiceAgentsTable/AgentStatus.vue
+++ b/src/components/insights/widgets/HumanServiceAgentsTable/AgentStatus.vue
@@ -75,15 +75,10 @@ const renderLabel = computed(() => {
 }
 
 .agent-status-label {
-  font-family: $unnnic-font-family;
+  font: $unnnic-font-body;
   color: $unnnic-color-gray-10;
   overflow: hidden;
   text-overflow: ellipsis;
-
-  font-size: 14px;
-  font-style: normal;
-  font-weight: $unnnic-font-weight-regular;
-  line-height: 14px + 8px;
 }
 
 .agent-status {

--- a/src/components/insights/widgets/HumanServiceAgentsTable/AgentStatus.vue
+++ b/src/components/insights/widgets/HumanServiceAgentsTable/AgentStatus.vue
@@ -71,19 +71,19 @@ const renderLabel = computed(() => {
 .agent-status-container {
   display: flex;
   align-items: center;
-  gap: $unnnic-spacing-nano;
+  gap: $unnnic-space-1;
 }
 
 .agent-status-label {
-  font-family: $unnnic-font-family-secondary;
-  color: $unnnic-color-neutral-dark;
+  font-family: $unnnic-font-family;
+  color: $unnnic-color-gray-10;
   overflow: hidden;
   text-overflow: ellipsis;
 
-  font-size: $unnnic-font-size-body-gt;
+  font-size: 14px;
   font-style: normal;
   font-weight: $unnnic-font-weight-regular;
-  line-height: $unnnic-font-size-body-gt + $unnnic-line-height-md;
+  line-height: 14px + 8px;
 }
 
 .agent-status {
@@ -95,13 +95,13 @@ const renderLabel = computed(() => {
 
   &.agent-status--offline {
     :deep(.primary) {
-      fill: $unnnic-color-neutral-cleanest;
+      fill: $unnnic-color-gray-4;
     }
   }
 
   &.agent-status--custom {
     :deep(.primary) {
-      fill: $unnnic-color-aux-orange-500;
+      fill: $unnnic-color-orange-7;
     }
   }
 }

--- a/src/components/insights/widgets/HumanServiceAgentsTable/index.vue
+++ b/src/components/insights/widgets/HumanServiceAgentsTable/index.vue
@@ -407,11 +407,11 @@ export default {
     }
 
     span[data-testid='arrow-asc-icon'] {
-      color: $unnnic-color-gray-7;
+      color: $unnnic-color-fg-muted;
     }
 
     span[data-testid='arrow-desc-icon'] {
-      color: $unnnic-color-gray-7;
+      color: $unnnic-color-fg-muted;
     }
   }
 

--- a/src/components/insights/widgets/HumanServiceAgentsTable/index.vue
+++ b/src/components/insights/widgets/HumanServiceAgentsTable/index.vue
@@ -391,11 +391,8 @@ export default {
     justify-content: space-between;
 
     .header__title {
-      font-family: $unnnic-font-family;
-      font-size: $unnnic-font-size;
+      font: $unnnic-font-display-3;
       color: $unnnic-color-gray-12;
-      font-weight: $unnnic-font-weight-bold;
-      line-height: 24px;
     }
   }
 

--- a/src/components/insights/widgets/HumanServiceAgentsTable/index.vue
+++ b/src/components/insights/widgets/HumanServiceAgentsTable/index.vue
@@ -368,34 +368,34 @@ export default {
 
 <style lang="scss" scoped>
 .widget-human-service-agents {
-  border: 1px solid $unnnic-color-neutral-soft;
-  box-shadow: $unnnic-shadow-level-far;
+  border: 1px solid $unnnic-color-gray-2;
+  box-shadow: $unnnic-shadow-2;
 
-  padding: $unnnic-spacing-sm;
+  padding: $unnnic-space-4;
 
   height: 100%;
 
-  background-color: $unnnic-color-background-snow;
-  border-radius: $unnnic-border-radius-sm;
+  background-color: $unnnic-color-gray-0;
+  border-radius: $unnnic-radius-1;
 
   display: flex;
   flex-direction: column;
-  gap: $unnnic-spacing-sm;
+  gap: $unnnic-space-4;
 
   overflow: auto;
 
   &__header {
     display: flex;
     align-items: center;
-    gap: $unnnic-spacing-stack-xs;
+    gap: $unnnic-space-2;
     justify-content: space-between;
 
     .header__title {
-      font-family: $unnnic-font-family-secondary;
+      font-family: $unnnic-font-family;
       font-size: $unnnic-font-size;
-      color: $unnnic-color-neutral-darkest;
+      color: $unnnic-color-gray-12;
       font-weight: $unnnic-font-weight-bold;
-      line-height: $unnnic-font-size-title-md;
+      line-height: 24px;
     }
   }
 
@@ -405,16 +405,16 @@ export default {
 
     :hover.unnnic-table-next__body-row {
       cursor: pointer;
-      background-color: $unnnic-color-neutral-lightest;
+      background-color: $unnnic-color-gray-1;
       font-weight: $unnnic-font-weight-bold;
     }
 
     span[data-testid='arrow-asc-icon'] {
-      color: $unnnic-color-neutral-cloudy;
+      color: $unnnic-color-gray-7;
     }
 
     span[data-testid='arrow-desc-icon'] {
-      color: $unnnic-color-neutral-cloudy;
+      color: $unnnic-color-gray-7;
     }
   }
 

--- a/src/components/insights/widgets/HumanServiceAgentsTable/index.vue
+++ b/src/components/insights/widgets/HumanServiceAgentsTable/index.vue
@@ -369,7 +369,7 @@ export default {
 <style lang="scss" scoped>
 .widget-human-service-agents {
   border: 1px solid $unnnic-color-gray-2;
-  box-shadow: $unnnic-shadow-2;
+  box-shadow: $unnnic-shadow-1;
 
   padding: $unnnic-space-4;
 

--- a/src/components/insights/widgets/MetaTemplateMessage.vue
+++ b/src/components/insights/widgets/MetaTemplateMessage.vue
@@ -172,8 +172,8 @@ const getButtonIcon = (buttonType) => {
   display: flex;
   flex-direction: column;
   height: 100%;
-  border: 1px solid $unnnic-color-neutral-soft;
-  border-radius: $unnnic-border-radius-sm;
+  border: 1px solid $unnnic-color-gray-2;
+  border-radius: $unnnic-radius-1;
 
   &__loading {
     height: 100%;
@@ -185,8 +185,8 @@ const getButtonIcon = (buttonType) => {
   &__header {
     display: flex;
     flex-direction: column;
-    gap: $unnnic-spacing-xs;
-    padding: $unnnic-spacing-sm;
+    gap: $unnnic-space-2;
+    padding: $unnnic-space-4;
   }
 
   :deep(.unnnic-tooltip-label) {
@@ -197,13 +197,13 @@ const getButtonIcon = (buttonType) => {
     &-title {
       display: flex;
       justify-content: space-between;
-      gap: $unnnic-spacing-nano;
+      gap: $unnnic-space-1;
       align-items: end;
-      color: $unnnic-color-neutral-dark;
+      color: $unnnic-color-gray-10;
 
-      font-family: $unnnic-font-family-secondary;
-      font-size: $unnnic-font-size-body-gt;
-      line-height: $unnnic-font-size-body-gt + $unnnic-line-height-md;
+      font-family: $unnnic-font-family;
+      font-size: 14px;
+      line-height: 14px + 8px;
 
       &__name {
         margin-right: auto;
@@ -214,17 +214,17 @@ const getButtonIcon = (buttonType) => {
       display: flex;
       flex-direction: column;
       height: 100%;
-      padding: $unnnic-spacing-sm;
+      padding: $unnnic-space-4;
     }
   }
 
   &__preview {
     display: flex;
     flex-direction: column;
-    padding: $unnnic-spacing-xs;
+    padding: $unnnic-space-2;
     gap: 5.35px;
-    background-color: $unnnic-color-neutral-white;
-    border-radius: $unnnic-border-radius-sm;
+    background-color: $unnnic-color-gray-0;
+    border-radius: $unnnic-radius-1;
 
     &-image {
       object-fit: cover;
@@ -232,36 +232,36 @@ const getButtonIcon = (buttonType) => {
     }
 
     &-title {
-      color: $unnnic-color-neutral-black;
-      font-family: $unnnic-font-family-secondary;
+      color: $unnnic-color-gray-13;
+      font-family: $unnnic-font-family;
       font-size: 10.692px;
       font-weight: $unnnic-font-weight-bold;
       line-height: 16.037px;
     }
 
     &-text {
-      color: $unnnic-color-neutral-black;
-      font-family: $unnnic-font-family-secondary;
+      color: $unnnic-color-gray-13;
+      font-family: $unnnic-font-family;
       font-size: 10.692px;
       line-height: 16.037px;
       word-break: break-word;
     }
 
     &-hint {
-      color: $unnnic-color-neutral-clean;
+      color: $unnnic-color-gray-5;
       text-align: right;
-      font-family: $unnnic-font-family-secondary;
+      font-family: $unnnic-font-family;
       font-size: 9.355px;
       line-height: 14.701px;
     }
 
     &-link {
       display: flex;
-      gap: $unnnic-spacing-nano;
+      gap: $unnnic-space-1;
       color: $unnnic-color-aux-blue-500;
       align-items: center;
       justify-content: center;
-      border-top: 1px solid $unnnic-color-neutral-soft;
+      border-top: 1px solid $unnnic-color-gray-2;
       padding: 5.35px 0;
     }
   }
@@ -269,7 +269,7 @@ const getButtonIcon = (buttonType) => {
   &__edit {
     display: flex;
     width: 100%;
-    padding: $unnnic-spacing-sm;
+    padding: $unnnic-space-4;
     background-color: $unnnic-color-background-grass;
     &-button {
       width: 100%;
@@ -277,10 +277,10 @@ const getButtonIcon = (buttonType) => {
   }
 
   &__preview-label {
-    font-family: $unnnic-font-family-secondary;
-    font-size: $unnnic-font-size-body-lg;
+    font-family: $unnnic-font-family;
+    font-size: $unnnic-font-size;
     font-weight: $unnnic-font-weight-bold;
-    line-height: $unnnic-font-size-body-lg + $unnnic-font-size-body-sm;
+    line-height: $unnnic-font-size + 8px;
   }
 }
 </style>

--- a/src/components/insights/widgets/MetaTemplateMessage.vue
+++ b/src/components/insights/widgets/MetaTemplateMessage.vue
@@ -246,7 +246,7 @@ const getButtonIcon = (buttonType) => {
     }
 
     &-hint {
-      color: $unnnic-color-gray-5;
+      color: $unnnic-color-fg-muted;
       text-align: right;
       font-family: $unnnic-font-family;
       font-size: 9.355px;

--- a/src/components/insights/widgets/MetaTemplateMessage.vue
+++ b/src/components/insights/widgets/MetaTemplateMessage.vue
@@ -201,9 +201,7 @@ const getButtonIcon = (buttonType) => {
       align-items: end;
       color: $unnnic-color-gray-10;
 
-      font-family: $unnnic-font-family;
-      font-size: 14px;
-      line-height: 14px + 8px;
+      font: $unnnic-font-body;
 
       &__name {
         margin-right: auto;
@@ -277,10 +275,7 @@ const getButtonIcon = (buttonType) => {
   }
 
   &__preview-label {
-    font-family: $unnnic-font-family;
-    font-size: $unnnic-font-size;
-    font-weight: $unnnic-font-weight-bold;
-    line-height: $unnnic-font-size + 8px;
+    font: $unnnic-font-display-3;
   }
 }
 </style>

--- a/src/components/insights/widgets/ProgressWidget.vue
+++ b/src/components/insights/widgets/ProgressWidget.vue
@@ -200,21 +200,21 @@ const isWarningMessage = computed(() => {
 .progress-widget {
   width: 100%;
   display: flex;
-  padding: $unnnic-spacing-md;
+  padding: $unnnic-space-6;
   flex-direction: column;
-  gap: $unnnic-spacing-sm;
+  gap: $unnnic-space-4;
   flex: 1 0 0;
   align-self: stretch;
 
-  border-radius: $unnnic-spacing-xs;
-  border: $unnnic-border-width-thinner solid $unnnic-color-neutral-soft;
-  background: $unnnic-color-neutral-white;
+  border-radius: $unnnic-space-2;
+  border: 1px solid $unnnic-color-gray-2;
+  background: $unnnic-color-gray-0;
 
   &__content {
     .content__card {
       display: flex;
-      min-height: calc(114px + $unnnic-spacing-sm);
-      padding-bottom: $unnnic-spacing-sm;
+      min-height: calc(114px + $unnnic-space-4);
+      padding-bottom: $unnnic-space-4;
     }
   }
 
@@ -230,12 +230,12 @@ const isWarningMessage = computed(() => {
     }
 
     .footer__text {
-      color: $unnnic-color-neutral-clean;
-      font-family: $unnnic-font-family-secondary;
-      font-size: $unnnic-font-size-body-gt;
+      color: $unnnic-color-gray-5;
+      font-family: $unnnic-font-family;
+      font-size: 14px;
       font-weight: $unnnic-font-weight-regular;
       font-style: normal;
-      line-height: $unnnic-font-size-body-gt + $unnnic-line-height-md;
+      line-height: 14px + 8px;
     }
 
     &-button {
@@ -246,7 +246,7 @@ const isWarningMessage = computed(() => {
   &__skeleton-container {
     display: flex;
     flex-direction: column;
-    gap: $unnnic-spacing-nano;
+    gap: $unnnic-space-1;
   }
 }
 </style>

--- a/src/components/insights/widgets/ProgressWidget.vue
+++ b/src/components/insights/widgets/ProgressWidget.vue
@@ -230,7 +230,7 @@ const isWarningMessage = computed(() => {
     }
 
     .footer__text {
-      color: $unnnic-color-gray-5;
+      color: $unnnic-color-fg-muted;
       font: $unnnic-font-body;
     }
 

--- a/src/components/insights/widgets/ProgressWidget.vue
+++ b/src/components/insights/widgets/ProgressWidget.vue
@@ -231,11 +231,7 @@ const isWarningMessage = computed(() => {
 
     .footer__text {
       color: $unnnic-color-gray-5;
-      font-family: $unnnic-font-family;
-      font-size: 14px;
-      font-weight: $unnnic-font-weight-regular;
-      font-style: normal;
-      line-height: 14px + 8px;
+      font: $unnnic-font-body;
     }
 
     &-button {

--- a/src/components/insights/widgets/SalesFunnelWidget.vue
+++ b/src/components/insights/widgets/SalesFunnelWidget.vue
@@ -65,10 +65,7 @@ import {
   formatCurrency,
 } from '@/utils/numbers';
 import i18n from '@/utils/plugins/i18n';
-import {
-  colorOrange500,
-  colorOrange200,
-} from '@weni/unnnic-system/tokens/colors';
+import { colorOrange7, colorOrange3 } from '@weni/unnnic-system/tokens/colors';
 
 defineOptions({
   name: 'SalesFunnelWidget',
@@ -110,7 +107,7 @@ const graphData = computed(() => {
     description: i18n.global.t(
       'conversations_dashboard.sales_funnel_widget.captured_leads',
     ),
-    color: colorOrange500,
+    color: colorOrange7,
   };
   const purchasesData = {
     title: formatPercentage(
@@ -124,7 +121,7 @@ const graphData = computed(() => {
     description: i18n.global.t(
       'conversations_dashboard.sales_funnel_widget.purchases_made',
     ),
-    color: colorOrange200,
+    color: colorOrange3,
   };
   return [leadsData, purchasesData];
 });

--- a/src/components/insights/widgets/SalesFunnelWidget.vue
+++ b/src/components/insights/widgets/SalesFunnelWidget.vue
@@ -65,7 +65,10 @@ import {
   formatCurrency,
 } from '@/utils/numbers';
 import i18n from '@/utils/plugins/i18n';
-import { colorOrange7, colorOrange3 } from '@weni/unnnic-system/tokens/colors';
+import {
+  colorBgOrangeStrong,
+  colorBgOrangePlain,
+} from '@weni/unnnic-system/tokens/colors';
 
 defineOptions({
   name: 'SalesFunnelWidget',
@@ -107,7 +110,7 @@ const graphData = computed(() => {
     description: i18n.global.t(
       'conversations_dashboard.sales_funnel_widget.captured_leads',
     ),
-    color: colorOrange7,
+    color: colorBgOrangeStrong,
   };
   const purchasesData = {
     title: formatPercentage(
@@ -121,7 +124,7 @@ const graphData = computed(() => {
     description: i18n.global.t(
       'conversations_dashboard.sales_funnel_widget.purchases_made',
     ),
-    color: colorOrange3,
+    color: colorBgOrangePlain,
   };
   return [leadsData, purchasesData];
 });

--- a/src/components/insights/widgets/SalesFunnelWidget.vue
+++ b/src/components/insights/widgets/SalesFunnelWidget.vue
@@ -151,8 +151,8 @@ const graphData = computed(() => {
     padding: $unnnic-space-6;
     width: 100%;
 
-    border-radius: $unnnic-border-radius-md;
-    border: 1px solid $unnnic-color-neutral-soft;
+    border-radius: $unnnic-radius-2;
+    border: 1px solid $unnnic-color-gray-2;
     background: $unnnic-color-bg-base;
 
     &-item {

--- a/src/components/insights/widgets/SingleTable.vue
+++ b/src/components/insights/widgets/SingleTable.vue
@@ -57,12 +57,7 @@ const paginationCssToken = computed(() =>
 
   &__title {
     color: $unnnic-color-gray-10;
-
-    font-family: $unnnic-font-family;
-    font-size: $unnnic-font-size;
-    font-style: normal;
-    font-weight: $unnnic-font-weight-bold;
-    line-height: 16px + 8px;
+    font: $unnnic-font-display-3;
   }
 
   &__table {

--- a/src/components/insights/widgets/SingleTable.vue
+++ b/src/components/insights/widgets/SingleTable.vue
@@ -56,13 +56,13 @@ const paginationCssToken = computed(() =>
   gap: 10px;
 
   &__title {
-    color: $unnnic-color-neutral-dark;
+    color: $unnnic-color-gray-10;
 
-    font-family: $unnnic-font-family-secondary;
-    font-size: $unnnic-font-size-body-lg;
+    font-family: $unnnic-font-family;
+    font-size: $unnnic-font-size;
     font-style: normal;
     font-weight: $unnnic-font-weight-bold;
-    line-height: $unnnic-line-height-large + $unnnic-line-height-medium;
+    line-height: 16px + 8px;
   }
 
   &__table {

--- a/src/components/insights/widgets/TableGroup.vue
+++ b/src/components/insights/widgets/TableGroup.vue
@@ -270,7 +270,7 @@ export default {
 
     :hover.unnnic-table-next__body-row {
       cursor: pointer;
-      background-color: $unnnic-color-neutral-lightest;
+      background-color: $unnnic-color-gray-1;
       font-weight: $unnnic-font-weight-bold;
     }
   }

--- a/src/components/insights/widgets/conversational/ConversationalAdd.vue
+++ b/src/components/insights/widgets/conversational/ConversationalAdd.vue
@@ -16,10 +16,7 @@
 import ProgressWidget from '@/components/insights/widgets/ProgressWidget.vue';
 import AddCustomizableWidget from '@/components/insights/conversations/CustomizableWidget/AddCustomizableWidget.vue';
 import { useConversational } from '@/store/modules/conversational/conversational';
-import {
-  colorPurple500,
-  colorPurple100,
-} from '@weni/unnnic-system/tokens/colors';
+import { colorPurple9, colorPurple2 } from '@weni/unnnic-system/tokens/colors';
 
 const conversational = useConversational();
 const { setIsDrawerCustomizableOpen } = conversational;
@@ -32,32 +29,32 @@ const MOCK_DATA = [
   {
     text: '🤩 Very satisfied',
     value: 57,
-    color: colorPurple500,
-    backgroundColor: colorPurple100,
+    color: colorPurple9,
+    backgroundColor: colorPurple2,
   },
   {
     text: '😁 Satisfied',
     value: 25,
-    color: colorPurple500,
-    backgroundColor: colorPurple100,
+    color: colorPurple9,
+    backgroundColor: colorPurple2,
   },
   {
     text: '😐 Neutral',
     value: 12,
-    color: colorPurple500,
-    backgroundColor: colorPurple100,
+    color: colorPurple9,
+    backgroundColor: colorPurple2,
   },
   {
     text: '☹️ Dissatisfied',
     value: 5,
-    color: colorPurple500,
-    backgroundColor: colorPurple100,
+    color: colorPurple9,
+    backgroundColor: colorPurple2,
   },
   {
     text: '😡 Very dissatisfied',
     value: 1,
-    color: colorPurple500,
-    backgroundColor: colorPurple100,
+    color: colorPurple9,
+    backgroundColor: colorPurple2,
   },
 ];
 </script>

--- a/src/components/insights/widgets/conversational/ConversationalAdd.vue
+++ b/src/components/insights/widgets/conversational/ConversationalAdd.vue
@@ -16,7 +16,10 @@
 import ProgressWidget from '@/components/insights/widgets/ProgressWidget.vue';
 import AddCustomizableWidget from '@/components/insights/conversations/CustomizableWidget/AddCustomizableWidget.vue';
 import { useConversational } from '@/store/modules/conversational/conversational';
-import { colorPurple9, colorPurple2 } from '@weni/unnnic-system/tokens/colors';
+import {
+  colorBgPurpleStrong,
+  colorBgPurplePlain,
+} from '@weni/unnnic-system/tokens/colors';
 
 const conversational = useConversational();
 const { setIsDrawerCustomizableOpen } = conversational;
@@ -29,32 +32,32 @@ const MOCK_DATA = [
   {
     text: '🤩 Very satisfied',
     value: 57,
-    color: colorPurple9,
-    backgroundColor: colorPurple2,
+    color: colorBgPurpleStrong,
+    backgroundColor: colorBgPurplePlain,
   },
   {
     text: '😁 Satisfied',
     value: 25,
-    color: colorPurple9,
-    backgroundColor: colorPurple2,
+    color: colorBgPurpleStrong,
+    backgroundColor: colorBgPurplePlain,
   },
   {
     text: '😐 Neutral',
     value: 12,
-    color: colorPurple9,
-    backgroundColor: colorPurple2,
+    color: colorBgPurpleStrong,
+    backgroundColor: colorBgPurplePlain,
   },
   {
     text: '☹️ Dissatisfied',
     value: 5,
-    color: colorPurple9,
-    backgroundColor: colorPurple2,
+    color: colorBgPurpleStrong,
+    backgroundColor: colorBgPurplePlain,
   },
   {
     text: '😡 Very dissatisfied',
     value: 1,
-    color: colorPurple9,
-    backgroundColor: colorPurple2,
+    color: colorBgPurpleStrong,
+    backgroundColor: colorBgPurplePlain,
   },
 ];
 </script>

--- a/src/components/insights/widgets/conversational/ConversationalCsat.vue
+++ b/src/components/insights/widgets/conversational/ConversationalCsat.vue
@@ -57,10 +57,7 @@ import { useConversationalWidgets } from '@/store/modules/conversational/widgets
 import { useConversational } from '@/store/modules/conversational/conversational';
 import type { CsatResponse } from '@/services/api/resources/conversational/widgets';
 import { Tab } from '@/components/insights/conversations/BaseConversationWidget.vue';
-import {
-  colorPurple500,
-  colorPurple100,
-} from '@weni/unnnic-system/tokens/colors';
+import { colorPurple9, colorPurple2 } from '@weni/unnnic-system/tokens/colors';
 
 const { t } = useI18n();
 const route = useRoute();
@@ -168,8 +165,8 @@ const actions = computed(() => {
 
 const handleCsatWidgetData = (data: CsatResponse) => {
   const defaultColors = {
-    color: colorPurple500,
-    backgroundColor: colorPurple100,
+    color: colorPurple9,
+    backgroundColor: colorPurple2,
   };
 
   const formattedData = {

--- a/src/components/insights/widgets/conversational/ConversationalCsat.vue
+++ b/src/components/insights/widgets/conversational/ConversationalCsat.vue
@@ -57,7 +57,10 @@ import { useConversationalWidgets } from '@/store/modules/conversational/widgets
 import { useConversational } from '@/store/modules/conversational/conversational';
 import type { CsatResponse } from '@/services/api/resources/conversational/widgets';
 import { Tab } from '@/components/insights/conversations/BaseConversationWidget.vue';
-import { colorPurple9, colorPurple2 } from '@weni/unnnic-system/tokens/colors';
+import {
+  colorBgPurpleStrong,
+  colorBgPurplePlain,
+} from '@weni/unnnic-system/tokens/colors';
 
 const { t } = useI18n();
 const route = useRoute();
@@ -165,8 +168,8 @@ const actions = computed(() => {
 
 const handleCsatWidgetData = (data: CsatResponse) => {
   const defaultColors = {
-    color: colorPurple9,
-    backgroundColor: colorPurple2,
+    color: colorBgPurpleStrong,
+    backgroundColor: colorBgPurplePlain,
   };
 
   const formattedData = {

--- a/src/components/insights/widgets/conversational/ConversationalCustom.vue
+++ b/src/components/insights/widgets/conversational/ConversationalCustom.vue
@@ -43,7 +43,10 @@ import SeeAllDrawer from '@/components/insights/conversations/CustomizableWidget
 import { useCustomWidgets } from '@/store/modules/conversational/customWidgets';
 import { useConversational } from '@/store/modules/conversational/conversational';
 import type { CustomWidgetResponse } from '@/services/api/resources/conversational/widgets';
-import { colorBlue8, colorBlue2 } from '@weni/unnnic-system/tokens/colors';
+import {
+  colorBgBlueStrong,
+  colorBgBluePlain,
+} from '@weni/unnnic-system/tokens/colors';
 
 interface Props {
   uuid: string;
@@ -131,8 +134,8 @@ const actions = computed(() => {
 
 const handleCustomWidgetData = (data: CustomWidgetResponse) => {
   const defaultColors = {
-    color: colorBlue8,
-    backgroundColor: colorBlue2,
+    color: colorBgBlueStrong,
+    backgroundColor: colorBgBluePlain,
   };
 
   if (data?.results?.length === 0) {

--- a/src/components/insights/widgets/conversational/ConversationalCustom.vue
+++ b/src/components/insights/widgets/conversational/ConversationalCustom.vue
@@ -43,7 +43,7 @@ import SeeAllDrawer from '@/components/insights/conversations/CustomizableWidget
 import { useCustomWidgets } from '@/store/modules/conversational/customWidgets';
 import { useConversational } from '@/store/modules/conversational/conversational';
 import type { CustomWidgetResponse } from '@/services/api/resources/conversational/widgets';
-import { colorBlue500, colorBlue100 } from '@weni/unnnic-system/tokens/colors';
+import { colorBlue8, colorBlue2 } from '@weni/unnnic-system/tokens/colors';
 
 interface Props {
   uuid: string;
@@ -131,8 +131,8 @@ const actions = computed(() => {
 
 const handleCustomWidgetData = (data: CustomWidgetResponse) => {
   const defaultColors = {
-    color: colorBlue500,
-    backgroundColor: colorBlue100,
+    color: colorBlue8,
+    backgroundColor: colorBlue2,
   };
 
   if (data?.results?.length === 0) {

--- a/src/components/insights/widgets/conversational/ConversationalNps.vue
+++ b/src/components/insights/widgets/conversational/ConversationalNps.vue
@@ -59,12 +59,12 @@ import { useConversational } from '@/store/modules/conversational/conversational
 import type { NpsResponse } from '@/services/api/resources/conversational/widgets';
 import { Tab } from '@/components/insights/conversations/BaseConversationWidget.vue';
 import {
-  colorGreen8,
-  colorGreen1,
-  colorOrange8,
-  colorOrange2,
-  colorRed9,
-  colorRed2,
+  colorBgGreenStrong,
+  colorBgGreenPlain,
+  colorBgOrangeStrong,
+  colorBgOrangePlain,
+  colorBgRedStrong,
+  colorBgRedPlain,
 } from '@weni/unnnic-system/tokens/colors';
 
 const { t } = useI18n();
@@ -175,16 +175,16 @@ const actions = computed(() => {
 const handleNpsWidgetData = (data: NpsResponse) => {
   const colors = {
     promoters: {
-      color: colorGreen8,
-      backgroundColor: colorGreen1,
+      color: colorBgGreenStrong,
+      backgroundColor: colorBgGreenPlain,
     },
     passives: {
-      color: colorOrange8,
-      backgroundColor: colorOrange2,
+      color: colorBgOrangeStrong,
+      backgroundColor: colorBgOrangePlain,
     },
     detractors: {
-      color: colorRed9,
-      backgroundColor: colorRed2,
+      color: colorBgRedStrong,
+      backgroundColor: colorBgRedPlain,
     },
   };
 

--- a/src/components/insights/widgets/conversational/ConversationalNps.vue
+++ b/src/components/insights/widgets/conversational/ConversationalNps.vue
@@ -59,12 +59,12 @@ import { useConversational } from '@/store/modules/conversational/conversational
 import type { NpsResponse } from '@/services/api/resources/conversational/widgets';
 import { Tab } from '@/components/insights/conversations/BaseConversationWidget.vue';
 import {
-  colorGreen500,
-  colorGreen100,
-  colorOrange600,
-  colorOrange100,
-  colorRed500,
-  colorRed100,
+  colorGreen8,
+  colorGreen1,
+  colorOrange8,
+  colorOrange2,
+  colorRed9,
+  colorRed2,
 } from '@weni/unnnic-system/tokens/colors';
 
 const { t } = useI18n();
@@ -175,16 +175,16 @@ const actions = computed(() => {
 const handleNpsWidgetData = (data: NpsResponse) => {
   const colors = {
     promoters: {
-      color: colorGreen500,
-      backgroundColor: colorGreen100,
+      color: colorGreen8,
+      backgroundColor: colorGreen1,
     },
     passives: {
-      color: colorOrange600,
-      backgroundColor: colorOrange100,
+      color: colorOrange8,
+      backgroundColor: colorOrange2,
     },
     detractors: {
-      color: colorRed500,
-      backgroundColor: colorRed100,
+      color: colorRed9,
+      backgroundColor: colorRed2,
     },
   };
 

--- a/src/components/insights/widgets/conversational/__tests__/ConversationalAdd.spec.js
+++ b/src/components/insights/widgets/conversational/__tests__/ConversationalAdd.spec.js
@@ -66,8 +66,8 @@ describe('ConversationalAdd', () => {
       expect(mockData).toHaveLength(5);
       expect(mockData[0].text).toContain('🤩');
       expect(mockData[0].value).toBe(57);
-      expect(mockData[0].color).toBe('#8D72E0'); // colorPurple500
-      expect(mockData[0].backgroundColor).toBe('#EEECFB'); // colorPurple100
+      expect(mockData[0].color).toBe('#9C56F3'); // colorPurple500
+      expect(mockData[0].backgroundColor).toBe('#F5EAFE'); // colorPurple100
     });
   });
 });

--- a/src/components/insights/widgets/conversational/__tests__/ConversationalAdd.spec.js
+++ b/src/components/insights/widgets/conversational/__tests__/ConversationalAdd.spec.js
@@ -66,8 +66,8 @@ describe('ConversationalAdd', () => {
       expect(mockData).toHaveLength(5);
       expect(mockData[0].text).toContain('🤩');
       expect(mockData[0].value).toBe(57);
-      expect(mockData[0].color).toBe('#9C56F3'); // colorPurple500
-      expect(mockData[0].backgroundColor).toBe('#F5EAFE'); // colorPurple100
+      expect(mockData[0].color).toBe('#AD71F8'); // colorBgPurpleStrong
+      expect(mockData[0].backgroundColor).toBe('#EDDCFE'); // colorBgPurplePlain
     });
   });
 });

--- a/src/components/insights/widgets/layout/CardWidgetContainer.vue
+++ b/src/components/insights/widgets/layout/CardWidgetContainer.vue
@@ -115,7 +115,7 @@ const handleTabChange = (tab: string) => {
   align-self: stretch;
 
   border-radius: $unnnic-radius-2;
-  border: 1px solid $unnnic-color-border-soft;
+  border: 1px solid $unnnic-color-border-base;
   background: $unnnic-color-bg-base;
 
   &__header {
@@ -124,7 +124,7 @@ const handleTabChange = (tab: string) => {
     align-items: center;
 
     .header__title {
-      color: $unnnic-color-neutral-darkest;
+      color: $unnnic-color-gray-12;
       font: $unnnic-font-display-3;
 
       overflow: hidden;

--- a/src/components/insights/widgets/layout/CardWidgetContainer.vue
+++ b/src/components/insights/widgets/layout/CardWidgetContainer.vue
@@ -32,7 +32,7 @@
             <UnnnicIcon
               icon="more_vert"
               size="ant"
-              scheme="neutral-cloudy"
+              scheme="fg-muted"
             />
           </template>
 

--- a/src/layouts/InsightsLayout.vue
+++ b/src/layouts/InsightsLayout.vue
@@ -57,20 +57,20 @@ export default {
 
   overflow: hidden;
 
-  padding: $unnnic-spacing-sm;
+  padding: $unnnic-space-4;
   padding-right: 0;
 
-  gap: $unnnic-spacing-sm;
+  gap: $unnnic-space-4;
   position: relative;
 
   &__header {
-    margin-right: $unnnic-spacing-sm;
+    margin-right: $unnnic-space-4;
   }
 
   &__insights {
     overflow: hidden;
 
-    margin-right: $unnnic-spacing-xs;
+    margin-right: $unnnic-space-2;
 
     height: 100%;
 
@@ -82,9 +82,9 @@ export default {
       display: flex;
       flex-direction: column;
 
-      padding-right: $unnnic-spacing-xs;
+      padding-right: $unnnic-space-2;
 
-      background-color: $unnnic-color-neutral-white;
+      background-color: $unnnic-color-gray-0;
 
       overflow-y: auto;
       overflow-x: hidden;

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -3,13 +3,13 @@
 
 * {
   box-sizing: border-box;
-  outline-color: $unnnic-color-weni-600;
+  outline-color: $unnnic-color-teal-8;
 }
 
 html,
 input,
 textarea {
-  font-family: $unnnic-font-family-secondary, sans-serif;
+  font-family: $unnnic-font-family, sans-serif;
 }
 
 html,

--- a/src/utils/__tests__/treemap.spec.js
+++ b/src/utils/__tests__/treemap.spec.js
@@ -174,22 +174,22 @@ describe('Treemap Utilities', () => {
         label: 'Item 1',
         value: 100,
         percentage: 40,
-        color: '#C7FFF7', // colorTeal100
-        hoverColor: '#51F7E7', // colorTeal300
+        color: '#CFF8F4', // colorTeal100
+        hoverColor: '#ABF2EB', // colorTeal300
       });
       expect(result[1]).toMatchObject({
         label: 'Item 2',
         value: 80,
         percentage: 32,
-        color: '#EEECFB', // colorPurple100
-        hoverColor: '#C7BFF3', // colorPurple300
+        color: '#F5EAFE', // colorPurple100
+        hoverColor: '#E5CFFE', // colorPurple300
       });
       expect(result[2]).toMatchObject({
         label: 'Item 3',
         value: 70,
         percentage: 28,
-        color: '#E5EEF9', // colorBlue100
-        hoverColor: '#90BDE9', // colorBlue300
+        color: '#E1F3FF', // colorBlue100
+        hoverColor: '#97CFFE', // colorBlue300
       });
     });
 
@@ -202,13 +202,13 @@ describe('Treemap Utilities', () => {
       const result = addColors(data);
 
       expect(result[0]).toMatchObject({
-        color: '#C7FFF7', // position color
-        hoverColor: '#51F7E7',
+        color: '#CFF8F4', // position color
+        hoverColor: '#ABF2EB',
       });
       expect(result[1]).toMatchObject({
         label: 'Others',
-        color: '#ECEEF2', // special others color (colorGray100)
-        hoverColor: '#D6D9E1', // colorGray200
+        color: '#EBEBEB', // special others color (colorGray100)
+        hoverColor: '#D6D6D6', // colorGray200
       });
     });
 
@@ -221,13 +221,13 @@ describe('Treemap Utilities', () => {
       const result = addColors(data);
 
       expect(result[0]).toMatchObject({
-        color: '#C7FFF7', // position color
-        hoverColor: '#51F7E7',
+        color: '#CFF8F4', // position color
+        hoverColor: '#ABF2EB',
       });
       expect(result[1]).toMatchObject({
         label: 'Unclassified',
-        color: '#FDE3E3', // special unclassified color (colorRed100)
-        hoverColor: '#F8A9A9', // colorRed300
+        color: '#FFEDEA', // special unclassified color (colorRed100)
+        hoverColor: '#FFD0C7', // colorRed300
       });
     });
 
@@ -245,12 +245,12 @@ describe('Treemap Utilities', () => {
       const result = addColors(data);
 
       expect(result[5]).toMatchObject({
-        color: '#ECEEF2', // fallback color (colorGray100)
-        hoverColor: '#D6D9E1', // colorGray200
+        color: '#EBEBEB', // fallback color (colorGray100)
+        hoverColor: '#D6D6D6', // colorGray200
       });
       expect(result[6]).toMatchObject({
-        color: '#ECEEF2',
-        hoverColor: '#D6D9E1',
+        color: '#EBEBEB',
+        hoverColor: '#D6D6D6',
       });
     });
 
@@ -266,11 +266,11 @@ describe('Treemap Utilities', () => {
       const result = addColors(data);
 
       const expectedColors = [
-        { color: '#C7FFF7', hoverColor: '#51F7E7' }, // teal
-        { color: '#EEECFB', hoverColor: '#C7BFF3' }, // purple
-        { color: '#E5EEF9', hoverColor: '#90BDE9' }, // blue
-        { color: '#DAF1E0', hoverColor: '#88CDA4' }, // green
-        { color: '#FBEED9', hoverColor: '#F1C080' }, // orange
+        { color: '#CFF8F4', hoverColor: '#ABF2EB' }, // teal
+        { color: '#F5EAFE', hoverColor: '#E5CFFE' }, // purple
+        { color: '#E1F3FF', hoverColor: '#97CFFE' }, // blue
+        { color: '#E9FCE3', hoverColor: '#97EF86' }, // green
+        { color: '#FFEDCD', hoverColor: '#FED392' }, // orange
       ];
 
       result.forEach((item, index) => {
@@ -300,8 +300,8 @@ describe('Treemap Utilities', () => {
         value: 100,
         percentage: 50,
         customProperty: 'custom value',
-        color: '#C7FFF7',
-        hoverColor: '#51F7E7',
+        color: '#CFF8F4',
+        hoverColor: '#ABF2EB',
       });
     });
 
@@ -335,16 +335,16 @@ describe('Treemap Utilities', () => {
         label: 'Others',
         value: 90, // F + G values
         percentage: 18, // F + G percentages
-        color: '#ECEEF2', // special others color (colorGray100)
-        hoverColor: '#D6D9E1', // colorGray200
+        color: '#EBEBEB', // special others color (colorGray100)
+        hoverColor: '#D6D6D6', // colorGray200
       });
 
       // Verify first 5 items have position colors
-      expect(coloredData[0].color).toBe('#C7FFF7');
-      expect(coloredData[1].color).toBe('#EEECFB');
-      expect(coloredData[2].color).toBe('#E5EEF9');
-      expect(coloredData[3].color).toBe('#DAF1E0');
-      expect(coloredData[4].color).toBe('#FBEED9');
+      expect(coloredData[0].color).toBe('#CFF8F4');
+      expect(coloredData[1].color).toBe('#F5EAFE');
+      expect(coloredData[2].color).toBe('#E1F3FF');
+      expect(coloredData[3].color).toBe('#E9FCE3');
+      expect(coloredData[4].color).toBe('#FFEDCD');
     });
 
     it('should handle mixed special and regular items', () => {
@@ -362,15 +362,15 @@ describe('Treemap Utilities', () => {
       expect(coloredData).toHaveLength(5);
       expect(coloredData[0]).toMatchObject({
         label: 'Regular 1',
-        color: '#C7FFF7', // position 0 color
+        color: '#CFF8F4', // position 0 color
       });
       expect(coloredData[1]).toMatchObject({
         label: 'Unclassified',
-        color: '#FDE3E3', // special unclassified color (colorRed100)
+        color: '#FFEDEA', // special unclassified color (colorRed100)
       });
       expect(coloredData[2]).toMatchObject({
         label: 'Regular 2',
-        color: '#E5EEF9', // position 2 color
+        color: '#E1F3FF', // position 2 color
       });
     });
   });
@@ -445,9 +445,9 @@ describe('Treemap Utilities', () => {
 
       const coloredData = addColors(data);
 
-      expect(coloredData[0].color).toBe('#C7FFF7'); // position color
-      expect(coloredData[1].color).toBe('#EEECFB'); // position color
-      expect(coloredData[2].color).toBe('#ECEEF2'); // special color (colorGray100)
+      expect(coloredData[0].color).toBe('#CFF8F4'); // position color
+      expect(coloredData[1].color).toBe('#F5EAFE'); // position color
+      expect(coloredData[2].color).toBe('#EBEBEB'); // special color (colorGray100)
     });
   });
 });

--- a/src/utils/__tests__/treemap.spec.js
+++ b/src/utils/__tests__/treemap.spec.js
@@ -174,22 +174,22 @@ describe('Treemap Utilities', () => {
         label: 'Item 1',
         value: 100,
         percentage: 40,
-        color: '#CFF8F4', // colorTeal100
-        hoverColor: '#ABF2EB', // colorTeal300
+        color: '#ABF2EB', // colorBgTealPlain
+        hoverColor: '#01A29B', // colorBgTealStrong
       });
       expect(result[1]).toMatchObject({
         label: 'Item 2',
         value: 80,
         percentage: 32,
-        color: '#F5EAFE', // colorPurple100
-        hoverColor: '#E5CFFE', // colorPurple300
+        color: '#EDDCFE', // colorBgPurplePlain
+        hoverColor: '#AD71F8', // colorBgPurpleStrong
       });
       expect(result[2]).toMatchObject({
         label: 'Item 3',
         value: 70,
         percentage: 28,
-        color: '#E1F3FF', // colorBlue100
-        hoverColor: '#97CFFE', // colorBlue300
+        color: '#CBE9FF', // colorBgBluePlain
+        hoverColor: '#3993F4', // colorBgBlueStrong
       });
     });
 
@@ -202,8 +202,8 @@ describe('Treemap Utilities', () => {
       const result = addColors(data);
 
       expect(result[0]).toMatchObject({
-        color: '#CFF8F4', // position color
-        hoverColor: '#ABF2EB',
+        color: '#ABF2EB', // position color
+        hoverColor: '#01A29B',
       });
       expect(result[1]).toMatchObject({
         label: 'Others',
@@ -221,13 +221,13 @@ describe('Treemap Utilities', () => {
       const result = addColors(data);
 
       expect(result[0]).toMatchObject({
-        color: '#CFF8F4', // position color
-        hoverColor: '#ABF2EB',
+        color: '#ABF2EB', // position color
+        hoverColor: '#01A29B',
       });
       expect(result[1]).toMatchObject({
         label: 'Unclassified',
-        color: '#FFEDEA', // special unclassified color (colorRed100)
-        hoverColor: '#FFD0C7', // colorRed300
+        color: '#FFDFD9', // special unclassified color (colorRed100)
+        hoverColor: '#EC3727', // colorRed300
       });
     });
 
@@ -266,11 +266,11 @@ describe('Treemap Utilities', () => {
       const result = addColors(data);
 
       const expectedColors = [
-        { color: '#CFF8F4', hoverColor: '#ABF2EB' }, // teal
-        { color: '#F5EAFE', hoverColor: '#E5CFFE' }, // purple
-        { color: '#E1F3FF', hoverColor: '#97CFFE' }, // blue
-        { color: '#E9FCE3', hoverColor: '#97EF86' }, // green
-        { color: '#FFEDCD', hoverColor: '#FED392' }, // orange
+        { color: '#ABF2EB', hoverColor: '#01A29B' }, // teal
+        { color: '#EDDCFE', hoverColor: '#AD71F8' }, // purple
+        { color: '#CBE9FF', hoverColor: '#3993F4' }, // blue
+        { color: '#AFF79E', hoverColor: '#08A822' }, // green
+        { color: '#FFE0AE', hoverColor: '#E57001' }, // orange
       ];
 
       result.forEach((item, index) => {
@@ -300,8 +300,8 @@ describe('Treemap Utilities', () => {
         value: 100,
         percentage: 50,
         customProperty: 'custom value',
-        color: '#CFF8F4',
-        hoverColor: '#ABF2EB',
+        color: '#ABF2EB',
+        hoverColor: '#01A29B',
       });
     });
 
@@ -340,11 +340,11 @@ describe('Treemap Utilities', () => {
       });
 
       // Verify first 5 items have position colors
-      expect(coloredData[0].color).toBe('#CFF8F4');
-      expect(coloredData[1].color).toBe('#F5EAFE');
-      expect(coloredData[2].color).toBe('#E1F3FF');
-      expect(coloredData[3].color).toBe('#E9FCE3');
-      expect(coloredData[4].color).toBe('#FFEDCD');
+      expect(coloredData[0].color).toBe('#ABF2EB');
+      expect(coloredData[1].color).toBe('#EDDCFE');
+      expect(coloredData[2].color).toBe('#CBE9FF');
+      expect(coloredData[3].color).toBe('#AFF79E');
+      expect(coloredData[4].color).toBe('#FFE0AE');
     });
 
     it('should handle mixed special and regular items', () => {
@@ -362,15 +362,15 @@ describe('Treemap Utilities', () => {
       expect(coloredData).toHaveLength(5);
       expect(coloredData[0]).toMatchObject({
         label: 'Regular 1',
-        color: '#CFF8F4', // position 0 color
+        color: '#ABF2EB', // position 0 color
       });
       expect(coloredData[1]).toMatchObject({
         label: 'Unclassified',
-        color: '#FFEDEA', // special unclassified color (colorRed100)
+        color: '#FFDFD9', // special unclassified color (colorBgRedPlain)
       });
       expect(coloredData[2]).toMatchObject({
         label: 'Regular 2',
-        color: '#E1F3FF', // position 2 color
+        color: '#CBE9FF', // position 2 color
       });
     });
   });
@@ -445,8 +445,8 @@ describe('Treemap Utilities', () => {
 
       const coloredData = addColors(data);
 
-      expect(coloredData[0].color).toBe('#CFF8F4'); // position color
-      expect(coloredData[1].color).toBe('#F5EAFE'); // position color
+      expect(coloredData[0].color).toBe('#ABF2EB'); // position color
+      expect(coloredData[1].color).toBe('#EDDCFE'); // position color
       expect(coloredData[2].color).toBe('#EBEBEB'); // special color (colorGray100)
     });
   });

--- a/src/utils/treemap.ts
+++ b/src/utils/treemap.ts
@@ -1,20 +1,20 @@
 import i18n from '@/utils/plugins/i18n';
 import type { topicDistributionMetric } from '@/services/api/resources/conversational/topics';
 import {
-  colorTeal100,
-  colorTeal300,
-  colorPurple100,
-  colorPurple300,
-  colorBlue100,
-  colorBlue300,
-  colorGreen100,
-  colorGreen300,
-  colorOrange100,
-  colorOrange300,
-  colorRed100,
-  colorRed300,
-  colorGray100,
-  colorGray200,
+  colorTeal2,
+  colorTeal3,
+  colorPurple2,
+  colorPurple4,
+  colorBlue2,
+  colorBlue5,
+  colorGreen1,
+  colorGreen4,
+  colorOrange2,
+  colorOrange4,
+  colorRed2,
+  colorRed4,
+  colorGray2,
+  colorGray4,
 } from '@weni/unnnic-system/tokens/colors';
 
 /**
@@ -55,33 +55,27 @@ interface DataWithColor extends topicDistributionMetric {
 }
 
 const COLOR_PALETTE = {
-  position: [
-    colorTeal100,
-    colorPurple100,
-    colorBlue100,
-    colorGreen100,
-    colorOrange100,
-  ],
+  position: [colorTeal2, colorPurple2, colorBlue2, colorGreen1, colorOrange2],
   positionHover: [
-    colorTeal300,
-    colorPurple300,
-    colorBlue300,
-    colorGreen300,
-    colorOrange300,
+    colorTeal3,
+    colorPurple4,
+    colorBlue5,
+    colorGreen4,
+    colorOrange4,
   ],
   special: {
     others: {
-      normal: colorGray100,
-      hover: colorGray200,
+      normal: colorGray2,
+      hover: colorGray4,
     },
     unclassified: {
-      normal: colorRed100,
-      hover: colorRed300,
+      normal: colorRed2,
+      hover: colorRed4,
     },
   },
   fallback: {
-    normal: colorGray100,
-    hover: colorGray200,
+    normal: colorGray2,
+    hover: colorGray4,
   },
 };
 

--- a/src/utils/treemap.ts
+++ b/src/utils/treemap.ts
@@ -1,19 +1,19 @@
 import i18n from '@/utils/plugins/i18n';
 import type { topicDistributionMetric } from '@/services/api/resources/conversational/topics';
 import {
-  colorTeal2,
-  colorTeal3,
-  colorPurple2,
-  colorPurple4,
-  colorBlue2,
-  colorBlue5,
-  colorGreen1,
-  colorGreen4,
-  colorOrange2,
-  colorOrange4,
-  colorRed2,
-  colorRed4,
-  colorGray2,
+  colorBgTealPlain,
+  colorBgTealStrong,
+  colorBgPurplePlain,
+  colorBgPurpleStrong,
+  colorBgBluePlain,
+  colorBgBlueStrong,
+  colorBgGreenPlain,
+  colorBgGreenStrong,
+  colorBgOrangePlain,
+  colorBgOrangeStrong,
+  colorBgRedPlain,
+  colorBgRedStrong,
+  colorBgMuted,
   colorGray4,
 } from '@weni/unnnic-system/tokens/colors';
 
@@ -55,26 +55,32 @@ interface DataWithColor extends topicDistributionMetric {
 }
 
 const COLOR_PALETTE = {
-  position: [colorTeal2, colorPurple2, colorBlue2, colorGreen1, colorOrange2],
+  position: [
+    colorBgTealPlain,
+    colorBgPurplePlain,
+    colorBgBluePlain,
+    colorBgGreenPlain,
+    colorBgOrangePlain,
+  ],
   positionHover: [
-    colorTeal3,
-    colorPurple4,
-    colorBlue5,
-    colorGreen4,
-    colorOrange4,
+    colorBgTealStrong,
+    colorBgPurpleStrong,
+    colorBgBlueStrong,
+    colorBgGreenStrong,
+    colorBgOrangeStrong,
   ],
   special: {
     others: {
-      normal: colorGray2,
+      normal: colorBgMuted,
       hover: colorGray4,
     },
     unclassified: {
-      normal: colorRed2,
-      hover: colorRed4,
+      normal: colorBgRedPlain,
+      hover: colorBgRedStrong,
     },
   },
   fallback: {
-    normal: colorGray2,
+    normal: colorBgMuted,
     hover: colorGray4,
   },
 };

--- a/src/views/insights/DashboardCommerce.vue
+++ b/src/views/insights/DashboardCommerce.vue
@@ -217,11 +217,8 @@ onMounted(() => {
 
     &-title {
       color: $unnnic-color-gray-12;
-      font-family: $unnnic-font-family;
-      font-size: $unnnic-font-size;
-      font-style: normal;
+      font: $unnnic-font-display-3;
       font-weight: 900;
-      line-height: $unnnic-font-size + 8px;
     }
   }
 
@@ -250,19 +247,11 @@ onMounted(() => {
     }
     &-title {
       color: $unnnic-color-gray-12;
-      font-family: $unnnic-font-family;
-      font-size: 14px;
-      font-style: normal;
-      font-weight: $unnnic-font-weight-bold;
-      line-height: 14px + 8px;
+      font: $unnnic-font-action;
     }
     &-description {
       color: $unnnic-color-gray-7;
-      font-family: $unnnic-font-family;
-      font-size: 14px;
-      font-style: normal;
-      font-weight: $unnnic-font-weight-regular;
-      line-height: 14px + 8px;
+      font: $unnnic-font-body;
     }
   }
 }
@@ -279,10 +268,7 @@ onMounted(() => {
   gap: $unnnic-space-4;
   &_title {
     color: $unnnic-color-gray-7;
-    font-family: $unnnic-font-family;
-    font-size: 14px;
-    font-weight: $unnnic-font-weight-regular;
-    line-height: 14px + 8px;
+    font: $unnnic-font-body;
   }
 }
 </style>

--- a/src/views/insights/DashboardCommerce.vue
+++ b/src/views/insights/DashboardCommerce.vue
@@ -216,12 +216,12 @@ onMounted(() => {
     width: 100%;
 
     &-title {
-      color: $unnnic-color-neutral-darkest;
-      font-family: $unnnic-font-family-secondary;
-      font-size: $unnnic-font-size-body-lg;
+      color: $unnnic-color-gray-12;
+      font-family: $unnnic-font-family;
+      font-size: $unnnic-font-size;
       font-style: normal;
-      font-weight: $unnnic-font-weight-black;
-      line-height: $unnnic-font-size-body-lg + $unnnic-line-height-md;
+      font-weight: 900;
+      line-height: $unnnic-font-size + 8px;
     }
   }
 
@@ -231,7 +231,7 @@ onMounted(() => {
     align-items: center;
     height: 100%;
     width: 100%;
-    padding-top: $unnnic-spacing-md;
+    padding-top: $unnnic-space-6;
   }
 
   &__error {
@@ -239,30 +239,30 @@ onMounted(() => {
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    border-radius: $unnnic-border-radius-md;
-    border: $unnnic-border-width-thinner solid $unnnic-color-neutral-soft;
-    opacity: $unnnic-opacity-level-darkest;
-    background: $unnnic-color-neutral-white;
-    margin-top: $unnnic-spacing-sm;
-    padding: $unnnic-spacing-lg;
+    border-radius: $unnnic-radius-2;
+    border: 1px solid $unnnic-color-gray-2;
+    opacity: 0.8;
+    background: $unnnic-color-gray-0;
+    margin-top: $unnnic-space-4;
+    padding: $unnnic-space-8;
     &-icon {
-      margin-bottom: $unnnic-spacing-sm;
+      margin-bottom: $unnnic-space-4;
     }
     &-title {
-      color: $unnnic-color-neutral-darkest;
-      font-family: $unnnic-font-family-secondary;
-      font-size: $unnnic-font-size-body-gt;
+      color: $unnnic-color-gray-12;
+      font-family: $unnnic-font-family;
+      font-size: 14px;
       font-style: normal;
       font-weight: $unnnic-font-weight-bold;
-      line-height: $unnnic-font-size-body-gt + $unnnic-line-height-md;
+      line-height: 14px + 8px;
     }
     &-description {
-      color: $unnnic-color-neutral-cloudy;
-      font-family: $unnnic-font-family-secondary;
-      font-size: $unnnic-font-size-body-gt;
+      color: $unnnic-color-gray-7;
+      font-family: $unnnic-font-family;
+      font-size: 14px;
       font-style: normal;
       font-weight: $unnnic-font-weight-regular;
-      line-height: $unnnic-font-size-body-gt + $unnnic-line-height-md;
+      line-height: 14px + 8px;
     }
   }
 }
@@ -270,19 +270,19 @@ onMounted(() => {
 .metrics-container {
   display: grid;
   grid-template-columns: repeat(3, minmax(250px, 1fr));
-  padding: $unnnic-spacing-sm 1px;
+  padding: $unnnic-space-4 1px;
 }
 
 .filter-type {
   display: flex;
   align-items: center;
-  gap: $unnnic-spacing-sm;
+  gap: $unnnic-space-4;
   &_title {
-    color: $unnnic-color-neutral-cloudy;
-    font-family: $unnnic-font-family-secondary;
-    font-size: $unnnic-font-size-body-gt;
+    color: $unnnic-color-gray-7;
+    font-family: $unnnic-font-family;
+    font-size: 14px;
     font-weight: $unnnic-font-weight-regular;
-    line-height: $unnnic-font-size-body-gt + $unnnic-line-height-md;
+    line-height: 14px + 8px;
   }
 }
 </style>

--- a/src/views/insights/Report.vue
+++ b/src/views/insights/Report.vue
@@ -82,7 +82,7 @@ export default {
 
   display: grid;
 
-  gap: $unnnic-spacing-sm;
+  gap: $unnnic-space-4;
 
   &--loading {
     display: flex;
@@ -92,11 +92,11 @@ export default {
   }
 
   & > [class*='chart'] {
-    border-radius: $unnnic-spacing-nano;
-    border: $unnnic-border-width-thinner solid $unnnic-color-neutral-soft;
+    border-radius: $unnnic-space-1;
+    border: 1px solid $unnnic-color-gray-2;
 
     :deep([class*='title']) {
-      font-size: $unnnic-font-size-body-lg;
+      font-size: $unnnic-font-size;
     }
   }
 }

--- a/src/views/insights/Report.vue
+++ b/src/views/insights/Report.vue
@@ -96,7 +96,7 @@ export default {
     border: 1px solid $unnnic-color-gray-2;
 
     :deep([class*='title']) {
-      font-size: $unnnic-font-size;
+      font: $unnnic-font-display-4;
     }
   }
 }


### PR DESCRIPTION
## Description
### Type of Change
* * [ ] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [x] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
The `@weni/unnnic-system` design system package was updated from `^3.24.2` to `3.24.4-redesign.2`, which introduces a new token system (Shoreline). The previous tokens located in the `deprecated/` folder of the library are scheduled for removal. This change migrates the entire codebase to use the new token names directly, eliminating dependency on the deprecated aliases and ensuring long-term compatibility with the design system.

### Summary of Changes

#### 1. JS Color Token Migration (18 source files + 8 test files)
Replaced all JavaScript color token imports from `@weni/unnnic-system/tokens/colors` to match the new naming convention. The old tokens used a Tailwind-style scale (50–950) while the new tokens use a 1–13 numeric scale.

Key mappings applied:
- `colorTeal600` → `colorTeal8`, `colorTeal500` → `colorTeal7`, `colorTeal100` → `colorTeal2`
- `colorGray950` → `colorGray12`, `colorGray50` → `colorGray1`, `colorWhite` → `colorGray0`
- `colorBlue500` → `colorBlue8`, `colorBlue100` → `colorBlue2`
- `colorPurple500` → `colorPurple9`, `colorPurple100` → `colorPurple2`
- `colorOrange500` → `colorOrange7`, `colorOrange100` → `colorOrange2`
- `colorGreen500` → `colorGreen8`, `colorGreen100` → `colorGreen1`
- `colorRed500` → `colorRed9`, `colorRed100` → `colorRed2`
- And all other palette colors following the same pattern

Updated 8 test files with new hex color values to match the updated token outputs.

#### 2. SCSS Color Token Migration (~90 files)
Replaced all deprecated SCSS color variables with their new equivalents:
- **Neutral named colors**: `$unnnic-color-neutral-darkest` → `$unnnic-color-gray-12`, `$unnnic-color-neutral-dark` → `$unnnic-color-gray-10`, `$unnnic-color-neutral-cloudy` → `$unnnic-color-gray-7`, `$unnnic-color-neutral-soft` → `$unnnic-color-gray-2`, `$unnnic-color-neutral-white` → `$unnnic-color-gray-0`, etc.
- **Weni brand**: `$unnnic-color-weni-600` → `$unnnic-color-teal-8`, `$unnnic-color-weni-50` → `$unnnic-color-teal-1`, etc.
- **Background named**: `$unnnic-color-background-white` → `$unnnic-color-gray-0`, `$unnnic-color-background-snow` → `$unnnic-color-gray-0`
- **Aux palette**: `$unnnic-color-aux-red-500` → `$unnnic-color-red-7`, `$unnnic-color-aux-green-500` → `$unnnic-color-green-7`, etc.
- **Semantic renames**: `$unnnic-color-bg-soft` → `$unnnic-color-bg-base-soft`, `$unnnic-color-border-soft` → `$unnnic-color-border-base`, `$unnnic-color-border-active` → `$unnnic-color-border-accent-strong`

#### 3. SCSS Spacing Token Migration (~50 files)
- `$unnnic-spacing-nano` → `$unnnic-space-1`, `$unnnic-spacing-xs` → `$unnnic-space-2`, `$unnnic-spacing-ant` → `$unnnic-space-3`, `$unnnic-spacing-sm` → `$unnnic-space-4`, `$unnnic-spacing-md` → `$unnnic-space-6`, `$unnnic-spacing-lg` → `$unnnic-space-8`, `$unnnic-spacing-awesome` → `$unnnic-space-20`

#### 4. SCSS Border Radius Migration (~15 files)
- `$unnnic-border-radius-sm` → `$unnnic-radius-1`, `$unnnic-border-radius-md` → `$unnnic-radius-2`, `$unnnic-border-radius-lg` → `$unnnic-radius-4`, `$unnnic-border-radius-pill` → `$unnnic-radius-full`

#### 5. SCSS Shadow, Icon Size Migrations (~7 files)
- `$unnnic-shadow-level-far` → `$unnnic-shadow-2`
- `$unnnic-icon-size-ant` → `$unnnic-icon-size-5`

#### 6. Font Family Migration (~54 files)
- `$unnnic-font-family-primary` and `$unnnic-font-family-secondary` → `$unnnic-font-family`

#### 7. Typography Shorthand Migration (~55 files, ~90 conversion points)
Replaced individual `font-family`, `font-size`, `font-weight`, and `line-height` properties with single `font:` shorthand tokens from the new design system:

| Token | Size | Weight | Applied to |
|-------|------|--------|------------|
| `$unnnic-font-body` | 14px | Regular | ~25 files |
| `$unnnic-font-action` | 14px | Bold | ~6 files |
| `$unnnic-font-caption-2` | 12px | Regular | ~13 files |
| `$unnnic-font-caption-1` | 12px | Medium | 1 file |
| `$unnnic-font-display-1` | 24px | Bold | ~4 files |
| `$unnnic-font-display-2` | 20px | Bold | ~12 files |
| `$unnnic-font-display-3` | 16px | Bold | ~12 files |
| `$unnnic-font-display-4` | 16px | Regular | ~15 files |

#### 8. Tokens Without Direct Replacement (~22 files)
Replaced deprecated tokens that have no new equivalent with raw CSS values:
- `$unnnic-border-width-thinner` → `1px`
- `$unnnic-avatar-size-nano` → `20px`, `$unnnic-avatar-size-sm` → `40px`
- `$unnnic-opacity-level-darkest` → `0.8`
- `$unnnic-font-weight-black` → `900`, `$unnnic-font-weight-light` → `300`
