### PR TITLE
[ENGAGE-7896] Feat: unnnic contacts conversational dashboard

### DIFF
--- a/src/components/insights/conversations/ContactsHeader.vue
+++ b/src/components/insights/conversations/ContactsHeader.vue
@@ -27,7 +27,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, watch } from 'vue';
+import { ref, computed, onMounted, onUnmounted, watch } from 'vue';
 import CardConversations from '@/components/insights/cards/CardConversations.vue';
 import Unnnic from '@weni/unnnic-system';
 import { useI18n } from 'vue-i18n';
@@ -136,6 +136,8 @@ const cards = computed(() =>
   shouldUseMock.value ? mockCards.value : apiCards.value,
 );
 
+let loadCardDataAbortController: AbortController | null = null;
+
 watch(
   () => route.query,
   () => {
@@ -199,19 +201,32 @@ const applyMetrics = (metrics: typeof MOCK_CONTACTS_DATA) => {
 };
 
 const loadCardData = async () => {
+  if (loadCardDataAbortController) {
+    loadCardDataAbortController.abort();
+  }
+  loadCardDataAbortController = new AbortController();
+  const { signal } = loadCardDataAbortController;
+
   cardsData.value.forEach((card) => {
     card.isLoading = true;
   });
 
   try {
-    const response =
-      await conversationalContactsApi.getConversationalContacts();
+    const response = await conversationalContactsApi.getConversationalContacts(
+      {},
+      { signal },
+    );
+
+    if (signal.aborted) return;
+
     applyMetrics(response);
     conversationalStore.setEndpointError('contacts', false);
     if (response.length > 0) {
       conversationalStore.setHasEndpointData(true);
     }
   } catch (error) {
+    if (signal.aborted) return;
+
     conversationalStore.setEndpointError('contacts', true);
     console.error('Error loading conversational contacts data:', error);
 
@@ -223,15 +238,24 @@ const loadCardData = async () => {
       showErrorToast();
     }
   } finally {
-    cardsData.value.forEach((card) => {
-      card.isLoading = false;
-    });
+    if (!signal.aborted) {
+      cardsData.value.forEach((card) => {
+        card.isLoading = false;
+      });
+    }
   }
 };
 
 onMounted(() => {
   dashboardsStore.updateLastUpdatedRequest();
   loadCardData();
+});
+
+onUnmounted(() => {
+  if (loadCardDataAbortController) {
+    loadCardDataAbortController.abort();
+    loadCardDataAbortController = null;
+  }
 });
 </script>
 

--- a/src/components/insights/conversations/ContactsHeader.vue
+++ b/src/components/insights/conversations/ContactsHeader.vue
@@ -1,0 +1,255 @@
+<template>
+  <section
+    class="dashboard-conversational__contacts-header"
+    data-testid="contacts-header"
+  >
+    <section
+      class="header__cards"
+      data-testid="contacts-header-left"
+    >
+      <template
+        v-for="(card, index) in cards"
+        :key="card.id"
+      >
+        <CardConversations
+          class="header__card"
+          :title="card.title"
+          :value="card.value"
+          :description="card.description"
+          :tooltipInfo="card.tooltipInfo"
+          :borderRadius="getBorderRadius(index, cards.length)"
+          :tooltipSide="handleTooltipSide(card.id)"
+          :isLoading="card.isLoading"
+        />
+      </template>
+    </section>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted, watch } from 'vue';
+import CardConversations from '@/components/insights/cards/CardConversations.vue';
+import Unnnic from '@weni/unnnic-system';
+import { useI18n } from 'vue-i18n';
+import { useWidgetFormatting } from '@/composables/useWidgetFormatting';
+import conversationalContactsApi from '@/services/api/resources/conversational/contacts';
+import { MOCK_CONTACTS_DATA } from '@/services/api/resources/conversational/mocks';
+import { useRoute } from 'vue-router';
+import { useConversational } from '@/store/modules/conversational/conversational';
+import { useDashboards } from '@/store/modules/dashboards';
+import { storeToRefs } from 'pinia';
+import type { ContactMetricId } from '@/services/api/resources/conversational/contacts';
+
+const { formatPercentage, formatNumber } = useWidgetFormatting();
+
+const { t } = useI18n();
+
+const route = useRoute();
+
+const dashboardsStore = useDashboards();
+const conversationalStore = useConversational();
+const { shouldUseMock } = storeToRefs(conversationalStore);
+
+const cardDefinitions: {
+  id: ContactMetricId;
+  titleKey: string;
+  tooltipKey: string;
+}[] = [
+  {
+    id: 'unique',
+    titleKey: 'conversations_dashboard.contacts_header.unique',
+    tooltipKey: 'conversations_dashboard.contacts_header.tooltips.unique',
+  },
+  {
+    id: 'returning',
+    titleKey: 'conversations_dashboard.contacts_header.returning',
+    tooltipKey: 'conversations_dashboard.contacts_header.tooltips.returning',
+  },
+  {
+    id: 'avg_conversations_per_contact',
+    titleKey: 'conversations_dashboard.contacts_header.avg',
+    tooltipKey: 'conversations_dashboard.contacts_header.tooltips.avg',
+  },
+];
+
+const createInitialCardData = () => ({
+  value: '-',
+  description: null as string | null,
+  isLoading: true,
+});
+
+const cardsData = ref(
+  cardDefinitions.map((def) => ({
+    id: def.id,
+    ...createInitialCardData(),
+  })),
+);
+
+const formatMetricValue = (
+  id: ContactMetricId,
+  metric: { value: number; percentage?: number },
+) => {
+  if (id === 'returning') {
+    return {
+      value: formatNumber(metric.value),
+      description:
+        typeof metric.percentage === 'number'
+          ? `${formatPercentage(metric.percentage)} ${t(
+              'conversations_dashboard.contacts_header.returning_description_suffix',
+            )}`
+          : null,
+    };
+  }
+
+  return { value: formatNumber(metric.value), description: null };
+};
+
+const mockCards = computed(() => {
+  return cardDefinitions.map((def) => {
+    const metric = MOCK_CONTACTS_DATA.find((m) => m.id === def.id);
+    const formatted = metric
+      ? formatMetricValue(def.id, metric)
+      : { value: '-', description: null };
+
+    return {
+      id: def.id,
+      title: t(def.titleKey),
+      tooltipInfo: t(def.tooltipKey),
+      isLoading: false,
+      ...formatted,
+    };
+  });
+});
+
+const apiCards = computed(() =>
+  cardDefinitions.map((def, index) => ({
+    id: def.id,
+    title: t(def.titleKey),
+    value: cardsData.value[index].value,
+    description: cardsData.value[index].description,
+    tooltipInfo: t(def.tooltipKey),
+    isLoading: cardsData.value[index].isLoading,
+  })),
+);
+
+const cards = computed(() =>
+  shouldUseMock.value ? mockCards.value : apiCards.value,
+);
+
+watch(
+  () => route.query,
+  () => {
+    if (shouldUseMock.value) return;
+    dashboardsStore.updateLastUpdatedRequest();
+    loadCardData();
+  },
+);
+
+watch(
+  () => conversationalStore.refreshDataConversational,
+  (newValue) => {
+    if (newValue && !shouldUseMock.value) {
+      dashboardsStore.updateLastUpdatedRequest();
+      conversationalStore.setIsLoadingConversationalData(
+        'contactsHeader',
+        true,
+      );
+      loadCardData().finally(() => {
+        conversationalStore.setIsLoadingConversationalData(
+          'contactsHeader',
+          false,
+        );
+      });
+    }
+  },
+);
+
+const getBorderRadius = (index: number, totalCards: number) => {
+  if (totalCards === 1) return 'full';
+  if (index === 0) return 'left';
+  if (index === totalCards - 1) return 'right';
+  return 'none';
+};
+
+const handleTooltipSide = (cardId: ContactMetricId) => {
+  if (cardId === 'avg_conversations_per_contact') return 'left';
+  return 'top';
+};
+
+const showErrorToast = () => {
+  Unnnic.unnnicCallAlert({
+    props: {
+      text: t('widgets.graph_funnel.error.title'),
+      type: 'error',
+    },
+    containerRef: null,
+  });
+};
+
+const applyMetrics = (metrics: typeof MOCK_CONTACTS_DATA) => {
+  metrics.forEach((metric) => {
+    const cardToUpdate = cardsData.value.find((card) => card.id === metric.id);
+
+    if (cardToUpdate) {
+      const formatted = formatMetricValue(metric.id, metric);
+      cardToUpdate.value = formatted.value;
+      cardToUpdate.description = formatted.description;
+    }
+  });
+};
+
+const loadCardData = async () => {
+  cardsData.value.forEach((card) => {
+    card.isLoading = true;
+  });
+
+  try {
+    const response =
+      await conversationalContactsApi.getConversationalContacts();
+    applyMetrics(response);
+    conversationalStore.setEndpointError('contacts', false);
+    if (response.length > 0) {
+      conversationalStore.setHasEndpointData(true);
+    }
+  } catch (error) {
+    conversationalStore.setEndpointError('contacts', true);
+    console.error('Error loading conversational contacts data:', error);
+
+    cardsData.value.forEach((card) => {
+      card.value = '-';
+      card.description = null;
+    });
+    if (!conversationalStore.shouldUseMock) {
+      showErrorToast();
+    }
+  } finally {
+    cardsData.value.forEach((card) => {
+      card.isLoading = false;
+    });
+  }
+};
+
+onMounted(() => {
+  dashboardsStore.updateLastUpdatedRequest();
+  loadCardData();
+});
+</script>
+
+<style scoped lang="scss">
+$min-height: 134px;
+
+.dashboard-conversational__contacts-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: $unnnic-space-4;
+
+  width: 100%;
+
+  .header__cards {
+    display: flex;
+    width: 100%;
+    min-height: $min-height;
+  }
+}
+</style>

