### PR TITLE
refactor: validate 90-day date range for abandoned cart recovery widget

### DIFF
--- a/src/components/insights/conversations/AbandonedCartWidget/index.vue
+++ b/src/components/insights/conversations/AbandonedCartWidget/index.vue
@@ -46,18 +46,12 @@
       </UnnnicPopover>
     </section>
     <section
-      v-if="hasEmptyData || hasError"
+      v-if="showDisclaimer"
       class="abandoned-cart-widget__no-data"
     >
       <UnnnicDisclaimer
-        :type="hasError ? 'error' : 'neutral'"
-        :description="
-          hasError
-            ? $t('conversations_dashboard.abandoned_cart_recovery_widget.error')
-            : $t(
-                'conversations_dashboard.abandoned_cart_recovery_widget.no_data',
-              )
-        "
+        :type="disclaimerType"
+        :description="disclaimerDescription"
       />
     </section>
     <section
@@ -85,6 +79,8 @@
 
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue';
+import { isBefore, parseISO, startOfDay, subDays } from 'date-fns';
+import { useI18n } from 'vue-i18n';
 
 import Chart from './Chart.vue';
 import InfoCard from './InfoCard.vue';
@@ -99,6 +95,9 @@ defineOptions({
   name: 'AbandonedCartWidget',
 });
 
+const DATA_AVAILABILITY_DAYS = 90;
+
+const { t } = useI18n();
 const conversationalStore = useConversational();
 const { appliedFilters, refreshDataConversational } =
   storeToRefs(conversationalStore);
@@ -130,6 +129,46 @@ const hasEmptyData = computed(() => {
   );
 });
 
+const minAvailableDate = computed(() =>
+  startOfDay(subDays(new Date(), DATA_AVAILABILITY_DAYS)),
+);
+
+const isFilterDateOutOfRange = computed(() => {
+  const { start_date: filterDateStart, end_date: filterDateEnd } =
+    appliedFilters.value;
+
+  const isDateBeforeMinAvailable = (date?: string) => {
+    if (!date) return false;
+
+    return isBefore(parseISO(date), minAvailableDate.value);
+  };
+
+  return (
+    isDateBeforeMinAvailable(filterDateStart) ||
+    isDateBeforeMinAvailable(filterDateEnd)
+  );
+});
+
+const showDisclaimer = computed(
+  () => isFilterDateOutOfRange.value || hasEmptyData.value || hasError.value,
+);
+
+const disclaimerType = computed(() => (hasError.value ? 'error' : 'neutral'));
+
+const disclaimerDescription = computed(() => {
+  if (hasError.value) {
+    return t('conversations_dashboard.abandoned_cart_recovery_widget.error');
+  }
+
+  if (isFilterDateOutOfRange.value) {
+    return t(
+      'conversations_dashboard.abandoned_cart_recovery_widget.unavailable_period',
+    );
+  }
+
+  return t('conversations_dashboard.abandoned_cart_recovery_widget.no_data');
+});
+
 const chartData = computed(() => {
   return {
     sent: widgetData.value.sent,
@@ -154,6 +193,12 @@ const handleRemoveWidget = () => {
 };
 
 const fetchData = async () => {
+  if (isFilterDateOutOfRange.value) {
+    hasError.value = false;
+    isLoadingData.value = false;
+    return;
+  }
+
   try {
     hasError.value = false;
     isLoadingData.value = true;

--- a/src/components/insights/conversations/AbandonedCartWidget/index.vue
+++ b/src/components/insights/conversations/AbandonedCartWidget/index.vue
@@ -280,8 +280,8 @@ watch(
     color: $unnnic-color-fg-emphasized;
   }
   &__content {
-    display: flex;
-    justify-content: space-between;
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
     align-items: center;
     gap: $unnnic-space-4;
   }

--- a/src/components/insights/conversations/AbandonedCartWidget/index.vue
+++ b/src/components/insights/conversations/AbandonedCartWidget/index.vue
@@ -95,7 +95,7 @@ defineOptions({
   name: 'AbandonedCartWidget',
 });
 
-const DATA_AVAILABILITY_DAYS = 90;
+const DATA_AVAILABILITY_DAYS = 89;
 
 const { t } = useI18n();
 const conversationalStore = useConversational();

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -190,6 +190,7 @@
       "title": "Abandoned cart recovery",
       "no_data": "No data available for the filtered period.",
       "error": "Error loading data. Please refresh the dashboard or contact support.",
+      "unavailable_period": "Data for this widget is provided by Meta for the last 90 days only. Check if the selected date range is within this period to view the information.",
       "chart": {
         "sent": "Sent",
         "delivered": "Delivered",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -190,6 +190,7 @@
       "title": "Recuperación de carrito abandonado",
       "no_data": "No hay datos disponibles para el período filtrado.",
       "error": "Error al cargar los datos. Actualiza el panel o contacta con soporte.",
+      "unavailable_period": "Los datos para este widget son proporcionados por Meta para los últimos 90 días solamente. Verifica si el rango de fechas seleccionado está dentro de este período para ver la información.",
       "chart": {
         "sent": "Enviados",
         "delivered": "Entregados",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -190,6 +190,7 @@
       "title": "Recuperação de carrinho abandonado",
       "no_data": "Nenhum dado disponível para o período filtrado.",
       "error": "Erro ao carregar os dados. Atualize o dashboard ou entre em contato com o suporte.",
+      "unavailable_period": "Os dados para este widget são fornecidos pela Meta para os últimos 90 dias apenas. Verifique se o intervalo de datas selecionado está dentro desse período para ver a informação.",
       "chart": {
         "sent": "Enviados",
         "delivered": "Entregues",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -184,6 +184,7 @@
       "title": "Recuperare coș abandonat",
       "no_data": "Nu sunt date disponibile pentru perioada filtrată.",
       "error": "Eroare la încărcarea datelor. Reîmprospătează tabloul de bord sau contactează suportul.",
+      "unavailable_period": "Datele pentru acest widget sunt furnizate de Meta pentru ultimele 90 de zile doar. Verifică dacă intervalul de date selectat se află în acest perioadă pentru a vedea informația.",
       "chart": {
         "sent": "Trimise",
         "delivered": "Livrate",


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [x] Refactoring (no functional changes, no api changes)
* [ ] Tests
* [ ] Other

### Motivation and Context
Abandoned cart recovery data is only available for the last 90 days (provided by Meta). When users select a dashboard date range that includes dates older than that window, the widget was still calling the API and could show misleading empty or error states.

This change validates the applied conversational filters before fetching data and surfaces a clear disclaimer when the selected period falls outside the supported range.

### Summary of Changes
- Added date range validation in `AbandonedCartWidget` using `date-fns` to check whether `start_date` or `end_date` is before the minimum available date (last 89 days, aligned with a 90-day inclusive window).
- Introduced `isFilterDateOutOfRange`, `showDisclaimer`, `disclaimerType`, and `disclaimerDescription` computed properties to centralize empty, error, and out-of-range states.
- Skipped API requests when the filter is out of range to avoid unnecessary calls and confusing results.
- Replaced inline disclaimer template logic with the new computed helpers.

### Demonstration <!--- (If not appropriate, remove this topic) -->
<img width="1416" height="565" alt="image" src="https://github.com/user-attachments/assets/f5140666-8afd-4468-b4af-65301f44ea91" />