### PR TITLE
[ENGAGE-7664] Feat: adjust export conversational to use agents and tools

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -859,6 +859,8 @@
       "sector_tags": "Tags",
       "contacts": "Contacts",
       "resolutions": "Conversation resolutions",
+      "tool_result": "Most used tools",
+      "agent_invocation": "Most used agents",
       "topics": "Topics",
       "csat": "CSAT",
       "nps": "NPS",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -859,6 +859,8 @@
       "sector_tags": "Tags",
       "contacts": "Contactos",
       "resolutions": "Resoluciones de conversaciones",
+      "tool_result": "Herramientas más usadas",
+      "agent_invocation": "Agentes más usados",
       "topics": "Asuntos",
       "csat": "CSAT",
       "nps": "NPS",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -859,6 +859,8 @@
       "sector_tags": "Tags",
       "contacts": "Contatos",
       "resolutions": "Resoluções de conversas",
+      "tool_result": "Ferramentas mais usadas",
+      "agent_invocation": "Agentes mais usados",
       "topics": "Assuntos",
       "csat": "CSAT",
       "nps": "NPS",

--- a/src/services/api/resources/export/conversational/export.ts
+++ b/src/services/api/resources/export/conversational/export.ts
@@ -3,6 +3,8 @@ import { useConfig } from '@/store/modules/config';
 
 type TypeSections =
   | 'RESOLUTIONS'
+  | 'TOOL_RESULT'
+  | 'AGENT_INVOCATION'
   | 'TOPICS_AI'
   | 'TOPICS_HUMAN'
   | 'CSAT_AI'

--- a/src/store/modules/export/conversational/__tests__/export.spec.js
+++ b/src/store/modules/export/conversational/__tests__/export.spec.js
@@ -229,6 +229,30 @@ describe('useConversationalExport', () => {
       expect(store.model_fields['widget-1']).toEqual({});
     });
 
+    it('should initialize tool_result and agent_invocation fields when available', async () => {
+      const mockResponse = {
+        sections: [
+          'RESOLUTIONS',
+          'TOOL_RESULT',
+          'AGENT_INVOCATION',
+          'TOPICS_AI',
+        ],
+        custom_widgets: [],
+        crosstab_widgets: [],
+      };
+      exportApi.getAvailableWidgets.mockResolvedValue(mockResponse);
+      store.setModelFields({});
+
+      await store.initializeDefaultFields();
+
+      expect(store.model_fields.resolutions).toEqual({});
+      expect(store.model_fields.tool_result).toEqual({});
+      expect(store.model_fields.agent_invocation).toEqual({});
+      expect(store.model_fields.topics).toEqual({
+        ai: { type: 'subsection' },
+      });
+    });
+
     it('should keep crosstab widget UUIDs from model_fields', async () => {
       const mockResponse = {
         sections: ['RESOLUTIONS'],
@@ -283,6 +307,28 @@ describe('useConversationalExport', () => {
       });
       expect(store.export_data).toEqual(mockResponse);
       expect(store.isRenderExportDataFeedback).toBe(true);
+    });
+
+    it('should include TOOL_RESULT section when tool_result is enabled', async () => {
+      exportApi.createExport.mockResolvedValue({ status: 'pending' });
+      store.enabled_models = ['tool_result'];
+      store.setSelectedFields({});
+
+      await store.createExport();
+
+      const call = exportApi.createExport.mock.calls[0][0];
+      expect(call.sections).toContain('TOOL_RESULT');
+    });
+
+    it('should include AGENT_INVOCATION section when agent_invocation is enabled', async () => {
+      exportApi.createExport.mockResolvedValue({ status: 'pending' });
+      store.enabled_models = ['agent_invocation'];
+      store.setSelectedFields({});
+
+      await store.createExport();
+
+      const call = exportApi.createExport.mock.calls[0][0];
+      expect(call.sections).toContain('AGENT_INVOCATION');
     });
 
     it('should include custom widgets in export', async () => {
@@ -400,6 +446,16 @@ describe('useConversationalExport', () => {
 
       store.setSelectedFields({ topics: [] });
       expect(store.hasEnabledToExport).toBeFalsy();
+    });
+
+    it('should return true when tool_result is enabled', () => {
+      store.enabled_models = ['tool_result'];
+      expect(store.hasEnabledToExport).toBe(true);
+    });
+
+    it('should return true when agent_invocation is enabled', () => {
+      store.enabled_models = ['agent_invocation'];
+      expect(store.hasEnabledToExport).toBe(true);
     });
 
     it('should return true when crosstab widget is enabled', () => {

--- a/src/store/modules/export/conversational/export.ts
+++ b/src/store/modules/export/conversational/export.ts
@@ -168,6 +168,8 @@ export const useConversationalExport = defineStore('conversationalExport', {
         { model: string; subsection?: string }
       > = {
         RESOLUTIONS: { model: 'resolutions' },
+        TOOL_RESULT: { model: 'tool_result' },
+        AGENT_INVOCATION: { model: 'agent_invocation' },
         TOPICS_AI: { model: 'topics', subsection: 'ai' },
         TOPICS_HUMAN: { model: 'topics', subsection: 'human' },
         CSAT_AI: { model: 'csat', subsection: 'ai' },
@@ -229,6 +231,8 @@ export const useConversationalExport = defineStore('conversationalExport', {
           string | Record<string, string>
         > = {
           resolutions: 'RESOLUTIONS',
+          tool_result: 'TOOL_RESULT',
+          agent_invocation: 'AGENT_INVOCATION',
           topics: { human: 'TOPICS_HUMAN', ai: 'TOPICS_AI' },
           csat: { human: 'CSAT_HUMAN', ai: 'CSAT_AI' },
           nps: { human: 'NPS_HUMAN', ai: 'NPS_AI' },
@@ -316,7 +320,9 @@ export const useConversationalExport = defineStore('conversationalExport', {
 
       if (
         state.enabled_models.includes('resolutions') ||
-        state.enabled_models.includes('transferred')
+        state.enabled_models.includes('transferred') ||
+        state.enabled_models.includes('tool_result') ||
+        state.enabled_models.includes('agent_invocation')
       ) {
         hasValidSelections = true;
       }


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [X] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [X] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- adjust export conversational to use agents and tools


### Summary of Changes
<!--- Describe your changes in detail -->
 - Add logic to accept 2 new widgets in the export data conversational