--- a/src/components/insights/conversations/__tests__/ContactsHeader.spec.js
+++ b/src/components/insights/conversations/__tests__/ContactsHeader.spec.js
@@ -256,7 +256,12 @@ describe('ContactsHeader.vue', () => {
       const vm = wrapper.vm;
       await vm.loadCardData();
 
-      expect(contactsApi.default.getConversationalContacts).toHaveBeenCalled();
+      expect(
+        contactsApi.default.getConversationalContacts,
+      ).toHaveBeenCalledWith(
+        {},
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
 
       expect(vm.cardsData[0].value).toBe('80');
       expect(vm.cardsData[0].description).toBe(null);

--- a/src/components/insights/conversations/__tests__/ContactsHeader.spec.js
+++ b/src/components/insights/conversations/__tests__/ContactsHeader.spec.js
@@ -1,0 +1,526 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ref as vueRef, reactive } from 'vue';
+import { mount, config } from '@vue/test-utils';
+
+import ContactsHeader from '../ContactsHeader.vue';
+
+import { createI18n } from 'vue-i18n';
+import Unnnic from '@weni/unnnic-system';
+
+vi.mock('@weni/unnnic-system', () => ({
+  default: {
+    unnnicCallAlert: vi.fn(),
+  },
+}));
+
+vi.mock('@/services/api/resources/conversational/contacts', () => ({
+  default: {
+    getConversationalContacts: vi.fn().mockResolvedValue([
+      { id: 'unique', value: 0 },
+      { id: 'returning', value: 0, percentage: 0 },
+      { id: 'avg_conversations_per_contact', value: 0 },
+    ]),
+  },
+}));
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({
+    params: {},
+    query: {},
+  }),
+  useRouter: () => ({
+    push: vi.fn(),
+  }),
+}));
+
+vi.mock('@/store/modules/dashboards', () => ({
+  useDashboards: () => ({
+    appliedFilters: {
+      ended_at: {
+        __gte: '2024-01-01',
+        __lte: '2024-01-31',
+      },
+    },
+    updateLastUpdatedRequest: vi.fn(),
+  }),
+}));
+
+const mockShouldUseMock = vueRef(false);
+const mockSetHasEndpointData = vi.fn();
+const mockSetEndpointError = vi.fn();
+const mockSetIsLoadingConversationalData = vi.fn();
+
+vi.mock('@/store/modules/conversational/conversational', () => {
+  return {
+    useConversational: () =>
+      reactive({
+        refreshDataConversational: false,
+        setIsLoadingConversationalData: mockSetIsLoadingConversationalData,
+        setEndpointError: mockSetEndpointError,
+        setHasEndpointData: mockSetHasEndpointData,
+        shouldUseMock: mockShouldUseMock,
+      }),
+  };
+});
+
+vi.mock('@/composables/useWidgetFormatting', () => ({
+  useWidgetFormatting: () => ({
+    formatPercentage: vi.fn((value) => `${value.toFixed(2)}%`),
+    formatNumber: vi.fn((value) =>
+      value.toLocaleString('en-US', {
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 3,
+      }),
+    ),
+  }),
+}));
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      conversations_dashboard: {
+        contacts_header: {
+          unique: 'Unique contacts',
+          returning: 'Returning contacts',
+          avg: 'Average conversations per contact',
+          returning_description_suffix: 'of total unique contacts',
+          tooltips: {
+            unique:
+              'Number of distinct contacts who started conversations during the selected period.',
+            returning:
+              'Contacts who started more than one conversation during the selected period.',
+            avg: 'Average conversations considering all unique contacts during the period.',
+          },
+        },
+      },
+      widgets: {
+        graph_funnel: {
+          error: {
+            title: 'Error loading data',
+          },
+        },
+      },
+    },
+  },
+  fallbackWarn: false,
+  missingWarn: false,
+});
+
+config.global.plugins = [i18n];
+
+const createWrapper = () => {
+  return mount(ContactsHeader, {
+    global: { plugins: [Unnnic] },
+  });
+};
+
+describe('ContactsHeader.vue', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    wrapper = createWrapper();
+  });
+
+  describe('Component Structure', () => {
+    it('should render contacts header structure correctly', () => {
+      expect(wrapper.find('[data-testid="contacts-header"]').exists()).toBe(
+        true,
+      );
+      expect(
+        wrapper.find('[data-testid="contacts-header-left"]').exists(),
+      ).toBe(true);
+    });
+
+    it('should render 3 cards in left section', () => {
+      const leftSection = wrapper.find('[data-testid="contacts-header-left"]');
+
+      expect(
+        leftSection.findAllComponents({ name: 'CardConversations' }),
+      ).toHaveLength(3);
+    });
+  });
+
+  describe('Card Definitions', () => {
+    it('should have correct card definitions structure', () => {
+      const vm = wrapper.vm;
+      expect(vm.cardDefinitions).toHaveLength(3);
+
+      expect(vm.cardDefinitions[0]).toEqual({
+        id: 'unique',
+        titleKey: 'conversations_dashboard.contacts_header.unique',
+        tooltipKey: 'conversations_dashboard.contacts_header.tooltips.unique',
+      });
+
+      expect(vm.cardDefinitions[1]).toEqual({
+        id: 'returning',
+        titleKey: 'conversations_dashboard.contacts_header.returning',
+        tooltipKey:
+          'conversations_dashboard.contacts_header.tooltips.returning',
+      });
+
+      expect(vm.cardDefinitions[2]).toEqual({
+        id: 'avg_conversations_per_contact',
+        titleKey: 'conversations_dashboard.contacts_header.avg',
+        tooltipKey: 'conversations_dashboard.contacts_header.tooltips.avg',
+      });
+    });
+
+    it('should create initial card data correctly', () => {
+      const vm = wrapper.vm;
+      const initialData = vm.createInitialCardData();
+
+      expect(initialData).toEqual({
+        value: '-',
+        description: null,
+        isLoading: true,
+      });
+    });
+  });
+
+  describe('Initial Loading States', () => {
+    it('should display initial titles and tooltips correctly', () => {
+      const cards = wrapper
+        .find('[data-testid="contacts-header-left"]')
+        .findAllComponents({ name: 'CardConversations' });
+
+      expect(cards[0].props('title')).toBe('Unique contacts');
+      expect(cards[1].props('title')).toBe('Returning contacts');
+      expect(cards[2].props('title')).toBe('Average conversations per contact');
+    });
+
+    it('should initialize cardsData with correct structure', async () => {
+      const contactsApi = await import(
+        '@/services/api/resources/conversational/contacts'
+      );
+      contactsApi.default.getConversationalContacts.mockResolvedValue([
+        { id: 'unique', value: 0 },
+        { id: 'returning', value: 0, percentage: 0 },
+        { id: 'avg_conversations_per_contact', value: 0 },
+      ]);
+
+      const testWrapper = createWrapper();
+      const vm = testWrapper.vm;
+
+      await testWrapper.vm.$nextTick();
+      await testWrapper.vm.$nextTick();
+
+      expect(vm.cardsData).toHaveLength(3);
+    });
+  });
+
+  describe('Border Radius Logic', () => {
+    const borderRadiusTests = [
+      { index: 0, total: 3, expected: 'left' },
+      { index: 1, total: 3, expected: 'none' },
+      { index: 2, total: 3, expected: 'right' },
+      { index: 0, total: 1, expected: 'full' },
+    ];
+
+    borderRadiusTests.forEach(({ index, total, expected }) => {
+      it(`should apply ${expected} border radius for card ${index} of ${total}`, () => {
+        const vm = wrapper.vm;
+        expect(vm.getBorderRadius(index, total)).toBe(expected);
+      });
+    });
+
+    it('should apply correct border radius across rendered cards', () => {
+      const cards = wrapper
+        .find('[data-testid="contacts-header-left"]')
+        .findAllComponents({ name: 'CardConversations' });
+
+      expect(cards[0].props('borderRadius')).toBe('left');
+      expect(cards[1].props('borderRadius')).toBe('none');
+      expect(cards[2].props('borderRadius')).toBe('right');
+    });
+  });
+
+  describe('API Data Loading', () => {
+    it('should handle successful API data loading', async () => {
+      const mockApiResponse = [
+        { id: 'unique', value: 80 },
+        { id: 'returning', value: 28, percentage: 35 },
+        { id: 'avg_conversations_per_contact', value: 1.25 },
+      ];
+
+      const contactsApi = await import(
+        '@/services/api/resources/conversational/contacts'
+      );
+      contactsApi.default.getConversationalContacts.mockResolvedValue(
+        mockApiResponse,
+      );
+
+      const vm = wrapper.vm;
+      await vm.loadCardData();
+
+      expect(contactsApi.default.getConversationalContacts).toHaveBeenCalled();
+
+      expect(vm.cardsData[0].value).toBe('80');
+      expect(vm.cardsData[0].description).toBe(null);
+
+      expect(vm.cardsData[1].value).toBe('28');
+      expect(vm.cardsData[1].description).toBe(
+        '35.00% of total unique contacts',
+      );
+
+      expect(vm.cardsData[2].value).toBe('1.25');
+      expect(vm.cardsData[2].description).toBe(null);
+
+      expect(vm.cardsData.every((card) => !card.isLoading)).toBe(true);
+    });
+
+    it('should call setHasEndpointData on successful non-empty API response', async () => {
+      const mockApiResponse = [
+        { id: 'unique', value: 80 },
+        { id: 'returning', value: 28, percentage: 35 },
+        { id: 'avg_conversations_per_contact', value: 1.25 },
+      ];
+
+      const contactsApi = await import(
+        '@/services/api/resources/conversational/contacts'
+      );
+      contactsApi.default.getConversationalContacts.mockResolvedValue(
+        mockApiResponse,
+      );
+
+      mockSetHasEndpointData.mockClear();
+
+      const vm = wrapper.vm;
+      await vm.loadCardData();
+
+      expect(mockSetHasEndpointData).toHaveBeenCalledWith(true);
+    });
+
+    it('should not call setHasEndpointData on empty API response', async () => {
+      const contactsApi = await import(
+        '@/services/api/resources/conversational/contacts'
+      );
+      contactsApi.default.getConversationalContacts.mockResolvedValue([]);
+
+      mockSetHasEndpointData.mockClear();
+
+      const vm = wrapper.vm;
+      await vm.loadCardData();
+
+      expect(mockSetHasEndpointData).not.toHaveBeenCalled();
+    });
+
+    it('should set contacts endpoint error to false on success', async () => {
+      const mockApiResponse = [
+        { id: 'unique', value: 1 },
+        { id: 'returning', value: 1, percentage: 1 },
+        { id: 'avg_conversations_per_contact', value: 1 },
+      ];
+
+      const contactsApi = await import(
+        '@/services/api/resources/conversational/contacts'
+      );
+      contactsApi.default.getConversationalContacts.mockResolvedValue(
+        mockApiResponse,
+      );
+
+      mockSetEndpointError.mockClear();
+
+      const vm = wrapper.vm;
+      await vm.loadCardData();
+
+      expect(mockSetEndpointError).toHaveBeenCalledWith('contacts', false);
+    });
+
+    it('should handle API error loading', async () => {
+      const consoleSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      const contactsApi = await import(
+        '@/services/api/resources/conversational/contacts'
+      );
+      contactsApi.default.getConversationalContacts.mockRejectedValue(
+        new Error('API Error'),
+      );
+
+      mockSetEndpointError.mockClear();
+
+      const vm = wrapper.vm;
+      await vm.loadCardData();
+
+      expect(contactsApi.default.getConversationalContacts).toHaveBeenCalled();
+
+      vm.cardsData.forEach((card) => {
+        expect(card.value).toBe('-');
+        expect(card.description).toBe(null);
+        expect(card.isLoading).toBe(false);
+      });
+
+      expect(mockSetEndpointError).toHaveBeenCalledWith('contacts', true);
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'Error loading conversational contacts data:',
+        expect.any(Error),
+      );
+
+      expect(Unnnic.unnnicCallAlert).toHaveBeenCalledWith({
+        props: {
+          text: 'Error loading data',
+          type: 'error',
+        },
+        containerRef: null,
+      });
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('Tooltip Side Logic', () => {
+    it('should return left side for avg card', () => {
+      const vm = wrapper.vm;
+      expect(vm.handleTooltipSide('avg_conversations_per_contact')).toBe(
+        'left',
+      );
+    });
+
+    it('should return top side for other cards', () => {
+      const vm = wrapper.vm;
+      expect(vm.handleTooltipSide('unique')).toBe('top');
+      expect(vm.handleTooltipSide('returning')).toBe('top');
+    });
+  });
+
+  describe('Translation Coverage', () => {
+    it('should display translated tooltips correctly', () => {
+      const cards = wrapper
+        .find('[data-testid="contacts-header-left"]')
+        .findAllComponents({ name: 'CardConversations' });
+
+      expect(cards[0].props('tooltipInfo')).toBe(
+        'Number of distinct contacts who started conversations during the selected period.',
+      );
+      expect(cards[1].props('tooltipInfo')).toBe(
+        'Contacts who started more than one conversation during the selected period.',
+      );
+      expect(cards[2].props('tooltipInfo')).toBe(
+        'Average conversations considering all unique contacts during the period.',
+      );
+    });
+  });
+
+  describe('Non-clickable cards', () => {
+    it('should not pass isClickable prop to cards', () => {
+      const cards = wrapper
+        .find('[data-testid="contacts-header-left"]')
+        .findAllComponents({ name: 'CardConversations' });
+
+      cards.forEach((card) => {
+        expect(card.props('isClickable')).toBeFalsy();
+      });
+    });
+  });
+
+  describe('Mock mode (shouldUseMock = true)', () => {
+    beforeEach(() => {
+      mockShouldUseMock.value = true;
+    });
+
+    afterEach(() => {
+      mockShouldUseMock.value = false;
+    });
+
+    it('should still call API on mount when shouldUseMock is true', async () => {
+      const contactsApi = await import(
+        '@/services/api/resources/conversational/contacts'
+      );
+      contactsApi.default.getConversationalContacts.mockClear();
+
+      createWrapper();
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(contactsApi.default.getConversationalContacts).toHaveBeenCalled();
+    });
+
+    it('should render mock cards with formatted values directly', () => {
+      const testWrapper = createWrapper();
+      const vm = testWrapper.vm;
+
+      expect(vm.cards).toHaveLength(3);
+      vm.cards.forEach((card) => {
+        expect(card.isLoading).toBe(false);
+        expect(card.value).not.toBe('-');
+      });
+    });
+
+    it('should render unique with formatted number and no description', () => {
+      const testWrapper = createWrapper();
+      const vm = testWrapper.vm;
+
+      const uniqueCard = vm.cards.find((c) => c.id === 'unique');
+      expect(uniqueCard.value).toBe('80');
+      expect(uniqueCard.description).toBeNull();
+    });
+
+    it('should render returning with formatted number and percentage description', () => {
+      const testWrapper = createWrapper();
+      const vm = testWrapper.vm;
+
+      const returningCard = vm.cards.find((c) => c.id === 'returning');
+      expect(returningCard.value).toBe('28');
+      expect(returningCard.description).toBe('35.00% of total unique contacts');
+    });
+
+    it('should render avg card with formatted decimal and no description', () => {
+      const testWrapper = createWrapper();
+      const vm = testWrapper.vm;
+
+      const avgCard = vm.cards.find(
+        (c) => c.id === 'avg_conversations_per_contact',
+      );
+      expect(avgCard.value).toBe('1.8');
+      expect(avgCard.description).toBeNull();
+    });
+  });
+
+  describe('Computed Properties Reactivity', () => {
+    it('should reactively compute card properties', () => {
+      const vm = wrapper.vm;
+
+      expect(vm.cards).toHaveLength(3);
+
+      vm.cards.forEach((card) => {
+        expect(card).toHaveProperty('id');
+        expect(card).toHaveProperty('title');
+        expect(card).toHaveProperty('value');
+        expect(card).toHaveProperty('description');
+        expect(card).toHaveProperty('tooltipInfo');
+        expect(card).toHaveProperty('isLoading');
+      });
+    });
+  });
+
+  describe('API Functions', () => {
+    it('should test loadCardData function exists', () => {
+      const vm = wrapper.vm;
+      expect(vm.loadCardData).toBeDefined();
+      expect(typeof vm.loadCardData).toBe('function');
+    });
+
+    it('should test showErrorToast function', () => {
+      const vm = wrapper.vm;
+      expect(vm.showErrorToast).toBeDefined();
+      expect(typeof vm.showErrorToast).toBe('function');
+
+      vm.showErrorToast();
+      expect(Unnnic.unnnicCallAlert).toHaveBeenCalled();
+    });
+  });
+
+  describe('Component Lifecycle', () => {
+    it('should mount component successfully', () => {
+      const testWrapper = createWrapper();
+
+      expect(testWrapper.exists()).toBe(true);
+      expect(testWrapper.vm.cardsData).toHaveLength(3);
+    });
+  });
+});

--- a/src/components/insights/conversations/__tests__/ContactsHeader.spec.js
+++ b/src/components/insights/conversations/__tests__/ContactsHeader.spec.js
@@ -379,6 +379,149 @@ describe('ContactsHeader.vue', () => {
     });
   });
 
