### PR TITLE
fix: correct drawer logic for CSAT widget state management

### DIFF
--- a/src/components/insights/conversations/CustomizableWidget/CustomizableDrawer.vue
+++ b/src/components/insights/conversations/CustomizableWidget/CustomizableDrawer.vue
@@ -439,12 +439,12 @@ const isDisabledPrimaryButton = computed(() => {
     return !isEnabledSaveAbsoluteNumbersForm.value;
   }
 
-  if (drawerWidgetType.value === 'csat') {
-    return !isEnabledUpdateWidgetCsat.value;
-  }
-
   if (isNewDrawerCustomizable.value) {
     return !isEnabledSaveNewWidget.value;
+  }
+
+  if (drawerWidgetType.value === 'csat') {
+    return !isEnabledUpdateWidgetCsat.value;
   }
 
   return !isEnabledUpdateWidgetNps.value;


### PR DESCRIPTION


## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
adjust disable btn problem in create csat widget

### Summary of Changes
<!--- Describe your changes in detail -->
- Moved the CSAT widget condition check to the correct position in the isDisabledPrimaryButton computed property.
- Ensured that the button's disabled state is accurately determined based on the widget type and form state.
