### PR TITLE
[ENGAGE-7633] FEAT: adjust layout in BaseConversationWidget for improved alignment

### DIFF
--- a/src/components/insights/conversations/BaseConversationWidget.vue
+++ b/src/components/insights/conversations/BaseConversationWidget.vue
@@ -134,7 +134,7 @@ const handleTabChange = (tab: Tab) => {
   display: flex;
   padding: $unnnic-space-6;
   flex-direction: column;
-  justify-content: space-between;
+  justify-content: flex-start;
   gap: $unnnic-space-4;
   flex: 1 0 0;
   align-self: stretch;


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Change order list widgets items 

### Summary of Changes
<!--- Describe your changes in detail -->
- Changed justify-content from space-between to flex-start to enhance the layout of conversation tabs.
- This adjustment aims to provide a more consistent visual structure within the widget.