+  describe('Abort Signal Handling', () => {
+    it('should pass an AbortSignal to the contacts service on each call', async () => {
+      const contactsApi = await import(
+        '@/services/api/resources/conversational/contacts'
+      );
+      contactsApi.default.getConversationalContacts.mockResolvedValue([
+        { id: 'unique', value: 1 },
+        { id: 'returning', value: 1, percentage: 1 },
+        { id: 'avg_conversations_per_contact', value: 1 },
+      ]);
+
+      const vm = wrapper.vm;
+      await vm.loadCardData();
+
+      const callArgs =
+        contactsApi.default.getConversationalContacts.mock.calls.at(-1);
+
+      expect(callArgs[1]).toBeDefined();
+      expect(callArgs[1].signal).toBeInstanceOf(AbortSignal);
+    });
+
+    it('should abort the previous in-flight request when called again', async () => {
+      const contactsApi = await import(
+        '@/services/api/resources/conversational/contacts'
+      );
+
+      const capturedSignals = [];
+      contactsApi.default.getConversationalContacts
+        .mockImplementationOnce((_q, options) => {
+          capturedSignals.push(options.signal);
+          return new Promise((resolve) => {
+            options.signal.addEventListener('abort', () =>
+              resolve([
+                { id: 'unique', value: 0 },
+                { id: 'returning', value: 0, percentage: 0 },
+                { id: 'avg_conversations_per_contact', value: 0 },
+              ]),
+            );
+          });
+        })
+        .mockImplementationOnce((_q, options) => {
+          capturedSignals.push(options.signal);
+          return Promise.resolve([
+            { id: 'unique', value: 1 },
+            { id: 'returning', value: 1, percentage: 1 },
+            { id: 'avg_conversations_per_contact', value: 1 },
+          ]);
+        });
+
+      const vm = wrapper.vm;
+
+      const firstPromise = vm.loadCardData();
+      const secondPromise = vm.loadCardData();
+
+      await Promise.all([firstPromise, secondPromise]);
+
+      expect(capturedSignals).toHaveLength(2);
+      expect(capturedSignals[0].aborted).toBe(true);
+      expect(capturedSignals[1].aborted).toBe(false);
+    });
+
+    it('should not apply data from an aborted (older) request', async () => {
+      const contactsApi = await import(
+        '@/services/api/resources/conversational/contacts'
+      );
+
+      let resolveOldRequest;
+      const oldPromise = new Promise((resolve) => {
+        resolveOldRequest = resolve;
+      });
+
+      const newResponse = [
+        { id: 'unique', value: 999 },
+        { id: 'returning', value: 999, percentage: 99 },
+        { id: 'avg_conversations_per_contact', value: 99 },
+      ];
+
+      contactsApi.default.getConversationalContacts
+        .mockReturnValueOnce(oldPromise)
+        .mockResolvedValueOnce(newResponse);
+
+      const vm = wrapper.vm;
+
+      const firstCall = vm.loadCardData();
+      const secondCall = vm.loadCardData();
+
+      await secondCall;
+
+      resolveOldRequest([
+        { id: 'unique', value: 1 },
+        { id: 'returning', value: 1, percentage: 1 },
+        { id: 'avg_conversations_per_contact', value: 1 },
+      ]);
+      await firstCall;
+
+      const uniqueCard = vm.cardsData.find((c) => c.id === 'unique');
+      expect(uniqueCard.value).toBe('999');
+    });
+
+    it('should ignore aborted error and not raise the error toast', async () => {
+      const consoleSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      Unnnic.unnnicCallAlert.mockClear();
+      mockSetEndpointError.mockClear();
+
+      const contactsApi = await import(
+        '@/services/api/resources/conversational/contacts'
+      );
+
+      let abortedSignal;
+      contactsApi.default.getConversationalContacts
+        .mockImplementationOnce((_q, options) => {
+          abortedSignal = options.signal;
+          return new Promise((_resolve, reject) => {
+            options.signal.addEventListener('abort', () => {
+              const abortError = new Error('Aborted');
+              abortError.name = 'AbortError';
+              reject(abortError);
+            });
+          });
+        })
+        .mockResolvedValueOnce([
+          { id: 'unique', value: 5 },
+          { id: 'returning', value: 5, percentage: 5 },
+          { id: 'avg_conversations_per_contact', value: 5 },
+        ]);
+
+      const vm = wrapper.vm;
+
+      const first = vm.loadCardData();
+      const second = vm.loadCardData();
+
+      await Promise.all([first, second]);
+
+      expect(abortedSignal.aborted).toBe(true);
+      expect(Unnnic.unnnicCallAlert).not.toHaveBeenCalled();
+      expect(mockSetEndpointError).not.toHaveBeenCalledWith('contacts', true);
+
+      consoleSpy.mockRestore();
+    });
+  });
+
   describe('Tooltip Side Logic', () => {
     it('should return left side for avg card', () => {
       const vm = wrapper.vm;

--- a/src/components/insights/dashboards/Conversational.vue
+++ b/src/components/insights/dashboards/Conversational.vue
@@ -2,7 +2,25 @@
   <section class="dashboard-conversational">
     <Info class="dashboard-conversational__info" />
 
-    <DashboardHeader class="dashboard-conversational__header" />
+    <section
+      class="dashboard-conversational__section"
+      data-testid="conversations-section"
+    >
+      <h2 class="dashboard-conversational__section-title">
+        {{ $t('conversations_dashboard.sections.conversations') }}
+      </h2>
+      <DashboardHeader class="dashboard-conversational__header" />
+    </section>
+
+    <section
+      class="dashboard-conversational__section"
+      data-testid="contacts-section"
+    >
+      <h2 class="dashboard-conversational__section-title">
+        {{ $t('conversations_dashboard.sections.contacts') }}
+      </h2>
+      <ContactsHeader class="dashboard-conversational__header" />
+    </section>
 
     <MostTalkedAboutTopicsWidget
       class="dashboard-conversational__most-talked-about-topics"
@@ -36,6 +54,7 @@
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
 import { storeToRefs } from 'pinia';
 import DashboardHeader from '@/components/insights/conversations/DashboardHeader.vue';
+import ContactsHeader from '@/components/insights/conversations/ContactsHeader.vue';
 import MostTalkedAboutTopicsWidget from '@/components/insights/conversations/MostTalkedAboutTopicsWidget/index.vue';
 import ConversationalDynamicWidget from '@/components/insights/conversations/ConversationalDynamicWidget.vue';
 import { useWidgets } from '@/store/modules/widgets';
@@ -247,6 +266,20 @@ $layout-gap: $unnnic-space-4;
   display: flex;
   gap: $layout-gap;
   flex-wrap: wrap;
+
+  &__section {
+    display: flex;
+    flex-direction: column;
+    gap: $unnnic-space-2;
+    width: 100%;
+  }
+
+  &__section-title {
+    color: $unnnic-color-gray-12;
+    font: $unnnic-font-display-2;
+    font-weight: 900;
+    margin: 0;
+  }
 
   &__header {
     width: 100%;

--- a/src/components/insights/dashboards/__tests__/Conversational.spec.js
+++ b/src/components/insights/dashboards/__tests__/Conversational.spec.js
@@ -66,7 +66,12 @@ describe('Conversational.vue', () => {
       shouldUseMock: false,
       hasEndpointErrors: false,
       hasEndpointData: false,
-      endpointErrors: { topics: false, header: false, widgets: false },
+      endpointErrors: {
+        topics: false,
+        header: false,
+        widgets: false,
+        contacts: false,
+      },
       isConfigurationLoaded: ref(true),
       setConfigurationLoaded: vi.fn(),
       setHasEndpointData: vi.fn(),
@@ -91,12 +96,38 @@ describe('Conversational.vue', () => {
       global: {
         stubs: {
           DashboardHeader: true,
+          ContactsHeader: true,
           MostTalkedAboutTopicsWidget: true,
           ConversationalDynamicWidget: true,
           CustomizableDrawer: true,
           Info: true,
         },
       },
+    });
+  });
+
+  describe('Sections layout', () => {
+    it('should render the conversations section with the DashboardHeader', () => {
+      const section = wrapper.find('[data-testid="conversations-section"]');
+      expect(section.exists()).toBe(true);
+      expect(section.findComponent({ name: 'DashboardHeader' }).exists()).toBe(
+        true,
+      );
+    });
+
+    it('should render the contacts section with the ContactsHeader', () => {
+      const section = wrapper.find('[data-testid="contacts-section"]');
+      expect(section.exists()).toBe(true);
+      expect(section.findComponent({ name: 'ContactsHeader' }).exists()).toBe(
+        true,
+      );
+    });
+
+    it('should render both section title elements', () => {
+      const titles = wrapper.findAll(
+        '.dashboard-conversational__section-title',
+      );
+      expect(titles).toHaveLength(2);
     });
   });
 
@@ -263,6 +294,7 @@ describe('Conversational.vue', () => {
         global: {
           stubs: {
             DashboardHeader: true,
+            ContactsHeader: true,
             MostTalkedAboutTopicsWidget: true,
             ConversationalDynamicWidget: true,
             CustomizableDrawer: true,
@@ -321,6 +353,7 @@ describe('Conversational.vue', () => {
         global: {
           stubs: {
             DashboardHeader: true,
+            ContactsHeader: true,
             MostTalkedAboutTopicsWidget: true,
             ConversationalDynamicWidget: true,
             CustomizableDrawer: true,
@@ -391,6 +424,7 @@ describe('Conversational.vue', () => {
         global: {
           stubs: {
             DashboardHeader: true,
+            ContactsHeader: true,
             MostTalkedAboutTopicsWidget: true,
             ConversationalDynamicWidget: true,
             CustomizableDrawer: true,
@@ -468,6 +502,7 @@ describe('Conversational.vue', () => {
         global: {
           stubs: {
             DashboardHeader: true,
+            ContactsHeader: true,
             MostTalkedAboutTopicsWidget: true,
             ConversationalDynamicWidget: true,
             CustomizableDrawer: true,
@@ -498,6 +533,7 @@ describe('Conversational.vue', () => {
         global: {
           stubs: {
             DashboardHeader: true,
+            ContactsHeader: true,
             MostTalkedAboutTopicsWidget: true,
             ConversationalDynamicWidget: true,
             CustomizableDrawer: true,
@@ -526,6 +562,7 @@ describe('Conversational.vue', () => {
         global: {
           stubs: {
             DashboardHeader: true,
+            ContactsHeader: true,
             MostTalkedAboutTopicsWidget: true,
             ConversationalDynamicWidget: true,
             CustomizableDrawer: true,

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -72,6 +72,21 @@
         "transferred": "Conversations requiring human support. Numbers may differ from the human support dashboard, as this counts conversations (not rooms) that were opened and went through AI. As the same conversation can generate multiple rooms, some of which may be opened directly by human support, comparing the dashboards isn't recommended."
       }
     },
+    "sections": {
+      "conversations": "Conversations",
+      "contacts": "Contacts"
+    },
+    "contacts_header": {
+      "unique": "Unique contacts",
+      "returning": "Returning contacts",
+      "avg": "Average conversations per contact",
+      "returning_description_suffix": "of total unique contacts",
+      "tooltips": {
+        "unique": "Number of distinct contacts who started conversations during the selected period.",
+        "returning": "Contacts who started more than one conversation during the selected period.",
+        "avg": "Average conversations considering all unique contacts during the period."
+      }
+    },
     "form_topic": {
       "add_topic": "Add topic",
       "add_sub_topic": "Add subtopic",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -72,6 +72,21 @@
         "transferred": "Conversaciones que requieren soporte humano. Los números pueden diferir del dashboard de soporte humano, ya que este cuenta conversaciones (no salas) que se abrieron y pasaron por IA. Como una misma conversación puede generar múltiples salas, algunas de las cuales pueden ser abiertas directamente por soporte humano, no se recomienda comparar los dashboards."
       }
     },
+    "sections": {
+      "conversations": "Conversaciones",
+      "contacts": "Contactos"
+    },
+    "contacts_header": {
+      "unique": "Contactos únicos",
+      "returning": "Contactos recurrentes",
+      "avg": "Promedio de conversaciones por contacto",
+      "returning_description_suffix": "del total de contactos únicos",
+      "tooltips": {
+        "unique": "Número de contactos distintos que iniciaron conversaciones durante el período seleccionado.",
+        "returning": "Contactos que iniciaron más de una conversación durante el período seleccionado.",
+        "avg": "Promedio de conversaciones considerando todos los contactos únicos del período."
+      }
+    },
     "form_topic": {
       "add_topic": "Agregar asunto",
       "add_sub_topic": "Agregar subasunto",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -72,6 +72,21 @@
         "transferred": "Conversas que requerem assistência humana. Os valores podem diferir do dashboard de atendimento humano, pois ele contabiliza conversas (não salas) que foram abertas e passaram pela IA. Como uma conversa pode gerar várias salas — e algumas delas podem ser abertas diretamente no atendimento humano —, a comparação entre painéis não é recomendada."
       }
     },
+    "sections": {
+      "conversations": "Conversas",
+      "contacts": "Contatos"
+    },
+    "contacts_header": {
+      "unique": "Contatos únicos",
+      "returning": "Contatos recorrentes",
+      "avg": "Média de conversas por contato",
+      "returning_description_suffix": "do total de contatos únicos",
+      "tooltips": {
+        "unique": "Número de contatos distintos que iniciaram conversas no período selecionado.",
+        "returning": "Contatos que iniciaram mais de uma conversa no período selecionado.",
+        "avg": "Média de conversas considerando todos os contatos únicos no período."
+      }
+    },
     "form_topic": {
       "add_topic": "Adicionar assunto",
       "add_sub_topic": "Adicionar subassunto",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -72,6 +72,21 @@
         "transferred": "Conversații care necesită asistență umană. Numerele pot diferi de cele din dashboard-ul de asistență umană, deoarece aici se numără conversațiile (nu camerele) care au fost deschise și au trecut prin IA. Deoarece aceeași conversație poate genera mai multe camere, dintre care unele pot fi deschise direct de asistența umană, compararea dashboard-urilor nu este recomandată."
       }
     },
+    "sections": {
+      "conversations": "Conversații",
+      "contacts": "Contacte"
+    },
+    "contacts_header": {
+      "unique": "Contacte unice",
+      "returning": "Contacte recurente",
+      "avg": "Media conversațiilor per contact",
+      "returning_description_suffix": "din totalul contactelor unice",
+      "tooltips": {
+        "unique": "Numărul de contacte distincte care au inițiat conversații în perioada selectată.",
+        "returning": "Contacte care au inițiat mai mult de o conversație în perioada selectată.",
+        "avg": "Media conversațiilor luând în considerare toate contactele unice din perioadă."
+      }
+    },
     "form_topic": {
       "add_topic": "Adaugă subiect",
       "add_sub_topic": "Adaugă subiect secundar",

--- a/src/services/api/resources/conversational/__tests__/contacts.spec.js
+++ b/src/services/api/resources/conversational/__tests__/contacts.spec.js
@@ -1,0 +1,156 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+import contactsService from '../contacts';
+import http from '@/services/api/http';
+import { useConfig } from '@/store/modules/config';
+import { useConversational } from '@/store/modules/conversational/conversational';
+import { createRequestQuery } from '@/utils/request';
+
+vi.mock('@/services/api/http', () => ({
+  default: {
+    get: vi.fn(),
+  },
+}));
+
+vi.mock('@/store/modules/config', () => ({
+  useConfig: vi.fn(),
+}));
+
+vi.mock('@/store/modules/conversational/conversational', () => ({
+  useConversational: vi.fn(),
+}));
+
+vi.mock('@/utils/request', () => ({
+  createRequestQuery: vi.fn((params) => params),
+}));
+
+describe('contactsService', () => {
+  const mockProjectUuid = 'test-project-uuid';
+  const mockApiResponse = {
+    unique: { value: 80 },
+    returning: { value: 28, percentage: 35 },
+    avg_conversations_per_contact: { value: 1.25 },
+  };
+  const mockAppliedFilters = {
+    'some-filter': 'some-value',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setActivePinia(createPinia());
+
+    useConfig.mockReturnValue({
+      project: {
+        uuid: mockProjectUuid,
+      },
+    });
+
+    useConversational.mockReturnValue({
+      appliedFilters: mockAppliedFilters,
+    });
+  });
+
+  describe('getConversationalContacts', () => {
+    it('should fetch, format, and return conversational contacts successfully', async () => {
+      const queryParams = { start_date: '2023-01-01', end_date: '2023-01-31' };
+      http.get.mockResolvedValue(mockApiResponse);
+
+      const result =
+        await contactsService.getConversationalContacts(queryParams);
+
+      const expectedParams = {
+        ...queryParams,
+        project_uuid: mockProjectUuid,
+        ...mockAppliedFilters,
+      };
+      expect(createRequestQuery).toHaveBeenCalledWith(queryParams);
+      expect(http.get).toHaveBeenCalledWith(
+        '/metrics/conversations/contacts/',
+        {
+          params: expectedParams,
+          signal: undefined,
+        },
+      );
+
+      expect(result).toHaveLength(3);
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ id: 'unique', value: 80 }),
+          expect.objectContaining({
+            id: 'returning',
+            value: 28,
+            percentage: 35,
+          }),
+          expect.objectContaining({
+            id: 'avg_conversations_per_contact',
+            value: 1.25,
+          }),
+        ]),
+      );
+    });
+
+    it('should forward AbortSignal to the underlying http call', async () => {
+      http.get.mockResolvedValue(mockApiResponse);
+
+      const controller = new AbortController();
+
+      await contactsService.getConversationalContacts({}, {
+        signal: controller.signal,
+      });
+
+      expect(http.get).toHaveBeenCalledWith(
+        '/metrics/conversations/contacts/',
+        expect.objectContaining({ signal: controller.signal }),
+      );
+    });
+
+    it('should omit percentage on metrics that do not provide it', async () => {
+      http.get.mockResolvedValue(mockApiResponse);
+
+      const result = await contactsService.getConversationalContacts();
+
+      const uniqueMetric = result.find((m) => m.id === 'unique');
+      const avgMetric = result.find(
+        (m) => m.id === 'avg_conversations_per_contact',
+      );
+
+      expect(uniqueMetric).not.toHaveProperty('percentage');
+      expect(avgMetric).not.toHaveProperty('percentage');
+    });
+
+    it('should handle API errors by rejecting the promise', async () => {
+      const apiError = new Error('Network Error');
+      http.get.mockRejectedValue(apiError);
+
+      await expect(
+        contactsService.getConversationalContacts(),
+      ).rejects.toThrow('Network Error');
+    });
+
+    it('should work correctly with empty query parameters', async () => {
+      http.get.mockResolvedValue(mockApiResponse);
+
+      await contactsService.getConversationalContacts();
+
+      const expectedParams = {
+        project_uuid: mockProjectUuid,
+        ...mockAppliedFilters,
+      };
+      expect(http.get).toHaveBeenCalledWith(
+        '/metrics/conversations/contacts/',
+        expect.objectContaining({ params: expectedParams }),
+      );
+    });
+
+    it('should pass undefined signal when options are not provided', async () => {
+      http.get.mockResolvedValue(mockApiResponse);
+
+      await contactsService.getConversationalContacts();
+
+      expect(http.get).toHaveBeenCalledWith(
+        '/metrics/conversations/contacts/',
+        expect.objectContaining({ signal: undefined }),
+      );
+    });
+  });
+});

--- a/src/services/api/resources/conversational/contacts.ts
+++ b/src/services/api/resources/conversational/contacts.ts
@@ -1,0 +1,94 @@
+import http from '@/services/api/http';
+import { useConfig } from '@/store/modules/config';
+import { useConversational } from '@/store/modules/conversational/conversational';
+import { createRequestQuery } from '@/utils/request';
+
+interface ContactsUniqueMetric {
+  value: number;
+}
+
+interface ContactsReturningMetric {
+  value: number;
+  percentage: number;
+}
+
+interface ContactsAvgMetric {
+  value: number;
+}
+
+interface ConversationalContactsResponse {
+  unique: ContactsUniqueMetric;
+  returning: ContactsReturningMetric;
+  avg_conversations_per_contact: ContactsAvgMetric;
+}
+
+export type ContactMetricId =
+  | 'unique'
+  | 'returning'
+  | 'avg_conversations_per_contact';
+
+export interface FormattedContactMetric {
+  id: ContactMetricId;
+  value: number;
+  percentage?: number;
+}
+
+interface QueryParams {
+  start_date?: string;
+  end_date?: string;
+  [key: string]: string;
+}
+
+interface FormattedParams extends QueryParams {
+  project_uuid: string;
+}
+
+export default {
+  async getConversationalContacts(
+    queryParams: QueryParams = {},
+  ): Promise<FormattedContactMetric[]> {
+    const { project } = useConfig();
+    const { appliedFilters } = useConversational();
+
+    const params = createRequestQuery(queryParams);
+
+    const formattedParams: FormattedParams = {
+      project_uuid: project.uuid,
+      ...appliedFilters,
+      ...params,
+    };
+
+    const response = (await http.get(`/metrics/conversations/contacts/`, {
+      params: formattedParams,
+    })) as ConversationalContactsResponse;
+
+    const formattedResponse: FormattedContactMetric[] = Object.entries(
+      response,
+    ).map(([id, data]) => {
+      const metric: FormattedContactMetric = {
+        id: id as ContactMetricId,
+        value: (data as { value: number }).value,
+      };
+
+      if (
+        data &&
+        typeof (data as { percentage?: number }).percentage === 'number'
+      ) {
+        metric.percentage = (data as { percentage: number }).percentage;
+      }
+
+      return metric;
+    });
+
+    return formattedResponse;
+  },
+};
+
+export type {
+  ContactsUniqueMetric,
+  ContactsReturningMetric,
+  ContactsAvgMetric,
+  ConversationalContactsResponse,
+  QueryParams,
+  FormattedParams,
+};

--- a/src/services/api/resources/conversational/contacts.ts
+++ b/src/services/api/resources/conversational/contacts.ts
@@ -46,6 +46,7 @@ interface FormattedParams extends QueryParams {
 export default {
   async getConversationalContacts(
     queryParams: QueryParams = {},
+    options: { signal?: AbortSignal } = {},
   ): Promise<FormattedContactMetric[]> {
     const { project } = useConfig();
     const { appliedFilters } = useConversational();
@@ -60,6 +61,7 @@ export default {
 
     const response = (await http.get(`/metrics/conversations/contacts/`, {
       params: formattedParams,
+      signal: options.signal,
     })) as ConversationalContactsResponse;
 
     const formattedResponse: FormattedContactMetric[] = Object.entries(

--- a/src/services/api/resources/conversational/mocks.ts
+++ b/src/services/api/resources/conversational/mocks.ts
@@ -1,5 +1,6 @@
 import type { ConversationalTopicsDistribution } from './topics';
 import type { FormattedMetric } from './header';
+import type { FormattedContactMetric } from './contacts';
 import type {
   CsatResponse,
   NpsResponse,
@@ -60,6 +61,12 @@ export const MOCK_HEADER_DATA: FormattedMetric[] = [
   { id: 'resolved', value: 15795, percentage: 65 },
   { id: 'unresolved', value: 4860, percentage: 20 },
   { id: 'transferred_to_human', value: 3645, percentage: 15 },
+];
+
+export const MOCK_CONTACTS_DATA: FormattedContactMetric[] = [
+  { id: 'unique', value: 80 },
+  { id: 'returning', value: 28, percentage: 35 },
+  { id: 'avg_conversations_per_contact', value: 1.8 },
 ];
 
 export const MOCK_CSAT_DATA: CsatResponse = {

--- a/src/services/api/resources/export/conversational/export.ts
+++ b/src/services/api/resources/export/conversational/export.ts
@@ -10,7 +10,8 @@ type TypeSections =
   | 'CSAT_AI'
   | 'CSAT_HUMAN'
   | 'NPS_AI'
-  | 'NPS_HUMAN';
+  | 'NPS_HUMAN'
+  | 'CONTACTS';
 
 interface ExportRequest {
   project_uuid: string;

--- a/src/store/modules/conversational/__tests__/conversational.spec.js
+++ b/src/store/modules/conversational/__tests__/conversational.spec.js
@@ -66,6 +66,7 @@ describe('useConversational store', () => {
       expect(store.refreshDataConversational).toBe(false);
       expect(store.isloadingConversationalData).toEqual({
         header: false,
+        contactsHeader: false,
         mostTalkedAboutTopics: false,
         dynamicWidgets: false,
       });
@@ -74,6 +75,7 @@ describe('useConversational store', () => {
         topics: false,
         header: false,
         widgets: false,
+        contacts: false,
       });
     });
   });
@@ -127,7 +129,12 @@ describe('useConversational store', () => {
   });
 
   describe('setIsLoadingConversationalData action', () => {
-    const keys = ['header', 'mostTalkedAboutTopics', 'dynamicWidgets'];
+    const keys = [
+      'header',
+      'contactsHeader',
+      'mostTalkedAboutTopics',
+      'dynamicWidgets',
+    ];
 
     keys.forEach((key) => {
       it(`should set ${key} loading to true`, () => {
@@ -218,7 +225,7 @@ describe('useConversational store', () => {
   });
 
   describe('setEndpointError action', () => {
-    const keys = ['topics', 'header', 'widgets'];
+    const keys = ['topics', 'header', 'widgets', 'contacts'];
 
     keys.forEach((key) => {
       it(`should set ${key} error to true`, () => {
@@ -251,6 +258,11 @@ describe('useConversational store', () => {
 
     it('should return true when widgets endpoint has error', () => {
       store.setEndpointError('widgets', true);
+      expect(store.hasEndpointErrors).toBe(true);
+    });
+
+    it('should return true when contacts endpoint has error', () => {
+      store.setEndpointError('contacts', true);
       expect(store.hasEndpointErrors).toBe(true);
     });
 

--- a/src/store/modules/conversational/conversational.ts
+++ b/src/store/modules/conversational/conversational.ts
@@ -15,7 +15,7 @@ export type DrawerWidgetType =
   | 'crosstab'
   | 'absolute_numbers'
   | null;
-type EndpointErrorKey = 'topics' | 'header' | 'widgets';
+type EndpointErrorKey = 'topics' | 'header' | 'widgets' | 'contacts';
 
 interface ConversationalState {
   isDrawerCustomizableOpen: boolean;
@@ -26,6 +26,7 @@ interface ConversationalState {
   hasEndpointData: boolean;
   isloadingConversationalData: {
     header: boolean;
+    contactsHeader: boolean;
     mostTalkedAboutTopics: boolean;
     dynamicWidgets: boolean;
   };
@@ -42,6 +43,7 @@ export const useConversational = defineStore('conversational', {
     hasEndpointData: false,
     isloadingConversationalData: {
       header: false,
+      contactsHeader: false,
       mostTalkedAboutTopics: false,
       dynamicWidgets: false,
     },
@@ -49,6 +51,7 @@ export const useConversational = defineStore('conversational', {
       topics: false,
       header: false,
       widgets: false,
+      contacts: false,
     },
   }),
 
@@ -66,7 +69,11 @@ export const useConversational = defineStore('conversational', {
       this.refreshDataConversational = value;
     },
     setIsLoadingConversationalData(
-      key: 'header' | 'mostTalkedAboutTopics' | 'dynamicWidgets',
+      key:
+        | 'header'
+        | 'contactsHeader'
+        | 'mostTalkedAboutTopics'
+        | 'dynamicWidgets',
       value: boolean,
     ) {
       this.isloadingConversationalData[key] = value;

--- a/src/store/modules/export/conversational/__tests__/export.spec.js
+++ b/src/store/modules/export/conversational/__tests__/export.spec.js
@@ -253,6 +253,21 @@ describe('useConversationalExport', () => {
       });
     });
 
+    it('should initialize contacts field when CONTACTS section is available', async () => {
+      const mockResponse = {
+        sections: ['RESOLUTIONS', 'CONTACTS'],
+        custom_widgets: [],
+        crosstab_widgets: [],
+      };
+      exportApi.getAvailableWidgets.mockResolvedValue(mockResponse);
+      store.setModelFields({});
+
+      await store.initializeDefaultFields();
+
+      expect(store.model_fields.resolutions).toEqual({});
+      expect(store.model_fields.contacts).toEqual({});
+    });
+
     it('should keep crosstab widget UUIDs from model_fields', async () => {
       const mockResponse = {
         sections: ['RESOLUTIONS'],
@@ -329,6 +344,17 @@ describe('useConversationalExport', () => {
 
       const call = exportApi.createExport.mock.calls[0][0];
       expect(call.sections).toContain('AGENT_INVOCATION');
+    });
+
+    it('should include CONTACTS section when contacts is enabled', async () => {
+      exportApi.createExport.mockResolvedValue({ status: 'pending' });
+      store.enabled_models = ['contacts'];
+      store.setSelectedFields({});
+
+      await store.createExport();
+
+      const call = exportApi.createExport.mock.calls[0][0];
+      expect(call.sections).toContain('CONTACTS');
     });
 
     it('should include custom widgets in export', async () => {
@@ -455,6 +481,11 @@ describe('useConversationalExport', () => {
 
     it('should return true when agent_invocation is enabled', () => {
       store.enabled_models = ['agent_invocation'];
+      expect(store.hasEnabledToExport).toBe(true);
+    });
+
+    it('should return true when contacts is enabled', () => {
+      store.enabled_models = ['contacts'];
       expect(store.hasEnabledToExport).toBe(true);
     });
 

--- a/src/store/modules/export/conversational/export.ts
+++ b/src/store/modules/export/conversational/export.ts
@@ -176,6 +176,7 @@ export const useConversationalExport = defineStore('conversationalExport', {
         CSAT_HUMAN: { model: 'csat', subsection: 'human' },
         NPS_AI: { model: 'nps', subsection: 'ai' },
         NPS_HUMAN: { model: 'nps', subsection: 'human' },
+        CONTACTS: { model: 'contacts' },
       };
 
       availableWidgets.sections.forEach((section) => {
@@ -233,6 +234,7 @@ export const useConversationalExport = defineStore('conversationalExport', {
           resolutions: 'RESOLUTIONS',
           tool_result: 'TOOL_RESULT',
           agent_invocation: 'AGENT_INVOCATION',
+          contacts: 'CONTACTS',
           topics: { human: 'TOPICS_HUMAN', ai: 'TOPICS_AI' },
           csat: { human: 'CSAT_HUMAN', ai: 'CSAT_AI' },
           nps: { human: 'NPS_HUMAN', ai: 'NPS_AI' },
@@ -322,7 +324,8 @@ export const useConversationalExport = defineStore('conversationalExport', {
         state.enabled_models.includes('resolutions') ||
         state.enabled_models.includes('transferred') ||
         state.enabled_models.includes('tool_result') ||
-        state.enabled_models.includes('agent_invocation')
+        state.enabled_models.includes('agent_invocation') ||
+        state.enabled_models.includes('contacts')
       ) {
         hasValidSelections = true;
       }


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The Conversational dashboard previously surfaced a single block of metric cards focused on conversation outcomes, with no visibility into the contacts driving those conversations. Product asked us to expose contact-level KPIs (unique contacts, returning contacts, average conversations per contact) right next to the conversation metrics, group both groups under clear section titles, and let users include this new data in the export flow. The new Contacts header also has to participate in the existing "show mock until real data arrives" rule, and the load logic needs to be resilient to fast filter changes that today can let a stale response overwrite a fresher one.

### Summary of Changes
<!--- Describe your changes in detail -->
- New `ContactsHeader.vue` component (3 cards: unique contacts, returning contacts, average conversations per contact) built on top of `CardConversations`, mirroring the API/mock/loading/error patterns of `DashboardHeader.vue`. Cards are non-clickable per design.
- New typed service `contacts.ts` calling `GET /v1/metrics/conversations/contacts/` with `project_uuid`, `start_date`, `end_date`, plus the conversational `appliedFilters`. Response is normalized into `FormattedContactMetric[]` preserving `percentage` only when the API returns it.
- `Conversational.vue` now renders two titled sections — "Conversations" (existing `DashboardHeader`) and "Contacts" (new `ContactsHeader`) — followed by the existing topics and dynamic widgets. Added section title styles using Unnnic tokens.
- Mock support: added `MOCK_CONTACTS_DATA` (80 / 28 @ 35% / 1.8) and wired the new endpoint into the conversational store: extended `EndpointErrorKey` with `'contacts'`, added `endpointErrors.contacts` and `isloadingConversationalData.contactsHeader`. The new endpoint contributes to `setHasEndpointData` exactly like the existing header, so the mock UI is hidden as soon as either header (or any other configured signal) returns real data.
- Export flow updated end-to-end to support the new `CONTACTS` section returned by `GET /metrics/conversations/report/available-widgets/`: extended `TypeSections`, added `CONTACTS → contacts` in `sectionsMap`, `contacts → CONTACTS` in `modelToSectionMap`, and included `contacts` in the `hasEnabledToExport` validation list. No new i18n needed for the export label since `export_data.model_labels.contacts` already exists.
- Race-condition handling: `getConversationalContacts` now accepts an optional `AbortSignal` and the component manages its own `AbortController`. Each `loadCardData` call aborts the previous in-flight request, ignores aborted responses (no state writes, no error toast, no `setEndpointError`), preserves `isLoading: true` while a newer request is still pending, and aborts on `onUnmounted`. This follows the same pattern already used by `widgets.ts` / `autoWidgets.ts`.
- i18n: added `conversations_dashboard.sections.{conversations,contacts}` and `conversations_dashboard.contacts_header.{unique,returning,avg,returning_description_suffix,tooltips.{unique,returning,avg}}` in `en.json`, `pt_br.json`, `es.json`, and `ro.json`, following the VTEX Content Guide (sentence case, no trailing periods on short labels, descriptive tooltips).
- Tests: new specs for `ContactsHeader.vue` (structure, definitions, border radius, API success / empty / error, mock mode, tooltip side, non-clickable cards, abort-signal race-condition coverage) and for the contacts service (endpoint path, params, formatted response, percentage omission, signal forwarding, error rejection). Updated `Conversational.spec.js` to stub `ContactsHeader` and assert both titled sections render. Updated `export.spec.js` to cover `CONTACTS` in `initializeDefaultFields`, `createExport` mapping, and `hasEnabledToExport`.

### Design Files <!--- (If not appropriate, remove this topic) -->
<!--- Links to the design files used for reference during implementation. -->

- [Design File](https://www.figma.com/design/aN8dbWdTMWAYlPA4t4o51D/Analytics---Conversational?node-id=3442-20042&m=dev)