### PR TITLE
[ENGAGE-7769] Feat: signal treatment conversational widgets

### DIFF
--- a/src/components/insights/widgets/conversational/ConversacionalAbsoluteNumbers/AbsoluteNumbersMetric.vue
+++ b/src/components/insights/widgets/conversational/ConversacionalAbsoluteNumbers/AbsoluteNumbersMetric.vue
@@ -69,6 +69,7 @@ const conversationalStore = useConversational();
 const isRemoveWidgetModalOpen = ref<boolean>(false);
 const metricValue = ref<number>(0);
 const isLoading = ref<boolean>(false);
+let abortController: AbortController | null = null;
 const formattedValue = computed(() => {
   if (props.metric.config.currency.code) {
     return formatCurrency(metricValue.value, props.metric.config.currency.code);
@@ -77,16 +78,26 @@ const formattedValue = computed(() => {
 });
 
 const getChildrenValue = async () => {
+  if (abortController) {
+    abortController.abort();
+  }
+  abortController = new AbortController();
+  const { signal } = abortController;
+
   try {
     isLoading.value = true;
     const response = await WidgetService.getAbsoluteNumbersChildrenValue(
       props.metric.uuid,
+      { signal },
     );
     metricValue.value = response.value;
   } catch (error) {
+    if (signal.aborted) return;
     console.error('Error getting children value', error);
   } finally {
-    isLoading.value = false;
+    if (!signal.aborted) {
+      isLoading.value = false;
+    }
   }
 };
 

--- a/src/components/insights/widgets/conversational/ConversacionalAbsoluteNumbers/__tests__/AbsoluteNumbersMetric.spec.js
+++ b/src/components/insights/widgets/conversational/ConversacionalAbsoluteNumbers/__tests__/AbsoluteNumbersMetric.spec.js
@@ -165,6 +165,9 @@ describe('AbsoluteNumbersMetric', () => {
     await flushPromises();
     expect(WidgetService.getAbsoluteNumbersChildrenValue).toHaveBeenCalledWith(
       'my-child-uuid',
+      expect.objectContaining({
+        signal: expect.any(AbortSignal),
+      }),
     );
   });
 
@@ -232,5 +235,46 @@ describe('AbsoluteNumbersMetric', () => {
     expect(actions[0].icon).toBe('edit_square');
     expect(actions[1].icon).toBe('delete');
     expect(actions[1].scheme).toBe('aux-red-500');
+  });
+
+  it('aborts previous request when getChildrenValue is called again', async () => {
+    let firstResolve;
+    let secondResolve;
+
+    WidgetService.getAbsoluteNumbersChildrenValue
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            firstResolve = resolve;
+          }),
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            secondResolve = resolve;
+          }),
+      );
+
+    createWrapper();
+    await nextTick();
+
+    const firstSignal =
+      WidgetService.getAbsoluteNumbersChildrenValue.mock.calls[0][1]?.signal;
+
+    expect(firstSignal?.aborted).toBe(false);
+
+    WidgetService.getAbsoluteNumbersChildrenValue.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          secondResolve = resolve;
+        }),
+    );
+
+    createWrapper();
+    await nextTick();
+
+    expect(
+      WidgetService.getAbsoluteNumbersChildrenValue,
+    ).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/services/api/resources/conversational/widgets.ts
+++ b/src/services/api/resources/conversational/widgets.ts
@@ -112,7 +112,7 @@ export default {
   async getCsatData(
     type: 'HUMAN' | 'AI',
     queryParams: Partial<WidgetQueryParams> = {},
-    options: { mock?: boolean } = { mock: false },
+    options: { mock?: boolean; signal?: AbortSignal } = {},
   ): Promise<CsatResponse> {
     if (options.mock) return MOCK_CSAT_DATA;
 
@@ -128,6 +128,7 @@ export default {
 
     const response = (await http.get('/metrics/conversations/csat/', {
       params,
+      signal: options.signal,
     })) as CsatResponse;
 
     return response;
@@ -136,7 +137,7 @@ export default {
   async getNpsData(
     type: 'HUMAN' | 'AI',
     queryParams: Partial<WidgetQueryParams> = {},
-    options: { mock?: boolean } = { mock: false },
+    options: { mock?: boolean; signal?: AbortSignal } = {},
   ): Promise<NpsResponse> {
     if (options.mock) return MOCK_NPS_DATA;
 
@@ -152,6 +153,7 @@ export default {
 
     const response = (await http2.get('/metrics/conversations/nps/', {
       params,
+      signal: options.signal,
     })) as NpsResponse;
 
     return response;
@@ -159,6 +161,7 @@ export default {
 
   async getCustomWidgetData(
     queryParams: WidgetQueryParams,
+    options: { signal?: AbortSignal } = {},
   ): Promise<CustomWidgetResponse> {
     const { project } = useConfig();
     const { appliedFilters } = useConversational();
@@ -171,12 +174,16 @@ export default {
 
     const response = (await http.get('/metrics/conversations/custom/', {
       params,
+      signal: options.signal,
     })) as CustomWidgetResponse;
 
     return response;
   },
 
-  async getCrosstabWidgetData(queryParams: WidgetQueryParams): Promise<any> {
+  async getCrosstabWidgetData(
+    queryParams: WidgetQueryParams,
+    options: { signal?: AbortSignal } = {},
+  ): Promise<any> {
     const { project } = useConfig();
     const { appliedFilters } = useConversational();
 
@@ -188,6 +195,7 @@ export default {
 
     const response = (await http.get('/metrics/conversations/crosstab/', {
       params,
+      signal: options.signal,
     })) as CrosstabWidgetResponse;
 
     const sortedResponse = {
@@ -253,6 +261,7 @@ export default {
 
   async getAbsoluteNumbersChildrenValue(
     widgetUuid: string,
+    options: { signal?: AbortSignal } = {},
   ): Promise<{ value: number }> {
     const { appliedFilters } = useConversational();
     const params = {
@@ -261,7 +270,7 @@ export default {
     };
     const response = (await http.get(
       `/metrics/conversations/absolute-numbers/`,
-      { params },
+      { params, signal: options.signal },
     )) as { value: number };
 
     return response;
@@ -269,6 +278,7 @@ export default {
 
   async getAgentInvocationData(
     queryParams: Partial<WidgetQueryParams> = {},
+    options: { signal?: AbortSignal } = {},
   ): Promise<AutoWidgetResponse> {
     const { project } = useConfig();
     const { appliedFilters } = useConversational();
@@ -281,7 +291,7 @@ export default {
 
     const response = (await http.get(
       '/metrics/conversations/agent-invocation/',
-      { params },
+      { params, signal: options.signal },
     )) as AutoWidgetResponse;
 
     return response;
@@ -289,6 +299,7 @@ export default {
 
   async getToolResultData(
     queryParams: Partial<WidgetQueryParams> = {},
+    options: { signal?: AbortSignal } = {},
   ): Promise<AutoWidgetResponse> {
     const { project } = useConfig();
     const { appliedFilters } = useConversational();
@@ -301,6 +312,7 @@ export default {
 
     const response = (await http.get('/metrics/conversations/tool-result/', {
       params,
+      signal: options.signal,
     })) as AutoWidgetResponse;
 
     return response;

--- a/src/store/modules/conversational/__tests__/autoWidgets.spec.ts
+++ b/src/store/modules/conversational/__tests__/autoWidgets.spec.ts
@@ -10,8 +10,7 @@ vi.mock('@/services/api/resources/conversational/widgets', () => ({
   default: {
     getAgentInvocationData: (...args: unknown[]) =>
       mockGetAgentInvocationData(...args),
-    getToolResultData: (...args: unknown[]) =>
-      mockGetToolResultData(...args),
+    getToolResultData: (...args: unknown[]) => mockGetToolResultData(...args),
   },
 }));
 
@@ -108,21 +107,74 @@ describe('useAutoWidgets store', () => {
       expect(store.agentInvocation.isLoading).toBe(false);
     });
 
-    it('should not make duplicate requests while loading', async () => {
-      let resolvePromise: (value: unknown) => void;
-      mockGetAgentInvocationData.mockReturnValue(
-        new Promise((resolve) => {
-          resolvePromise = resolve;
-        }),
-      );
+    it('should abort previous request when called again', async () => {
+      let secondResolve: (value: unknown) => void;
+
+      mockGetAgentInvocationData
+        .mockImplementationOnce(
+          (_params: unknown, opts: { signal: AbortSignal }) =>
+            new Promise((_resolve, reject) => {
+              opts.signal.addEventListener('abort', () => {
+                reject(new DOMException('Aborted', 'AbortError'));
+              });
+            }),
+        )
+        .mockReturnValueOnce(
+          new Promise((resolve) => {
+            secondResolve = resolve;
+          }),
+        );
 
       const first = store.loadAgentInvocationData();
-      store.loadAgentInvocationData();
+      const second = store.loadAgentInvocationData();
 
-      expect(mockGetAgentInvocationData).toHaveBeenCalledTimes(1);
+      expect(mockGetAgentInvocationData).toHaveBeenCalledTimes(2);
 
-      resolvePromise!({ results: [] });
+      const firstSignal = mockGetAgentInvocationData.mock.calls[0][1]?.signal;
+      expect(firstSignal?.aborted).toBe(true);
+
+      secondResolve!({ results: [] });
+      await second;
       await first;
+
+      expect(store.agentInvocation.data).toEqual({ results: [] });
+      expect(store.agentInvocation.isLoading).toBe(false);
+      expect(store.agentInvocation.error).toBe(false);
+    });
+
+    it('should not set error or update loading when aborted', async () => {
+      mockGetAgentInvocationData
+        .mockImplementationOnce(
+          (_params: unknown, opts: { signal: AbortSignal }) =>
+            new Promise((_resolve, reject) => {
+              opts.signal.addEventListener('abort', () => {
+                reject(new DOMException('Aborted', 'AbortError'));
+              });
+            }),
+        )
+        .mockResolvedValueOnce({ results: [] });
+
+      const first = store.loadAgentInvocationData();
+      const second = store.loadAgentInvocationData();
+
+      await second;
+      await first;
+
+      expect(store.agentInvocation.error).toBe(false);
+      expect(store.agentInvocation.isLoading).toBe(false);
+    });
+
+    it('should pass signal to service call', async () => {
+      mockGetAgentInvocationData.mockResolvedValue({ results: [] });
+
+      await store.loadAgentInvocationData();
+
+      expect(mockGetAgentInvocationData).toHaveBeenCalledWith(
+        {},
+        expect.objectContaining({
+          signal: expect.any(AbortSignal),
+        }),
+      );
     });
   });
 
@@ -180,6 +232,54 @@ describe('useAutoWidgets store', () => {
       expect(store.toolResult.error).toBe(true);
       expect(store.toolResult.isLoading).toBe(false);
     });
+
+    it('should abort previous request when called again', async () => {
+      let secondResolve: (value: unknown) => void;
+
+      mockGetToolResultData
+        .mockImplementationOnce(
+          (_params: unknown, opts: { signal: AbortSignal }) =>
+            new Promise((_resolve, reject) => {
+              opts.signal.addEventListener('abort', () => {
+                reject(new DOMException('Aborted', 'AbortError'));
+              });
+            }),
+        )
+        .mockReturnValueOnce(
+          new Promise((resolve) => {
+            secondResolve = resolve;
+          }),
+        );
+
+      const first = store.loadToolResultData();
+      const second = store.loadToolResultData();
+
+      expect(mockGetToolResultData).toHaveBeenCalledTimes(2);
+
+      const firstSignal = mockGetToolResultData.mock.calls[0][1]?.signal;
+      expect(firstSignal?.aborted).toBe(true);
+
+      secondResolve!({ results: [] });
+      await second;
+      await first;
+
+      expect(store.toolResult.data).toEqual({ results: [] });
+      expect(store.toolResult.isLoading).toBe(false);
+      expect(store.toolResult.error).toBe(false);
+    });
+
+    it('should pass signal to service call', async () => {
+      mockGetToolResultData.mockResolvedValue({ results: [] });
+
+      await store.loadToolResultData();
+
+      expect(mockGetToolResultData).toHaveBeenCalledWith(
+        {},
+        expect.objectContaining({
+          signal: expect.any(AbortSignal),
+        }),
+      );
+    });
   });
 
   describe('loadAllAutoWidgets', () => {
@@ -220,6 +320,42 @@ describe('useAutoWidgets store', () => {
         isLoading: false,
         error: false,
       });
+    });
+
+    it('should abort in-flight requests', async () => {
+      mockGetAgentInvocationData.mockImplementation(
+        (_params: unknown, opts: { signal: AbortSignal }) =>
+          new Promise((_resolve, reject) => {
+            opts.signal.addEventListener('abort', () => {
+              reject(new DOMException('Aborted', 'AbortError'));
+            });
+          }),
+      );
+      mockGetToolResultData.mockImplementation(
+        (_params: unknown, opts: { signal: AbortSignal }) =>
+          new Promise((_resolve, reject) => {
+            opts.signal.addEventListener('abort', () => {
+              reject(new DOMException('Aborted', 'AbortError'));
+            });
+          }),
+      );
+
+      const agentPromise = store.loadAgentInvocationData();
+      const toolPromise = store.loadToolResultData();
+
+      const agentSignal = mockGetAgentInvocationData.mock.calls[0][1]?.signal;
+      const toolSignal = mockGetToolResultData.mock.calls[0][1]?.signal;
+
+      store.resetAutoWidgets();
+
+      expect(agentSignal?.aborted).toBe(true);
+      expect(toolSignal?.aborted).toBe(true);
+
+      await agentPromise;
+      await toolPromise;
+
+      expect(store.agentInvocation.data).toBeNull();
+      expect(store.toolResult.data).toBeNull();
     });
   });
 

--- a/src/store/modules/conversational/autoWidgets.ts
+++ b/src/store/modules/conversational/autoWidgets.ts
@@ -16,6 +16,9 @@ interface AutoWidgetState {
   };
 }
 
+let agentInvocationAbortController: AbortController | null = null;
+let toolResultAbortController: AbortController | null = null;
+
 export const useAutoWidgets = defineStore('autoWidgets', {
   state: (): AutoWidgetState => ({
     agentInvocation: {
@@ -32,14 +35,21 @@ export const useAutoWidgets = defineStore('autoWidgets', {
 
   actions: {
     async loadAgentInvocationData() {
-      if (this.agentInvocation.isLoading) return;
+      if (agentInvocationAbortController) {
+        agentInvocationAbortController.abort();
+      }
+      agentInvocationAbortController = new AbortController();
+      const { signal } = agentInvocationAbortController;
 
       this.agentInvocation.isLoading = true;
       this.agentInvocation.error = false;
 
       try {
         const response =
-          await WidgetConversationalService.getAgentInvocationData();
+          await WidgetConversationalService.getAgentInvocationData(
+            {},
+            { signal },
+          );
         this.agentInvocation.data = response;
 
         if (response.results?.length > 0) {
@@ -47,21 +57,31 @@ export const useAutoWidgets = defineStore('autoWidgets', {
           conversational.setHasEndpointData(true);
         }
       } catch (error) {
+        if (signal.aborted) return;
         this.agentInvocation.error = true;
         console.error('Error loading agent invocation data', error);
       } finally {
-        this.agentInvocation.isLoading = false;
+        if (!signal.aborted) {
+          this.agentInvocation.isLoading = false;
+        }
       }
     },
 
     async loadToolResultData() {
-      if (this.toolResult.isLoading) return;
+      if (toolResultAbortController) {
+        toolResultAbortController.abort();
+      }
+      toolResultAbortController = new AbortController();
+      const { signal } = toolResultAbortController;
 
       this.toolResult.isLoading = true;
       this.toolResult.error = false;
 
       try {
-        const response = await WidgetConversationalService.getToolResultData();
+        const response = await WidgetConversationalService.getToolResultData(
+          {},
+          { signal },
+        );
         this.toolResult.data = response;
 
         if (response.results?.length > 0) {
@@ -69,10 +89,13 @@ export const useAutoWidgets = defineStore('autoWidgets', {
           conversational.setHasEndpointData(true);
         }
       } catch (error) {
+        if (signal.aborted) return;
         this.toolResult.error = true;
         console.error('Error loading tool result data', error);
       } finally {
-        this.toolResult.isLoading = false;
+        if (!signal.aborted) {
+          this.toolResult.isLoading = false;
+        }
       }
     },
 
@@ -84,6 +107,14 @@ export const useAutoWidgets = defineStore('autoWidgets', {
     },
 
     resetAutoWidgets() {
+      if (agentInvocationAbortController) {
+        agentInvocationAbortController.abort();
+        agentInvocationAbortController = null;
+      }
+      if (toolResultAbortController) {
+        toolResultAbortController.abort();
+        toolResultAbortController = null;
+      }
       this.agentInvocation = { data: null, isLoading: false, error: false };
       this.toolResult = { data: null, isLoading: false, error: false };
     },

--- a/src/store/modules/conversational/customWidgets.ts
+++ b/src/store/modules/conversational/customWidgets.ts
@@ -16,6 +16,8 @@ import i18n from '@/utils/plugins/i18n';
 export const MOCK_CUSTOM_UUID = 'mock-custom';
 export const MOCK_CROSSTAB_UUID = 'mock-crosstab';
 
+const abortControllersByUuid = new Map<string, AbortController>();
+
 interface customForm {
   agent_uuid: string;
   agent_name: string;
@@ -365,13 +367,21 @@ export const useCustomWidgets = defineStore('customWidgets', {
       }
     },
     async loadCustomWidgetData(uuid: string) {
-      if (this.loadingByUuid.includes(uuid)) return;
+      const existingController = abortControllersByUuid.get(uuid);
+      if (existingController) {
+        existingController.abort();
+      }
+      const controller = new AbortController();
+      abortControllersByUuid.set(uuid, controller);
+      const { signal } = controller;
 
       const widget = this.getCustomWidgetByUuid(uuid);
 
       if (!widget) return;
 
-      this.loadingByUuid.push(uuid);
+      if (!this.loadingByUuid.includes(uuid)) {
+        this.loadingByUuid.push(uuid);
+      }
 
       try {
         const sourceMap = {
@@ -381,16 +391,18 @@ export const useCustomWidgets = defineStore('customWidgets', {
             WidgetConversationalService.getCrosstabWidgetData,
         };
         const dataRequest = sourceMap[widget.source as keyof typeof sourceMap];
-        const response = await dataRequest({
-          widget_uuid: uuid,
-        });
+        const response = await dataRequest({ widget_uuid: uuid }, { signal });
         this.updateCustomWidget(uuid, response);
         this.customWidgetDataErrorByUuid[uuid] = false;
       } catch (error) {
+        if (signal.aborted) return;
         this.customWidgetDataErrorByUuid[uuid] = error.status || true;
         console.error('Error loading custom widget data', error);
       } finally {
-        this.loadingByUuid = this.loadingByUuid.filter((id) => id !== uuid);
+        if (!signal.aborted) {
+          this.loadingByUuid = this.loadingByUuid.filter((id) => id !== uuid);
+          abortControllersByUuid.delete(uuid);
+        }
       }
     },
   },

--- a/src/store/modules/conversational/widgets.ts
+++ b/src/store/modules/conversational/widgets.ts
@@ -39,6 +39,8 @@ interface ConversationalWidgetsState {
 }
 
 let salesFunnelAbortController: AbortController | null = null;
+let csatAbortController: AbortController | null = null;
+let npsAbortController: AbortController | null = null;
 
 export const useConversationalWidgets = defineStore('conversationalWidgets', {
   state: (): ConversationalWidgetsState => ({
@@ -231,6 +233,12 @@ export const useConversationalWidgets = defineStore('conversationalWidgets', {
       }
     },
     async loadCsatWidgetData() {
+      if (csatAbortController) {
+        csatAbortController.abort();
+      }
+      csatAbortController = new AbortController();
+      const { signal } = csatAbortController;
+
       this.isLoadingCsatWidgetData = true;
       try {
         const { shouldUseMock } = useConversational();
@@ -255,19 +263,29 @@ export const useConversationalWidgets = defineStore('conversationalWidgets', {
         const csatData = await WidgetConversationalService.getCsatData(
           this.csatWidgetType,
           { widget_uuid: widgetCsat.uuid },
+          { signal },
         );
 
         this.setCsatWidgetData(csatData);
         this.isCsatWidgetDataError = false;
       } catch (error) {
+        if (signal.aborted) return;
         this.setCsatWidgetData({ results: [] });
         this.isCsatWidgetDataError = true;
         console.error('Error loading CSAT widget data', error);
       } finally {
-        this.isLoadingCsatWidgetData = false;
+        if (!signal.aborted) {
+          this.isLoadingCsatWidgetData = false;
+        }
       }
     },
     async loadNpsWidgetData() {
+      if (npsAbortController) {
+        npsAbortController.abort();
+      }
+      npsAbortController = new AbortController();
+      const { signal } = npsAbortController;
+
       this.isLoadingNpsWidgetData = true;
       try {
         const { shouldUseMock } = useConversational();
@@ -292,16 +310,20 @@ export const useConversationalWidgets = defineStore('conversationalWidgets', {
         const npsData = await WidgetConversationalService.getNpsData(
           this.npsWidgetType,
           { widget_uuid: widgetNps.uuid },
+          { signal },
         );
 
         this.setNpsWidgetData(npsData);
         this.isNpsWidgetDataError = false;
       } catch (error) {
+        if (signal.aborted) return;
         this.setNpsWidgetData({ total_responses: 0 });
         this.isNpsWidgetDataError = true;
         console.error('Error loading NPS widget data', error);
       } finally {
-        this.isLoadingNpsWidgetData = false;
+        if (!signal.aborted) {
+          this.isLoadingNpsWidgetData = false;
+        }
       }
     },
     async saveNewWidget() {


### PR DESCRIPTION
## Description
### Type of Change
* [X] Bugfix
* [X] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [X] Tests
* [ ] Other

### Motivation and Context
When filters change on the conversational dashboard, all widgets fire new API requests. If a previous request completes after a newer one, the stale response overwrites the fresh data, causing the UI to display outdated values. This race condition was already fixed for the SalesFunnel widget using an `AbortController`/`signal` pattern. This PR extends the same treatment to every remaining conversational widget.

### Summary of Changes

**Service layer** (`src/services/api/resources/conversational/widgets.ts`):
- Added an optional `signal?: AbortSignal` parameter to 7 service methods: `getCsatData`, `getNpsData`, `getCustomWidgetData`, `getCrosstabWidgetData`, `getAgentInvocationData`, `getToolResultData`, and `getAbsoluteNumbersChildrenValue`.
- Each method now forwards the signal to its underlying `http.get` / `http2.get` call.

**CSAT & NPS** (`src/store/modules/conversational/widgets.ts`):
- Added module-level `csatAbortController` and `npsAbortController`.
- `loadCsatWidgetData` and `loadNpsWidgetData` now abort any in-flight request before starting a new one, and guard `catch`/`finally` blocks with `signal.aborted` to prevent stale updates.

**Agent Invocation & Tool Result** (`src/store/modules/conversational/autoWidgets.ts`):
- Added module-level `agentInvocationAbortController` and `toolResultAbortController`.
- Replaced the `if (isLoading) return` early-exit guard with the abort pattern — new requests now cancel pending ones instead of being silently dropped.
- `resetAutoWidgets` now aborts any in-flight controllers before resetting state.

**Custom & Crosstab widgets** (`src/store/modules/conversational/customWidgets.ts`):
- Added a module-level `Map<string, AbortController>` keyed by widget UUID, since `loadCustomWidgetData` can be called for multiple widgets concurrently.
- Each call aborts only the previous request for the same UUID.

**Absolute Numbers** (`AbsoluteNumbersMetric.vue`):
- Added a component-level `abortController` variable.
- `getChildrenValue` now aborts the previous request before firing a new one.

**Tests**:
- Updated `autoWidgets.spec.ts`: replaced the "should not make duplicate requests" test with abort-aware tests (signal is aborted on re-call, aborted requests don't set error/loading state, `resetAutoWidgets` aborts in-flight requests, signal is passed to service calls).
- Updated `AbsoluteNumbersMetric.spec.js`: updated call signature assertion to include the signal parameter, added a test verifying abort on rapid re-fetch.