### PR TITLE
[ENGAGE-7445] Feat: cancel last request if new is called

### DIFF
--- a/src/services/api/resources/conversational/widgets.ts
+++ b/src/services/api/resources/conversational/widgets.ts
@@ -166,7 +166,7 @@ export default {
 
   async getSalesFunnelData(
     queryParams: Partial<WidgetQueryParams> = {},
-    options: { mock?: boolean } = { mock: false },
+    options: { mock?: boolean; signal?: AbortSignal } = {},
   ): Promise<SalesFunnelResponse> {
     if (options.mock) return MOCK_SALES_FUNNEL_DATA;
 
@@ -181,6 +181,7 @@ export default {
 
     const response = (await http.get('/metrics/conversations/sales_funnel/', {
       params,
+      signal: options.signal,
     })) as SalesFunnelResponse;
 
     return response;

--- a/src/store/modules/conversational/widgets.ts
+++ b/src/store/modules/conversational/widgets.ts
@@ -38,6 +38,8 @@ interface ConversationalWidgetsState {
   isSalesFunnelWidgetDataError: boolean;
 }
 
+let salesFunnelAbortController: AbortController | null = null;
+
 export const useConversationalWidgets = defineStore('conversationalWidgets', {
   state: (): ConversationalWidgetsState => ({
     newWidget: null,
@@ -129,6 +131,12 @@ export const useConversationalWidgets = defineStore('conversationalWidgets', {
       this.npsWidgetType = type;
     },
     async loadSalesFunnelWidgetData() {
+      if (salesFunnelAbortController) {
+        salesFunnelAbortController.abort();
+      }
+      salesFunnelAbortController = new AbortController();
+      const { signal } = salesFunnelAbortController;
+
       this.isLoadingSalesFunnelWidgetData = true;
       try {
         const { shouldUseMock } = useConversational();
@@ -152,17 +160,21 @@ export const useConversationalWidgets = defineStore('conversationalWidgets', {
         }
 
         const salesFunnelData =
-          await WidgetConversationalService.getSalesFunnelData({
-            widget_uuid: widgetSalesFunnel.uuid,
-          });
+          await WidgetConversationalService.getSalesFunnelData(
+            { widget_uuid: widgetSalesFunnel.uuid },
+            { signal },
+          );
 
         this.salesFunnelWidgetData = salesFunnelData;
       } catch (error) {
+        if (signal.aborted) return;
         this.salesFunnelWidgetData = null;
         this.isSalesFunnelWidgetDataError = true;
         console.error('Error loading sales funnel widget data', error);
       } finally {
-        this.isLoadingSalesFunnelWidgetData = false;
+        if (!signal.aborted) {
+          this.isLoadingSalesFunnelWidgetData = false;
+        }
       }
     },
     async loadCsatWidgetData() {


### PR DESCRIPTION
## Description
### Type of Change
* [x] Bugfix
* [x] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Tests
* [ ] Other

### Motivation and Context
**Race condition on filter change**: When a user changed filters before the initial request finished, the slower first request would resolve after the second one and overwrite the correct data. This caused stale data to be displayed and wasted network resources by not cancelling the outdated request.

### Summary of Changes
- **Added request cancellation via `AbortController`** to `loadSalesFunnelWidgetData` (`src/store/modules/conversational/widgets.ts`): each new call aborts the previous in-flight request before issuing a new one. The service (`getSalesFunnelData`) was updated to accept and forward an `AbortSignal` to axios. Aborted requests are silently ignored in the `catch`/`finally` blocks, preventing stale data overwrites and unnecessary loading state resets.