### PR TITLE
feat: improve dashboard widget initialization and testing

### DIFF
--- a/src/components/insights/dashboards/Conversational.vue
+++ b/src/components/insights/dashboards/Conversational.vue
@@ -89,7 +89,7 @@ const dynamicWidgets = ref<{ type: ConversationalWidgetType; uuid: string }[]>(
 );
 
 const orderedDynamicWidgets = computed(() => {
-  if (isLoadingCurrentDashboardWidgets.value || !isConfigurationLoaded.value) {
+  if (isLoadingCurrentDashboardWidgets.value) {
     return [];
   }
 
@@ -165,11 +165,13 @@ const waitForDashboardWidgets = () =>
   });
 
 const initializeConfiguration = async () => {
-  await Promise.all([
-    waitForDashboardWidgets(),
-    topicsStore.loadFormTopics(),
-    autoWidgets.loadAllAutoWidgets(),
-  ]);
+  const topicsPromise = topicsStore.loadFormTopics();
+  const autoWidgetsPromise = autoWidgets.loadAllAutoWidgets();
+
+  await waitForDashboardWidgets();
+  setDynamicWidgets();
+
+  await Promise.all([topicsPromise, autoWidgetsPromise]);
   conversational.setConfigurationLoaded(true);
 
   if (conversational.shouldUseMock) {

--- a/src/components/insights/dashboards/__tests__/Conversational.spec.js
+++ b/src/components/insights/dashboards/__tests__/Conversational.spec.js
@@ -451,6 +451,67 @@ describe('Conversational.vue', () => {
     });
   });
 
+  describe('Configured widgets show during initialization', () => {
+    it('should show configured widgets before isConfigurationLoaded is true', async () => {
+      conversationalStore.shouldUseMock = false;
+      conversationalStore.isConfigurationLoaded = false;
+
+      conversationalWidgetsStore.isCsatConfigured = true;
+      conversationalWidgetsStore.isNpsConfigured = true;
+
+      widgetsStore.isLoadingCurrentDashboardWidgets = ref(false);
+      widgetsStore.currentDashboardWidgets = ref([]);
+
+      customWidgetsStore.getCustomWidgets = [];
+
+      wrapper = shallowMount(Conversational, {
+        global: {
+          stubs: {
+            DashboardHeader: true,
+            MostTalkedAboutTopicsWidget: true,
+            ConversationalDynamicWidget: true,
+            CustomizableDrawer: true,
+            Info: true,
+          },
+        },
+      });
+
+      await nextTick();
+      await nextTick();
+
+      const types = wrapper.vm.orderedDynamicWidgets.map((w) => w.type);
+      expect(types).toContain('agent_invocation');
+      expect(types).toContain('tool_result');
+      expect(types).toContain('csat');
+      expect(types).toContain('nps');
+      expect(types).toContain('add');
+    });
+
+    it('should return empty when dashboard widgets are still loading', async () => {
+      conversationalStore.shouldUseMock = false;
+      conversationalStore.isConfigurationLoaded = false;
+
+      widgetsStore.isLoadingCurrentDashboardWidgets = ref(true);
+      widgetsStore.currentDashboardWidgets = ref([]);
+
+      wrapper = shallowMount(Conversational, {
+        global: {
+          stubs: {
+            DashboardHeader: true,
+            MostTalkedAboutTopicsWidget: true,
+            ConversationalDynamicWidget: true,
+            CustomizableDrawer: true,
+            Info: true,
+          },
+        },
+      });
+
+      await nextTick();
+
+      expect(wrapper.vm.orderedDynamicWidgets).toEqual([]);
+    });
+  });
+
   describe('Auto widgets ordering', () => {
     beforeEach(async () => {
       conversationalStore.shouldUseMock = false;


### PR DESCRIPTION


## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
improve dashboard widget initialization and testing

### Summary of Changes
<!--- Describe your changes in detail -->
- Simplified the logic for ordered dynamic widgets by removing unnecessary configuration checks during loading.
- Enhanced the initialization process by separating promises for loading topics and auto widgets, ensuring dynamic widgets are set before awaiting their completion.
- Added tests to verify the display of configured widgets during initialization and the behavior when dashboard widgets are still loading.

### Design Files <!--- (If not appropriate, remove this topic) -->
<!--- Links to the design files used for reference during implementation. -->

- [Design File 1](link_to_design_file_1)

### Demonstration <!--- (If not appropriate, remove this topic) -->
<!--- Include a screenshot or video showcasing a feature or fix implemented in this pull request. -->
