### PR TITLE
feat: add lazy loading foundation for insights dashboards

### DIFF
--- a/setupVitest.js
+++ b/setupVitest.js
@@ -89,7 +89,22 @@ const i18n = createI18n({
 
 config.global.plugins = [i18n, UnnnicSystemPlugin];
 
+/**
+ * Default stub for the lazy-loading wrapper.
+ * Renders its slot without providing visibility, so `useLazyData` falls back to
+ * eager loading in unit tests (preserving legacy "loads on mount" assertions).
+ * Opt out with `stubs: { LazyWidget: false }` to test real visibility gating.
+ */
+const lazyWidgetStub = {
+  LazyWidget: {
+    name: 'LazyWidget',
+    props: ['rootMargin', 'forceVisible'],
+    template: '<div class="lazy-widget-stub"><slot /></div>',
+  },
+};
+
 config.global.stubs = {
   ...(config.global.stubs || {}),
   ...unnnicDialogStubs,
+  ...lazyWidgetStub,
 };

--- a/src/components/insights/Layout/LazyWidget.vue
+++ b/src/components/insights/Layout/LazyWidget.vue
@@ -52,9 +52,7 @@ watch(
 );
 
 onMounted(() => {
-  observerRoot.value =
-    injectedScrollContainer?.value ??
-    (document.querySelector('.insights__main') as HTMLElement | null);
+  observerRoot.value = injectedScrollContainer?.value ?? null;
 });
 
 useIntersectionObserver(

--- a/src/components/insights/Layout/LazyWidget.vue
+++ b/src/components/insights/Layout/LazyWidget.vue
@@ -1,0 +1,82 @@
+<template>
+  <div
+    ref="lazyRoot"
+    class="lazy-widget"
+    data-testid="lazy-widget"
+  >
+    <slot />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { inject, onMounted, provide, ref, watch, type Ref } from 'vue';
+import { useIntersectionObserver } from '@vueuse/core';
+
+import { LazyVisibilityKey } from '@/composables/useLazyData';
+
+const props = withDefaults(
+  defineProps<{
+    /** Prefetch margin so requests start slightly before the widget is in view. */
+    rootMargin?: string;
+    /** Force the widget to be treated as visible (e.g. scroll/redirect targets). */
+    forceVisible?: boolean;
+  }>(),
+  {
+    rootMargin: '300px 0px',
+    forceVisible: false,
+  },
+);
+
+const lazyRoot = ref<HTMLElement | null>(null);
+const isVisible = ref(false);
+const hasBeenVisible = ref(false);
+
+const injectedScrollContainer = inject<Ref<HTMLElement | null> | null>(
+  'insightsScrollContainer',
+  null,
+);
+
+const observerRoot = ref<HTMLElement | null>(null);
+
+const forceLoad = () => {
+  isVisible.value = true;
+  hasBeenVisible.value = true;
+};
+
+watch(
+  () => props.forceVisible,
+  (value) => {
+    if (value) forceLoad();
+  },
+  { immediate: true },
+);
+
+onMounted(() => {
+  observerRoot.value =
+    injectedScrollContainer?.value ??
+    (document.querySelector('.insights__main') as HTMLElement | null);
+});
+
+useIntersectionObserver(
+  lazyRoot,
+  ([entry]) => {
+    isVisible.value = entry?.isIntersecting ?? false;
+    if (isVisible.value) hasBeenVisible.value = true;
+  },
+  {
+    root: observerRoot,
+    rootMargin: props.rootMargin,
+  },
+);
+
+provide(LazyVisibilityKey, { isVisible, hasBeenVisible, forceLoad });
+
+defineExpose({ isVisible, hasBeenVisible, forceLoad });
+</script>
+
+<style scoped lang="scss">
+.lazy-widget {
+  display: flex;
+  flex-direction: column;
+}
+</style>

--- a/src/components/insights/Layout/__tests__/LazyWidget.spec.js
+++ b/src/components/insights/Layout/__tests__/LazyWidget.spec.js
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { defineComponent, h, inject } from 'vue';
+
+import LazyWidget from '../LazyWidget.vue';
+import { LazyVisibilityKey } from '@/composables/useLazyData';
+
+let observerCallback = null;
+
+vi.mock('@vueuse/core', () => ({
+  useIntersectionObserver: vi.fn((_target, cb) => {
+    observerCallback = cb;
+    return { stop: vi.fn() };
+  }),
+}));
+
+const Probe = defineComponent({
+  setup() {
+    const visibility = inject(LazyVisibilityKey);
+    return { visibility };
+  },
+  template: '<span class="probe" />',
+});
+
+const mountLazy = (props = {}) =>
+  mount(LazyWidget, {
+    props,
+    slots: { default: () => h(Probe) },
+    global: { stubs: { LazyWidget: false } },
+  });
+
+const triggerIntersection = (isIntersecting) => {
+  observerCallback?.([{ isIntersecting }]);
+};
+
+describe('LazyWidget', () => {
+  beforeEach(() => {
+    observerCallback = null;
+  });
+
+  it('renders its default slot', () => {
+    const wrapper = mountLazy();
+    expect(wrapper.find('.probe').exists()).toBe(true);
+  });
+
+  it('provides lazy visibility to slotted content', () => {
+    const wrapper = mountLazy();
+    const probe = wrapper.findComponent(Probe);
+
+    expect(probe.vm.visibility).toBeTruthy();
+    expect(probe.vm.visibility.hasBeenVisible.value).toBe(false);
+    expect(probe.vm.visibility.isVisible.value).toBe(false);
+  });
+
+  it('marks the widget visible when it intersects the viewport', async () => {
+    const wrapper = mountLazy();
+    const probe = wrapper.findComponent(Probe);
+
+    triggerIntersection(true);
+    await wrapper.vm.$nextTick();
+
+    expect(probe.vm.visibility.isVisible.value).toBe(true);
+    expect(probe.vm.visibility.hasBeenVisible.value).toBe(true);
+  });
+
+  it('keeps hasBeenVisible true after leaving the viewport', async () => {
+    const wrapper = mountLazy();
+    const probe = wrapper.findComponent(Probe);
+
+    triggerIntersection(true);
+    triggerIntersection(false);
+    await wrapper.vm.$nextTick();
+
+    expect(probe.vm.visibility.isVisible.value).toBe(false);
+    expect(probe.vm.visibility.hasBeenVisible.value).toBe(true);
+  });
+
+  it('forces visibility when forceVisible prop is true', () => {
+    const wrapper = mountLazy({ forceVisible: true });
+    const probe = wrapper.findComponent(Probe);
+
+    expect(probe.vm.visibility.hasBeenVisible.value).toBe(true);
+    expect(probe.vm.visibility.isVisible.value).toBe(true);
+  });
+
+  it('forces visibility when forceVisible becomes true', async () => {
+    const wrapper = mountLazy({ forceVisible: false });
+    const probe = wrapper.findComponent(Probe);
+
+    expect(probe.vm.visibility.hasBeenVisible.value).toBe(false);
+
+    await wrapper.setProps({ forceVisible: true });
+
+    expect(probe.vm.visibility.hasBeenVisible.value).toBe(true);
+  });
+});

--- a/src/components/insights/conversations/AbandonedCartWidget/index.vue
+++ b/src/components/insights/conversations/AbandonedCartWidget/index.vue
@@ -78,9 +78,11 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { isBefore, parseISO, startOfDay, subDays } from 'date-fns';
 import { useI18n } from 'vue-i18n';
+
+import { useLazyData } from '@/composables/useLazyData';
 
 import Chart from './Chart.vue';
 import InfoCard from './InfoCard.vue';
@@ -231,13 +233,14 @@ const fetchData = async () => {
   }
 };
 
-onMounted(() => {
-  fetchData();
+const { hasBeenVisible } = useLazyData({
+  load: fetchData,
 });
 
 watch(
   () => appliedFilters.value,
   () => {
+    if (!hasBeenVisible.value) return;
     fetchData();
   },
   { deep: true },
@@ -246,6 +249,7 @@ watch(
 watch(
   () => refreshDataConversational.value,
   (val) => {
+    if (!hasBeenVisible.value) return;
     if (val) {
       fetchData();
     }

--- a/src/components/insights/conversations/ContactsHeader.vue
+++ b/src/components/insights/conversations/ContactsHeader.vue
@@ -27,11 +27,12 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted, watch } from 'vue';
+import { ref, computed, onUnmounted, watch } from 'vue';
 import CardConversations from '@/components/insights/cards/CardConversations.vue';
 import Unnnic from '@weni/unnnic-system';
 import { useI18n } from 'vue-i18n';
 import { useWidgetFormatting } from '@/composables/useWidgetFormatting';
+import { useLazyData } from '@/composables/useLazyData';
 import conversationalContactsApi from '@/services/api/resources/conversational/contacts';
 import { MOCK_CONTACTS_DATA } from '@/services/api/resources/conversational/mocks';
 import { useRoute } from 'vue-router';
@@ -141,6 +142,7 @@ let loadCardDataAbortController: AbortController | null = null;
 watch(
   () => route.query,
   () => {
+    if (!hasBeenVisible.value) return;
     if (shouldUseMock.value) return;
     dashboardsStore.updateLastUpdatedRequest();
     loadCardData();
@@ -150,6 +152,7 @@ watch(
 watch(
   () => conversationalStore.refreshDataConversational,
   (newValue) => {
+    if (!hasBeenVisible.value) return;
     if (newValue && !shouldUseMock.value) {
       dashboardsStore.updateLastUpdatedRequest();
       conversationalStore.setIsLoadingConversationalData(
@@ -246,9 +249,11 @@ const loadCardData = async () => {
   }
 };
 
-onMounted(() => {
-  dashboardsStore.updateLastUpdatedRequest();
-  loadCardData();
+const { hasBeenVisible } = useLazyData({
+  load: () => {
+    dashboardsStore.updateLastUpdatedRequest();
+    return loadCardData();
+  },
 });
 
 onUnmounted(() => {

--- a/src/components/insights/conversations/ConversationalDynamicWidget.vue
+++ b/src/components/insights/conversations/ConversationalDynamicWidget.vue
@@ -1,27 +1,31 @@
 <template>
-  <section
-    class="conversational-dynamic-widget"
-    :class="{ 'conversational-dynamic-widget--mock-hover': showMockOverlay }"
-  >
-    <component
-      :is="currentComponent"
-      :uuid="uuid"
-    />
+  <LazyWidget>
+    <section
+      class="conversational-dynamic-widget"
+      :class="{ 'conversational-dynamic-widget--mock-hover': showMockOverlay }"
+    >
+      <component
+        :is="currentComponent"
+        :uuid="uuid"
+      />
 
-    <AddWidget
-      v-if="showMockOverlay"
-      class="conversational-dynamic-widget__mock-overlay"
-      :title="$t('conversations_dashboard.customize_your_dashboard.title')"
-      :description="
-        $t('conversations_dashboard.customize_your_dashboard.description')
-      "
-      :actionText="
-        $t('conversations_dashboard.customize_your_dashboard.add_first_widget')
-      "
-      data-testid="mock-widget-overlay"
-      @action="handleOpenDrawer"
-    />
-  </section>
+      <AddWidget
+        v-if="showMockOverlay"
+        class="conversational-dynamic-widget__mock-overlay"
+        :title="$t('conversations_dashboard.customize_your_dashboard.title')"
+        :description="
+          $t('conversations_dashboard.customize_your_dashboard.description')
+        "
+        :actionText="
+          $t(
+            'conversations_dashboard.customize_your_dashboard.add_first_widget',
+          )
+        "
+        data-testid="mock-widget-overlay"
+        @action="handleOpenDrawer"
+      />
+    </section>
+  </LazyWidget>
 </template>
 
 <script setup lang="ts">
@@ -40,6 +44,7 @@ import ConversationalSearchTerm from '@/components/insights/widgets/conversation
 import ConversationalAddedToCart from '@/components/insights/widgets/conversational/ConversationalAddedToCart.vue';
 import ConversationalAdd from '@/components/insights/widgets/conversational/ConversationalAdd.vue';
 import AddWidget from '@/components/insights/conversations/AddWidget.vue';
+import LazyWidget from '@/components/insights/Layout/LazyWidget.vue';
 import { useConversational } from '@/store/modules/conversational/conversational';
 
 type ConversationalWidgetType =

--- a/src/components/insights/conversations/DashboardHeader.vue
+++ b/src/components/insights/conversations/DashboardHeader.vue
@@ -28,11 +28,12 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, watch } from 'vue';
+import { ref, computed, watch } from 'vue';
 import CardConversations from '@/components/insights/cards/CardConversations.vue';
 import Unnnic from '@weni/unnnic-system';
 import { useI18n } from 'vue-i18n';
 import { useWidgetFormatting } from '@/composables/useWidgetFormatting';
+import { useLazyData } from '@/composables/useLazyData';
 import conversationalHeaderApi from '@/services/api/resources/conversational/header';
 import { MOCK_HEADER_DATA } from '@/services/api/resources/conversational/mocks';
 import { useRoute } from 'vue-router';
@@ -127,6 +128,7 @@ const cards = computed(() =>
 watch(
   () => route.query,
   () => {
+    if (!hasBeenVisible.value) return;
     if (shouldUseMock.value) return;
     dashboardsStore.updateLastUpdatedRequest();
     loadCardData();
@@ -136,6 +138,7 @@ watch(
 watch(
   () => conversationalStore.refreshDataConversational,
   (newValue) => {
+    if (!hasBeenVisible.value) return;
     if (newValue && !shouldUseMock.value) {
       dashboardsStore.updateLastUpdatedRequest();
       conversationalStore.setIsLoadingConversationalData('header', true);
@@ -234,9 +237,11 @@ const handleCardClick = (cardId: string) => {
   );
 };
 
-onMounted(() => {
-  dashboardsStore.updateLastUpdatedRequest();
-  loadCardData();
+const { hasBeenVisible } = useLazyData({
+  load: () => {
+    dashboardsStore.updateLastUpdatedRequest();
+    return loadCardData();
+  },
 });
 </script>
 

--- a/src/components/insights/conversations/MostTalkedAboutTopicsWidget/index.vue
+++ b/src/components/insights/conversations/MostTalkedAboutTopicsWidget/index.vue
@@ -59,9 +59,10 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useI18n } from 'vue-i18n';
+import { useLazyData } from '@/composables/useLazyData';
 import BaseConversationWidget from '@/components/insights/conversations/BaseConversationWidget.vue';
 import TreemapChart from '@/components/insights/charts/TreemapChart.vue';
 import SeeAllDrawer from './SeeAllDrawer.vue';
@@ -132,13 +133,19 @@ const handleTabChange = (tab: Tab) => {
   setTopicType(tab === 'artificial-intelligence' ? 'AI' : 'HUMAN');
 };
 
+const { hasBeenVisible } = useLazyData({
+  load: loadTopicsDistribution,
+});
+
 watch(topicType, () => {
+  if (!hasBeenVisible.value) return;
   loadTopicsDistribution();
 });
 
 watch(
   () => route.query,
   () => {
+    if (!hasBeenVisible.value) return;
     loadTopicsDistribution();
   },
 );
@@ -146,6 +153,7 @@ watch(
 watch(
   () => conversationalStore.refreshDataConversational,
   (newValue) => {
+    if (!hasBeenVisible.value) return;
     if (newValue) {
       conversationalStore.setIsLoadingConversationalData(
         'mostTalkedAboutTopics',
@@ -160,10 +168,6 @@ watch(
     }
   },
 );
-
-onMounted(() => {
-  loadTopicsDistribution();
-});
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/insights/conversations/__tests__/ConversationalDynamicWidget.spec.js
+++ b/src/components/insights/conversations/__tests__/ConversationalDynamicWidget.spec.js
@@ -150,6 +150,15 @@ describe('ConversationalDynamicWidget', () => {
       );
     });
 
+    it('wraps the widget in a LazyWidget boundary', () => {
+      const wrapper = createWrapper({ type: 'csat' });
+      const lazyWidget = wrapper.findComponent({ name: 'LazyWidget' });
+      expect(lazyWidget.exists()).toBe(true);
+      expect(
+        lazyWidget.findComponent({ name: 'ConversationalCsat' }).exists(),
+      ).toBe(true);
+    });
+
     it('computes currentComponent correctly', () => {
       const wrapper = createWrapper({ type: 'csat' });
       expect(wrapper.vm.currentComponent).toBeDefined();

--- a/src/components/insights/conversations/__tests__/DashboardHeader.spec.js
+++ b/src/components/insights/conversations/__tests__/DashboardHeader.spec.js
@@ -3,6 +3,7 @@ import { ref as vueRef, reactive } from 'vue';
 import { mount, config } from '@vue/test-utils';
 
 import DashboardHeader from '../DashboardHeader.vue';
+import { LazyVisibilityKey } from '@/composables/useLazyData';
 
 import { createI18n } from 'vue-i18n';
 import Unnnic from '@weni/unnnic-system';
@@ -117,6 +118,23 @@ const createWrapper = () => {
   });
 };
 
+const createLazyWrapper = (hasBeenVisible) => {
+  const hasBeenVisibleRef = vueRef(hasBeenVisible);
+  const wrapper = mount(DashboardHeader, {
+    global: {
+      plugins: [Unnnic],
+      provide: {
+        [LazyVisibilityKey]: {
+          hasBeenVisible: hasBeenVisibleRef,
+          isVisible: vueRef(hasBeenVisible),
+          forceLoad: vi.fn(),
+        },
+      },
+    },
+  });
+  return { wrapper, hasBeenVisibleRef };
+};
+
 describe('DashboardHeader.vue', () => {
   let wrapper;
 
@@ -124,6 +142,41 @@ describe('DashboardHeader.vue', () => {
     vi.clearAllMocks();
 
     wrapper = createWrapper();
+  });
+
+  describe('Lazy loading', () => {
+    it('should not load card data while off screen', async () => {
+      const conversationalHeaderApi = await import(
+        '@/services/api/resources/conversational/header'
+      );
+      conversationalHeaderApi.default.getConversationalHeaderTotals.mockClear();
+
+      createLazyWrapper(false);
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(
+        conversationalHeaderApi.default.getConversationalHeaderTotals,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('should load card data once it becomes visible', async () => {
+      const conversationalHeaderApi = await import(
+        '@/services/api/resources/conversational/header'
+      );
+      conversationalHeaderApi.default.getConversationalHeaderTotals.mockClear();
+
+      const { hasBeenVisibleRef } = createLazyWrapper(false);
+      expect(
+        conversationalHeaderApi.default.getConversationalHeaderTotals,
+      ).not.toHaveBeenCalled();
+
+      hasBeenVisibleRef.value = true;
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(
+        conversationalHeaderApi.default.getConversationalHeaderTotals,
+      ).toHaveBeenCalled();
+    });
   });
 
   describe('Component Structure', () => {

--- a/src/components/insights/dashboards/Conversational.vue
+++ b/src/components/insights/dashboards/Conversational.vue
@@ -9,7 +9,9 @@
       <h2 class="dashboard-conversational__section-title">
         {{ $t('conversations_dashboard.sections.conversations') }}
       </h2>
-      <DashboardHeader class="dashboard-conversational__header" />
+      <LazyWidget class="dashboard-conversational__header">
+        <DashboardHeader />
+      </LazyWidget>
     </section>
 
     <section
@@ -19,17 +21,21 @@
       <h2 class="dashboard-conversational__section-title">
         {{ $t('conversations_dashboard.sections.contacts') }}
       </h2>
-      <ContactsHeader class="dashboard-conversational__header" />
+      <LazyWidget class="dashboard-conversational__header">
+        <ContactsHeader />
+      </LazyWidget>
     </section>
 
-    <MostTalkedAboutTopicsWidget
-      class="dashboard-conversational__most-talked-about-topics"
-    />
+    <LazyWidget class="dashboard-conversational__most-talked-about-topics">
+      <MostTalkedAboutTopicsWidget />
+    </LazyWidget>
 
-    <AbandonedCartWidget
+    <LazyWidget
       v-if="isAbandonedCartRecoveryConfigured"
       class="dashboard-conversational__abandoned-cart-widget"
-    />
+    >
+      <AbandonedCartWidget />
+    </LazyWidget>
 
     <ConversationalDynamicWidget
       v-for="(widget, index) in orderedDynamicWidgets"
@@ -67,6 +73,7 @@ import CustomizableDrawer from '@/components/insights/conversations/Customizable
 import Info from '@/components/insights/conversations/Info.vue';
 import DataFeedbackModal from '@/components/insights/conversations/Feedback/DataFeedbackModal.vue';
 import AbandonedCartWidget from '@/components/insights/conversations/AbandonedCartWidget/index.vue';
+import LazyWidget from '@/components/insights/Layout/LazyWidget.vue';
 
 import { useWidgets } from '@/store/modules/widgets';
 import { useCustomWidgets } from '@/store/modules/conversational/customWidgets';
@@ -223,13 +230,12 @@ const waitForDashboardWidgets = () =>
 
 const initializeConfiguration = async () => {
   const topicsPromise = topicsStore.loadFormTopics();
-  const autoWidgetsPromise = autoWidgets.loadAllAutoWidgets();
   project.getAgentsTeam();
 
   await waitForDashboardWidgets();
   setDynamicWidgets();
 
-  await Promise.all([topicsPromise, autoWidgetsPromise]);
+  await topicsPromise;
   conversational.setConfigurationLoaded(true);
 
   if (conversational.shouldUseMock) {

--- a/src/components/insights/dashboards/__tests__/Conversational.spec.js
+++ b/src/components/insights/dashboards/__tests__/Conversational.spec.js
@@ -185,6 +185,13 @@ describe('Conversational.vue', () => {
     });
   });
 
+  describe('Lazy loading', () => {
+    it('should not eagerly load auto widgets on init (lazy-loaded per widget)', async () => {
+      await nextTick();
+      expect(autoWidgetsStore.loadAllAutoWidgets).not.toHaveBeenCalled();
+    });
+  });
+
   it('should always include agent_invocation and tool_result first', async () => {
     widgetsStore.currentDashboardWidgets.value = [];
     await nextTick();

--- a/src/components/insights/humanSupport/Analysis/Analysis.vue
+++ b/src/components/insights/humanSupport/Analysis/Analysis.vue
@@ -4,15 +4,24 @@
       v-if="!hasSectorsConfigured"
       :description="$t('human_support_dashboard.setup.disclaimer')"
     />
-    <StatusCards data-testid="status-cards" />
-    <ServicesOpenByHour data-testid="services-open-by-hour" />
-    <VolumePerTagAndQueueWidget context="analysis" />
-    <CsatRatings
-      v-if="isFeatureFlagEnabled('insightsCSAT')"
-      type="analysis"
-      data-testid="analysis-csat-ratings"
-    />
-    <DetailedAnalysis data-testid="detailed-analysis" />
+    <LazyWidget>
+      <StatusCards data-testid="status-cards" />
+    </LazyWidget>
+    <LazyWidget>
+      <ServicesOpenByHour data-testid="services-open-by-hour" />
+    </LazyWidget>
+    <LazyWidget>
+      <VolumePerTagAndQueueWidget context="analysis" />
+    </LazyWidget>
+    <LazyWidget v-if="isFeatureFlagEnabled('insightsCSAT')">
+      <CsatRatings
+        type="analysis"
+        data-testid="analysis-csat-ratings"
+      />
+    </LazyWidget>
+    <LazyWidget :forceVisible="forceLoadDetailed">
+      <DetailedAnalysis data-testid="detailed-analysis" />
+    </LazyWidget>
   </section>
 </template>
 
@@ -24,9 +33,11 @@ import ServicesOpenByHour from './ServicesOpenByHour.vue';
 import DetailedAnalysis from './DetailedAnalysis.vue';
 import CsatRatings from '../CommonWidgets/CsatRatings/CsatRatings.vue';
 import VolumePerTagAndQueueWidget from '../CommonWidgets/VolumePerTagAndQueue/index.vue';
+import LazyWidget from '@/components/insights/Layout/LazyWidget.vue';
 
 import { useFeatureFlag } from '@/store/modules/featureFlag';
 import { useProject } from '@/store/modules/project';
+import { useHumanSupportAnalysis } from '@/store/modules/humanSupport/analysis';
 
 defineOptions({
   name: 'AnalysisView',
@@ -34,6 +45,8 @@ defineOptions({
 
 const projectStore = useProject();
 const { hasSectorsConfigured } = storeToRefs(projectStore);
+
+const { forceLoadDetailed } = storeToRefs(useHumanSupportAnalysis());
 
 const { isFeatureFlagEnabled } = useFeatureFlag();
 </script>

--- a/src/components/insights/humanSupport/Analysis/ServicesOpenByHour.vue
+++ b/src/components/insights/humanSupport/Analysis/ServicesOpenByHour.vue
@@ -19,12 +19,14 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, computed, useTemplateRef } from 'vue';
+import { computed, useTemplateRef } from 'vue';
 import { useMouseInElement } from '@vueuse/core';
 import { storeToRefs } from 'pinia';
 
 import LineChart from '@/components/insights/charts/LineChart.vue';
 import BlurSetupWidget from '@/components/insights/Layout/BlurSetupWidget.vue';
+
+import { useLazyData } from '@/composables/useLazyData';
 
 import { useHumanSupport } from '@/store/modules/humanSupport/humanSupport';
 import { useHumanSupportAnalysis } from '@/store/modules/humanSupport/analysis';
@@ -76,9 +78,7 @@ const isLoading = computed(() => {
   return loadingHumanSupportByHourData.value;
 });
 
-onMounted(() => {
-  loadHumanSupportByHourData();
-});
+useLazyData({ load: loadHumanSupportByHourData });
 </script>
 
 <style scoped lang="scss">

--- a/src/components/insights/humanSupport/Analysis/StatusCards.vue
+++ b/src/components/insights/humanSupport/Analysis/StatusCards.vue
@@ -54,12 +54,14 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, computed, useTemplateRef } from 'vue';
+import { computed, useTemplateRef } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useMouseInElement } from '@vueuse/core';
 
 import CardConversations from '@/components/insights/cards/CardConversations.vue';
 import BlurSetupWidget from '@/components/insights/Layout/BlurSetupWidget.vue';
+
+import { useLazyData } from '@/composables/useLazyData';
 
 import { useProject } from '@/store/modules/project';
 import { useHumanSupport } from '@/store/modules/humanSupport/humanSupport';
@@ -135,9 +137,12 @@ const cardDefinitions: CardData[] = [
 ];
 
 const humanSupportAnalysis = useHumanSupportAnalysis();
-const { loadServiceStatusData, setActiveDetailedTab } = humanSupportAnalysis;
+const { loadServiceStatusData, setActiveDetailedTab, setForceLoadDetailed } =
+  humanSupportAnalysis;
 const { serviceStatusData, loadingServiceStatusData } =
   storeToRefs(humanSupportAnalysis);
+
+useLazyData({ load: loadServiceStatusData });
 
 const isLoadingCards = computed(() => loadingServiceStatusData.value);
 
@@ -170,13 +175,13 @@ const getTooltipSide = (index: number) => {
   return 'top';
 };
 
-const scrollToDetailedMonitoring = () => {
-  const detailedMonitoringElement = document.querySelector(
-    '[id="detailed-monitoring"]',
+const scrollToDetailedAnalysis = () => {
+  const detailedAnalysisElement = document.querySelector(
+    '[id="detailed-analysis"]',
   );
 
-  if (detailedMonitoringElement) {
-    detailedMonitoringElement.scrollIntoView({
+  if (detailedAnalysisElement) {
+    detailedAnalysisElement.scrollIntoView({
       behavior: 'smooth',
       block: 'start',
     });
@@ -191,12 +196,9 @@ const handleCardClick = (id: CardId) => {
   };
 
   setActiveDetailedTab(status[id] as ActiveDetailedTab);
-  setTimeout(scrollToDetailedMonitoring, 100);
+  setForceLoadDetailed(true);
+  setTimeout(scrollToDetailedAnalysis, 100);
 };
-
-onMounted(() => {
-  loadServiceStatusData();
-});
 </script>
 
 <style scoped lang="scss">

--- a/src/components/insights/humanSupport/Analysis/Tables/Finished.vue
+++ b/src/components/insights/humanSupport/Analysis/Tables/Finished.vue
@@ -110,6 +110,7 @@ import { useHumanSupport } from '@/store/modules/humanSupport/humanSupport';
 import { useProject } from '@/store/modules/project';
 import { formatSecondsToTime } from '@/utils/time';
 import { useInfiniteScrollTable } from '@/composables/useInfiniteScrollTable';
+import { useLazyData } from '@/composables/useLazyData';
 import { analysisDetailedAnalysisFinishedMock } from '../mocks';
 import { openNewTabLink } from '@/utils/redirect';
 import DynamicCellText from '../../Common/DynamicCellText.vue';
@@ -237,6 +238,10 @@ const redirectItem = (item: FinishedDataResult) => {
   window.parent.postMessage({ event: 'redirect', path: url }, '*');
 };
 
+const { hasBeenVisible } = useLazyData({
+  load: () => resetAndLoadData(currentSort.value),
+});
+
 watch(
   [
     currentSort,
@@ -247,9 +252,9 @@ watch(
     () => humanSupport.appliedDetailFilters.ticketId,
   ],
   () => {
+    if (!hasBeenVisible.value) return;
     resetAndLoadData(currentSort.value);
   },
-  { immediate: true },
 );
 </script>
 

--- a/src/components/insights/humanSupport/Common/Tables/Pauses.vue
+++ b/src/components/insights/humanSupport/Common/Tables/Pauses.vue
@@ -58,6 +58,7 @@ import { useHumanSupportMonitoring } from '@/store/modules/humanSupport/monitori
 import { useHumanSupport } from '@/store/modules/humanSupport/humanSupport';
 import { formatSecondsToTime } from '@/utils/time';
 import { useInfiniteScrollTable } from '@/composables/useInfiniteScrollTable';
+import { useLazyData } from '@/composables/useLazyData';
 import { storeToRefs } from 'pinia';
 import { openNewTabLink } from '@/utils/redirect';
 import DynamicCellText from '../DynamicCellText.vue';
@@ -214,6 +215,10 @@ const loadDataSafely = async (sortValue: typeof currentSort.value) => {
   }
 };
 
+const { hasBeenVisible } = useLazyData({
+  load: () => loadDataSafely(currentSort.value),
+});
+
 watch(
   [
     currentSort,
@@ -222,14 +227,15 @@ watch(
     () => humanSupport.appliedDateRange,
   ],
   () => {
+    if (!hasBeenVisible.value) return;
     loadDataSafely(currentSort.value);
   },
-  { immediate: true },
 );
 
 watch(
   () => humanSupportMonitoring.refreshDataMonitoring,
   (newValue) => {
+    if (!hasBeenVisible.value) return;
     if (newValue && humanSupportMonitoring.activeDetailedTab === 'pauses') {
       loadDataSafely(currentSort.value);
     }

--- a/src/components/insights/humanSupport/CommonWidgets/CsatRatings/CsatRatings.vue
+++ b/src/components/insights/humanSupport/CommonWidgets/CsatRatings/CsatRatings.vue
@@ -102,10 +102,12 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, useTemplateRef, watch } from 'vue';
+import { computed, ref, useTemplateRef, watch } from 'vue';
 import { useInfiniteScroll, useMouseInElement } from '@vueuse/core';
 import { useI18n } from 'vue-i18n';
 import { storeToRefs } from 'pinia';
+
+import { useLazyData } from '@/composables/useLazyData';
 
 import type {
   AgentsTotalsResponse,
@@ -155,8 +157,8 @@ interface Props {
 
 const props = defineProps<Props>();
 
-onMounted(() => {
-  configStore.checkEnableCsat().then(() => {
+const loadCsatData = () => {
+  return configStore.checkEnableCsat().then(() => {
     if (configStore.enableCsat) {
       loadAgentsData();
       loadRatingsData();
@@ -165,7 +167,9 @@ onMounted(() => {
       isLoadingRatingsData.value = false;
     }
   });
-});
+};
+
+const { hasBeenVisible } = useLazyData({ load: loadCsatData });
 
 const { t, locale: localeI18n } = useI18n();
 
@@ -325,6 +329,7 @@ watch(activeAgentEmail, () => {
 watch(
   () => [appliedFilters.value, appliedDateRange.value],
   () => {
+    if (!hasBeenVisible.value) return;
     if (!configStore.enableCsat) return;
     loadAgentsData();
     if (!activeAgentEmail.value) {
@@ -337,6 +342,7 @@ watch(
 watch(
   () => humanSupportMonitoringStore.refreshDataMonitoring,
   (value) => {
+    if (!hasBeenVisible.value) return;
     if (!configStore.enableCsat) return;
     if (value) {
       agentsTotalNext.value = null;

--- a/src/components/insights/humanSupport/CommonWidgets/VolumePerTagAndQueue/VolumeBarListWidget.vue
+++ b/src/components/insights/humanSupport/CommonWidgets/VolumePerTagAndQueue/VolumeBarListWidget.vue
@@ -26,12 +26,14 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, watch } from 'vue';
+import { ref, computed, watch } from 'vue';
 import { storeToRefs } from 'pinia';
 
 import { useHumanSupport } from '@/store/modules/humanSupport/humanSupport';
 import { useHumanSupportMonitoring } from '@/store/modules/humanSupport/monitoring';
 import { useProject } from '@/store/modules/project';
+
+import { useLazyData } from '@/composables/useLazyData';
 
 import BarList from '../BarList/index.vue';
 import SeeAllDrawer from './SeeAllDrawer.vue';
@@ -270,8 +272,8 @@ const seeAllDrawerTitle = computed(() => {
   return `${t(props.seeAllTitleKey)} - ${statusLabel}`;
 });
 
-onMounted(async () => {
-  await getItems({ silent: false, concat: false });
+const { hasBeenVisible } = useLazyData({
+  load: () => getItems({ silent: false, concat: false }),
 });
 
 watch(
@@ -282,12 +284,14 @@ watch(
 );
 
 watch([currentTab, appliedFilters, appliedDateRange], async () => {
+  if (!hasBeenVisible.value) return;
   itemsNext.value = null;
   itemsPrevious.value = null;
   await getItems({ silent: false, concat: false });
 });
 
 watch(refreshDataMonitoring, async () => {
+  if (!hasBeenVisible.value) return;
   if (refreshDataMonitoring.value && autoRefresh.value) {
     itemsNext.value = null;
     itemsPrevious.value = null;

--- a/src/components/insights/humanSupport/Monitoring/Monitoring.vue
+++ b/src/components/insights/humanSupport/Monitoring/Monitoring.vue
@@ -8,16 +8,27 @@
       v-if="!hasSectorsConfigured"
       :description="$t('human_support_dashboard.setup.disclaimer')"
     />
-    <StatusCards data-testid="monitoring-status-cards" />
-    <TimeMetrics data-testid="monitoring-time-metrics" />
-    <ServicesOpenByHour data-testid="monitoring-services-open-by-hour" />
-    <VolumePerTagAndQueueWidget context="monitoring" />
-    <CsatRatings
-      v-if="isFeatureFlagEnabled('insightsCSAT')"
-      type="monitoring"
-      data-testid="monitoring-csat-ratings"
-    />
-    <DetailedMonitoring data-testid="monitoring-detailed-monitoring" />
+    <LazyWidget>
+      <StatusCards data-testid="monitoring-status-cards" />
+    </LazyWidget>
+    <LazyWidget>
+      <TimeMetrics data-testid="monitoring-time-metrics" />
+    </LazyWidget>
+    <LazyWidget>
+      <ServicesOpenByHour data-testid="monitoring-services-open-by-hour" />
+    </LazyWidget>
+    <LazyWidget>
+      <VolumePerTagAndQueueWidget context="monitoring" />
+    </LazyWidget>
+    <LazyWidget v-if="isFeatureFlagEnabled('insightsCSAT')">
+      <CsatRatings
+        type="monitoring"
+        data-testid="monitoring-csat-ratings"
+      />
+    </LazyWidget>
+    <LazyWidget :forceVisible="forceLoadDetailed">
+      <DetailedMonitoring data-testid="monitoring-detailed-monitoring" />
+    </LazyWidget>
   </section>
 </template>
 
@@ -36,6 +47,7 @@ import ServicesOpenByHour from './ServicesOpenByHour.vue';
 import DetailedMonitoring from './DetailedMonitoring.vue';
 import CsatRatings from '../CommonWidgets/CsatRatings/CsatRatings.vue';
 import VolumePerTagAndQueueWidget from '../CommonWidgets/VolumePerTagAndQueue/index.vue';
+import LazyWidget from '@/components/insights/Layout/LazyWidget.vue';
 
 const { isFeatureFlagEnabled } = useFeatureFlag();
 
@@ -54,7 +66,9 @@ const AUTO_REFRESH_INTERVAL = 60 * 1000;
 const humanSupportMonitoringStore = useHumanSupportMonitoring();
 
 const { setRefreshDataMonitoring } = humanSupportMonitoringStore;
-const { autoRefresh } = storeToRefs(humanSupportMonitoringStore);
+const { autoRefresh, forceLoadDetailed } = storeToRefs(
+  humanSupportMonitoringStore,
+);
 
 const monitoringRef = ref(null);
 const isVisible = useElementVisibility(monitoringRef);

--- a/src/components/insights/humanSupport/Monitoring/ServicesOpenByHour.vue
+++ b/src/components/insights/humanSupport/Monitoring/ServicesOpenByHour.vue
@@ -24,12 +24,14 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, computed, useTemplateRef } from 'vue';
+import { computed, useTemplateRef } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useMouseInElement } from '@vueuse/core';
 
 import LineChart from '@/components/insights/charts/LineChart.vue';
 import BlurSetupWidget from '@/components/insights/Layout/BlurSetupWidget.vue';
+
+import { useLazyData } from '@/composables/useLazyData';
 
 import { useHumanSupportMonitoring } from '@/store/modules/humanSupport/monitoring';
 import { useProject } from '@/store/modules/project';
@@ -80,9 +82,7 @@ const showSetup = computed(() => {
   return !isOutside.value && !hasSectorsConfigured.value;
 });
 
-onMounted(() => {
-  loadHumanSupportByHourData();
-});
+useLazyData({ load: loadHumanSupportByHourData });
 </script>
 
 <style scoped lang="scss">

--- a/src/components/insights/humanSupport/Monitoring/StatusCards.vue
+++ b/src/components/insights/humanSupport/Monitoring/StatusCards.vue
@@ -39,12 +39,14 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, computed, useTemplateRef } from 'vue';
+import { computed, useTemplateRef } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useMouseInElement } from '@vueuse/core';
 
 import CardConversations from '@/components/insights/cards/CardConversations.vue';
 import BlurSetupWidget from '@/components/insights/Layout/BlurSetupWidget.vue';
+
+import { useLazyData } from '@/composables/useLazyData';
 
 import {
   ActiveDetailedTab,
@@ -96,10 +98,13 @@ const cardDefinitions: CardData[] = [
 ];
 
 const humanSupportMonitoring = useHumanSupportMonitoring();
-const { loadServiceStatusData, setActiveDetailedTab } = humanSupportMonitoring;
+const { loadServiceStatusData, setActiveDetailedTab, setForceLoadDetailed } =
+  humanSupportMonitoring;
 const { serviceStatusData, loadingServiceStatusData } = storeToRefs(
   humanSupportMonitoring,
 );
+
+useLazyData({ load: loadServiceStatusData });
 
 const isLoadingCards = computed(() => loadingServiceStatusData.value);
 
@@ -144,12 +149,9 @@ const handleCardClick = (id: CardId) => {
   };
 
   setActiveDetailedTab(status[id] as ActiveDetailedTab);
+  setForceLoadDetailed(true);
   setTimeout(scrollToDetailedMonitoring, 100);
 };
-
-onMounted(() => {
-  loadServiceStatusData();
-});
 </script>
 
 <style scoped lang="scss">

--- a/src/components/insights/humanSupport/Monitoring/Tables/Attendant.vue
+++ b/src/components/insights/humanSupport/Monitoring/Tables/Attendant.vue
@@ -61,6 +61,7 @@ import AgentStatus from '@/components/insights/widgets/HumanServiceAgentsTable/A
 import DynamicCellText from '../../Common/DynamicCellText.vue';
 import { formatSecondsToTime } from '@/utils/time';
 import { useInfiniteScrollTable } from '@/composables/useInfiniteScrollTable';
+import { useLazyData } from '@/composables/useLazyData';
 import { storeToRefs } from 'pinia';
 import { openNewTabLink } from '@/utils/redirect';
 
@@ -241,9 +242,14 @@ const loadDataSafely = async (sortValue: typeof currentSort.value) => {
   }
 };
 
+const { hasBeenVisible } = useLazyData({
+  load: () => loadDataSafely(currentSort.value),
+});
+
 watchDebounced(
   () => humanSupport.appliedDetailFilters.status,
   async () => {
+    if (!hasBeenVisible.value) return;
     await resetAndLoadData(currentSort.value);
   },
   { deep: true, debounce: 700 },
@@ -256,14 +262,16 @@ watch(
     () => humanSupport.appliedFilters,
   ],
   () => {
+    if (!hasBeenVisible.value) return;
     loadDataSafely(currentSort.value);
   },
-  { immediate: true, deep: true },
+  { deep: true },
 );
 
 watch(
   () => humanSupportMonitoring.refreshDataMonitoring,
   (newValue) => {
+    if (!hasBeenVisible.value) return;
     if (newValue && humanSupportMonitoring.activeDetailedTab === 'attendant') {
       loadDataSafely(currentSort.value);
     }

--- a/src/components/insights/humanSupport/Monitoring/Tables/InAwaiting.vue
+++ b/src/components/insights/humanSupport/Monitoring/Tables/InAwaiting.vue
@@ -32,6 +32,7 @@ import { useHumanSupportMonitoring } from '@/store/modules/humanSupport/monitori
 import { useHumanSupport } from '@/store/modules/humanSupport/humanSupport';
 import { formatSecondsToTime } from '@/utils/time';
 import { useInfiniteScrollTable } from '@/composables/useInfiniteScrollTable';
+import { useLazyData } from '@/composables/useLazyData';
 import { storeToRefs } from 'pinia';
 import { openNewTabLink } from '@/utils/redirect';
 
@@ -139,6 +140,10 @@ const loadDataSafely = async (sortValue: typeof currentSort.value) => {
   }
 };
 
+const { hasBeenVisible } = useLazyData({
+  load: () => loadDataSafely(currentSort.value),
+});
+
 watch(
   [
     currentSort,
@@ -146,14 +151,16 @@ watch(
     () => humanSupport.appliedDetailFilters.contactInput,
   ],
   () => {
+    if (!hasBeenVisible.value) return;
     loadDataSafely(currentSort.value);
   },
-  { immediate: true, deep: true },
+  { deep: true },
 );
 
 watch(
   () => humanSupportMonitoring.refreshDataMonitoring,
   (newValue) => {
+    if (!hasBeenVisible.value) return;
     if (
       newValue &&
       humanSupportMonitoring.activeDetailedTab === 'in_awaiting'

--- a/src/components/insights/humanSupport/Monitoring/Tables/InProgress.vue
+++ b/src/components/insights/humanSupport/Monitoring/Tables/InProgress.vue
@@ -71,6 +71,7 @@ import { useProject } from '@/store/modules/project';
 import { formatSecondsToTime } from '@/utils/time';
 
 import { useInfiniteScrollTable } from '@/composables/useInfiniteScrollTable';
+import { useLazyData } from '@/composables/useLazyData';
 
 import { InProgressDataResult } from '@/services/api/resources/humanSupport/monitoring/detailedMonitoring/inProgress';
 import service from '@/services/api/resources/humanSupport/monitoring/detailedMonitoring/inProgress';
@@ -189,6 +190,10 @@ const loadDataSafely = async (sortValue: typeof currentSort.value) => {
   }
 };
 
+const { hasBeenVisible } = useLazyData({
+  load: () => loadDataSafely(currentSort.value),
+});
+
 watch(
   [
     currentSort,
@@ -196,14 +201,16 @@ watch(
     () => humanSupport.appliedDetailFilters.contactInput,
   ],
   () => {
+    if (!hasBeenVisible.value) return;
     loadDataSafely(currentSort.value);
   },
-  { immediate: true, deep: true },
+  { deep: true },
 );
 
 watch(
   () => humanSupportMonitoring.refreshDataMonitoring,
   (newValue) => {
+    if (!hasBeenVisible.value) return;
     if (
       newValue &&
       humanSupportMonitoring.activeDetailedTab === 'in_progress'

--- a/src/components/insights/humanSupport/Monitoring/TimeMetrics.vue
+++ b/src/components/insights/humanSupport/Monitoring/TimeMetrics.vue
@@ -42,13 +42,15 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, computed, useTemplateRef } from 'vue';
+import { computed, useTemplateRef } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useI18n } from 'vue-i18n';
 import { useMouseInElement } from '@vueuse/core';
 
 import CardConversations from '@/components/insights/cards/CardConversations.vue';
 import BlurSetupWidget from '@/components/insights/Layout/BlurSetupWidget.vue';
+
+import { useLazyData } from '@/composables/useLazyData';
 
 import {
   ActiveDetailedTab,
@@ -109,10 +111,13 @@ const cardDefinitions: CardData[] = [
 const { t } = useI18n();
 
 const humanSupportMonitoring = useHumanSupportMonitoring();
-const { loadTimeMetricsData, setActiveDetailedTab } = humanSupportMonitoring;
+const { loadTimeMetricsData, setActiveDetailedTab, setForceLoadDetailed } =
+  humanSupportMonitoring;
 const { timeMetricsData, loadingTimeMetricsData } = storeToRefs(
   humanSupportMonitoring,
 );
+
+useLazyData({ load: loadTimeMetricsData });
 
 const widgetData = computed(() => {
   if (!hasSectorsConfigured.value) {
@@ -165,12 +170,9 @@ const handleCardClick = (id: CardId) => {
   };
 
   setActiveDetailedTab(status[id] as ActiveDetailedTab);
+  setForceLoadDetailed(true);
   setTimeout(scrollToDetailedMonitoring, 100);
 };
-
-onMounted(() => {
-  loadTimeMetricsData();
-});
 </script>
 
 <style scoped lang="scss">

--- a/src/components/insights/humanSupport/Monitoring/__tests__/StatusCards.spec.js
+++ b/src/components/insights/humanSupport/Monitoring/__tests__/StatusCards.spec.js
@@ -5,6 +5,7 @@ import { createTestingPinia } from '@pinia/testing';
 import { ref } from 'vue';
 
 import ServiceStatus from '../StatusCards.vue';
+import { LazyVisibilityKey } from '@/composables/useLazyData';
 
 const defaultServiceStatusData = {
   is_waiting: 25,
@@ -15,6 +16,8 @@ const defaultServiceStatusData = {
 const mockMonitoringStore = {
   $id: 'humanSupportMonitoring',
   loadServiceStatusData: vi.fn(),
+  setActiveDetailedTab: vi.fn(),
+  setForceLoadDetailed: vi.fn(),
   serviceStatusData: { value: { ...defaultServiceStatusData } },
   loadingServiceStatusData: { value: false },
 };
@@ -104,10 +107,35 @@ describe('ServiceStatus', () => {
   const title = () => wrapper.find('[data-testid="service-status-title"]');
   const cards = () => wrapper.find('[data-testid="service-status-cards"]');
 
+  const createLazyWrapper = (hasBeenVisible) => {
+    const hasBeenVisibleRef = ref(hasBeenVisible);
+    const isVisibleRef = ref(hasBeenVisible);
+    const lazyWrapper = mount(ServiceStatus, {
+      global: {
+        plugins: [
+          createTestingPinia({
+            initialState: { project: { hasSectorsConfigured: true } },
+          }),
+        ],
+        stubs: { CardConversations: true },
+        provide: {
+          [LazyVisibilityKey]: {
+            hasBeenVisible: hasBeenVisibleRef,
+            isVisible: isVisibleRef,
+            forceLoad: vi.fn(),
+          },
+        },
+      },
+    });
+    return { lazyWrapper, hasBeenVisibleRef };
+  };
+
   beforeEach(() => {
     vi.clearAllMocks();
     Object.assign(mockMonitoringStore, {
       loadServiceStatusData: vi.fn(),
+      setActiveDetailedTab: vi.fn(),
+      setForceLoadDetailed: vi.fn(),
       serviceStatusData: { value: { ...defaultServiceStatusData } },
       loadingServiceStatusData: { value: false },
     });
@@ -294,6 +322,47 @@ describe('ServiceStatus', () => {
   describe('Lifecycle', () => {
     it('should load service status data on mounted', () => {
       expect(mockMonitoringStore.loadServiceStatusData).toHaveBeenCalled();
+    });
+  });
+
+  describe('Lazy loading', () => {
+    it('should not load data while the widget is off screen', () => {
+      mockMonitoringStore.loadServiceStatusData.mockClear();
+      createLazyWrapper(false);
+      expect(mockMonitoringStore.loadServiceStatusData).not.toHaveBeenCalled();
+    });
+
+    it('should load data once the widget becomes visible', async () => {
+      mockMonitoringStore.loadServiceStatusData.mockClear();
+      const { hasBeenVisibleRef } = createLazyWrapper(false);
+      expect(mockMonitoringStore.loadServiceStatusData).not.toHaveBeenCalled();
+
+      hasBeenVisibleRef.value = true;
+      await Promise.resolve();
+
+      expect(mockMonitoringStore.loadServiceStatusData).toHaveBeenCalledTimes(
+        1,
+      );
+    });
+  });
+
+  describe('Card click navigation', () => {
+    it('should force-load the detailed section and switch tab on click', () => {
+      wrapper.vm.handleCardClick('is_waiting');
+
+      expect(mockMonitoringStore.setActiveDetailedTab).toHaveBeenCalledWith(
+        'in_awaiting',
+      );
+      expect(mockMonitoringStore.setForceLoadDetailed).toHaveBeenCalledWith(
+        true,
+      );
+    });
+
+    it('should not navigate when the finished card is clicked', () => {
+      wrapper.vm.handleCardClick('finished');
+
+      expect(mockMonitoringStore.setActiveDetailedTab).not.toHaveBeenCalled();
+      expect(mockMonitoringStore.setForceLoadDetailed).not.toHaveBeenCalled();
     });
   });
 

--- a/src/components/insights/widgets/conversational/ConversacionalAbsoluteNumbers/AbsoluteNumbersMetric.vue
+++ b/src/components/insights/widgets/conversational/ConversacionalAbsoluteNumbers/AbsoluteNumbersMetric.vue
@@ -37,8 +37,10 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { useRoute } from 'vue-router';
+
+import { useLazyData } from '@/composables/useLazyData';
 
 import CardWidgetContainer from '../../layout/CardWidgetContainer.vue';
 import WidgetService, {
@@ -118,13 +120,14 @@ const actions = computed(() => {
   return [editOption, deleteOption];
 });
 
-onMounted(() => {
-  getChildrenValue();
+const { hasBeenVisible } = useLazyData({
+  load: getChildrenValue,
 });
 
 watch(
   () => route.query,
   () => {
+    if (!hasBeenVisible.value) return;
     getChildrenValue();
   },
   { deep: true },
@@ -133,6 +136,7 @@ watch(
 watch(
   () => conversationalStore.refreshDataConversational,
   (newValue) => {
+    if (!hasBeenVisible.value) return;
     if (newValue) {
       getChildrenValue();
     }

--- a/src/components/insights/widgets/conversational/ConversacionalAbsoluteNumbers/index.vue
+++ b/src/components/insights/widgets/conversational/ConversacionalAbsoluteNumbers/index.vue
@@ -77,9 +77,11 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue';
+import { computed, ref } from 'vue';
 import { storeToRefs } from 'pinia';
 import { cloneDeep } from 'lodash-es';
+
+import { useLazyData } from '@/composables/useLazyData';
 
 import CardWidgetContainer from '@/components/insights/widgets/layout/CardWidgetContainer.vue';
 import AbsoluteNumbersMetric from './AbsoluteNumbersMetric.vue';
@@ -105,8 +107,8 @@ const props = defineProps<{
   uuid: string;
 }>();
 
-onMounted(() => {
-  loadChildren();
+useLazyData({
+  load: () => loadChildren(),
 });
 
 const customWidgetsStore = useCustomWidgets();

--- a/src/components/insights/widgets/conversational/ConversationalAddedToCart.vue
+++ b/src/components/insights/widgets/conversational/ConversationalAddedToCart.vue
@@ -67,10 +67,12 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useRoute } from 'vue-router';
 import { useI18n } from 'vue-i18n';
+
+import { useLazyData } from '@/composables/useLazyData';
 
 import BaseConversationWidget from '@/components/insights/conversations/BaseConversationWidget.vue';
 import ProgressTable from '@/components/ProgressTable.vue';
@@ -151,13 +153,14 @@ const actions = computed(() => {
   ];
 });
 
-onMounted(() => {
-  loadAddedToCartWidgetData();
+const { hasBeenVisible } = useLazyData({
+  load: loadAddedToCartWidgetData,
 });
 
 watch(
   () => route.query,
   () => {
+    if (!hasBeenVisible.value) return;
     loadAddedToCartWidgetData();
   },
   { deep: true },
@@ -166,6 +169,7 @@ watch(
 watch(
   () => conversational.refreshDataConversational,
   (newValue) => {
+    if (!hasBeenVisible.value) return;
     if (newValue) {
       conversational.setIsLoadingConversationalData('dynamicWidgets', true);
       loadAddedToCartWidgetData().finally(() => {

--- a/src/components/insights/widgets/conversational/ConversationalAgentInvocation.vue
+++ b/src/components/insights/widgets/conversational/ConversationalAgentInvocation.vue
@@ -73,10 +73,12 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { useRoute } from 'vue-router';
 import { storeToRefs } from 'pinia';
 import { UnnnicDisclaimer } from '@weni/unnnic-system';
+
+import { useLazyData } from '@/composables/useLazyData';
 
 import BaseConversationWidget from '@/components/insights/conversations/BaseConversationWidget.vue';
 import ProgressTable from '@/components/ProgressTable.vue';
@@ -163,18 +165,21 @@ const widgetActions = computed(() => {
   return [deleteOption];
 });
 
-onMounted(() => {
-  if (!shouldUseMock.value) {
-    autoWidgetsStore.loadAgentInvocationData();
-    if (!projectStore.agentsTeam.agents.length) {
-      projectStore.getAgentsTeam();
+const { hasBeenVisible } = useLazyData({
+  load: () => {
+    if (!shouldUseMock.value) {
+      autoWidgetsStore.loadAgentInvocationData();
+      if (!projectStore.agentsTeam.agents.length) {
+        projectStore.getAgentsTeam();
+      }
     }
-  }
+  },
 });
 
 watch(
   () => route.query,
   () => {
+    if (!hasBeenVisible.value) return;
     if (!shouldUseMock.value) {
       autoWidgetsStore.loadAgentInvocationData();
     }
@@ -185,6 +190,7 @@ watch(
 watch(
   () => conversational.refreshDataConversational,
   (newValue) => {
+    if (!hasBeenVisible.value) return;
     if (newValue && !shouldUseMock.value) {
       conversational.setIsLoadingConversationalData('dynamicWidgets', true);
       autoWidgetsStore.loadAgentInvocationData().finally(() => {

--- a/src/components/insights/widgets/conversational/ConversationalCrosstab.vue
+++ b/src/components/insights/widgets/conversational/ConversationalCrosstab.vue
@@ -33,10 +33,12 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { useRoute } from 'vue-router';
 import { useI18n } from 'vue-i18n';
 import { storeToRefs } from 'pinia';
+
+import { useLazyData } from '@/composables/useLazyData';
 
 import ProgressWidget from '@/components/insights/widgets/ProgressWidget.vue';
 import ModalRemoveWidget from '@/components/insights/conversations/CustomizableWidget/ModalRemoveWidget.vue';
@@ -165,15 +167,18 @@ const handleOpenExpanded = () => {
   isSeeAllDrawerOpen.value = true;
 };
 
-onMounted(() => {
-  if (!shouldUseMock.value) {
-    loadCustomWidgetData(props.uuid);
-  }
+const { hasBeenVisible } = useLazyData({
+  load: () => {
+    if (!shouldUseMock.value) {
+      loadCustomWidgetData(props.uuid);
+    }
+  },
 });
 
 watch(
   () => route.query,
   () => {
+    if (!hasBeenVisible.value) return;
     if (!shouldUseMock.value) {
       loadCustomWidgetData(props.uuid);
     }
@@ -184,6 +189,7 @@ watch(
 watch(
   () => conversational.refreshDataConversational,
   (newValue) => {
+    if (!hasBeenVisible.value) return;
     if (newValue && !shouldUseMock.value) {
       conversational.setIsLoadingConversationalData('dynamicWidgets', true);
       loadCustomWidgetData(props.uuid).finally(() => {

--- a/src/components/insights/widgets/conversational/ConversationalCsat.vue
+++ b/src/components/insights/widgets/conversational/ConversationalCsat.vue
@@ -45,10 +45,12 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useRoute } from 'vue-router';
 import { useI18n } from 'vue-i18n';
+
+import { useLazyData } from '@/composables/useLazyData';
 
 import ProgressWidget from '@/components/insights/widgets/ProgressWidget.vue';
 import SetupWidget from '@/components/insights/conversations/SetupWidget.vue';
@@ -220,15 +222,17 @@ const handleTabChange = (tab: Tab) => {
   }
 };
 
-onMounted(() => {
-  if (shouldUseMock.value) {
-    setCsatWidgetType('AI');
-  } else if (csatWidgetType.value === 'AI' && !isCsatAiConfig.value) {
-    setCsatWidgetType('HUMAN');
-  } else if (csatWidgetType.value === 'HUMAN' && !isCsatHumanConfig.value) {
-    setCsatWidgetType('AI');
-  }
-  loadCsatWidgetData();
+const { hasBeenVisible } = useLazyData({
+  load: () => {
+    if (shouldUseMock.value) {
+      setCsatWidgetType('AI');
+    } else if (csatWidgetType.value === 'AI' && !isCsatAiConfig.value) {
+      setCsatWidgetType('HUMAN');
+    } else if (csatWidgetType.value === 'HUMAN' && !isCsatHumanConfig.value) {
+      setCsatWidgetType('AI');
+    }
+    loadCsatWidgetData();
+  },
 });
 
 watch(
@@ -248,6 +252,7 @@ watch(
 watch(
   () => route.query,
   () => {
+    if (!hasBeenVisible.value) return;
     loadCsatWidgetData();
   },
   { deep: true },
@@ -256,6 +261,7 @@ watch(
 watch(
   () => conversational.refreshDataConversational,
   (newValue) => {
+    if (!hasBeenVisible.value) return;
     if (newValue) {
       conversational.setIsLoadingConversationalData('dynamicWidgets', true);
       loadCsatWidgetData().finally(() => {

--- a/src/components/insights/widgets/conversational/ConversationalCustom.vue
+++ b/src/components/insights/widgets/conversational/ConversationalCustom.vue
@@ -32,10 +32,12 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { useRoute } from 'vue-router';
 import { useI18n } from 'vue-i18n';
 import { storeToRefs } from 'pinia';
+
+import { useLazyData } from '@/composables/useLazyData';
 
 import ProgressWidget from '@/components/insights/widgets/ProgressWidget.vue';
 import ModalRemoveWidget from '@/components/insights/conversations/CustomizableWidget/ModalRemoveWidget.vue';
@@ -181,15 +183,18 @@ const handleOpenExpanded = () => {
   isSeeAllDrawerOpen.value = true;
 };
 
-onMounted(() => {
-  if (!shouldUseMock.value) {
-    loadCustomWidgetData(props.uuid);
-  }
+const { hasBeenVisible } = useLazyData({
+  load: () => {
+    if (!shouldUseMock.value) {
+      loadCustomWidgetData(props.uuid);
+    }
+  },
 });
 
 watch(
   () => route.query,
   () => {
+    if (!hasBeenVisible.value) return;
     if (!shouldUseMock.value) {
       loadCustomWidgetData(props.uuid);
     }
@@ -200,6 +205,7 @@ watch(
 watch(
   () => conversational.refreshDataConversational,
   (newValue) => {
+    if (!hasBeenVisible.value) return;
     if (newValue && !shouldUseMock.value) {
       conversational.setIsLoadingConversationalData('dynamicWidgets', true);
       loadCustomWidgetData(props.uuid).finally(() => {

--- a/src/components/insights/widgets/conversational/ConversationalNps.vue
+++ b/src/components/insights/widgets/conversational/ConversationalNps.vue
@@ -46,10 +46,12 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useRoute } from 'vue-router';
 import { useI18n } from 'vue-i18n';
+
+import { useLazyData } from '@/composables/useLazyData';
 
 import ProgressWidget from '@/components/insights/widgets/ProgressWidget.vue';
 import SetupWidget from '@/components/insights/conversations/SetupWidget.vue';
@@ -270,15 +272,17 @@ const handleTabChange = (tab: Tab) => {
   }
 };
 
-onMounted(() => {
-  if (shouldUseMock.value) {
-    setNpsWidgetType('AI');
-  } else if (npsWidgetType.value === 'AI' && !isNpsAiConfig.value) {
-    setNpsWidgetType('HUMAN');
-  } else if (npsWidgetType.value === 'HUMAN' && !isNpsHumanConfig.value) {
-    setNpsWidgetType('AI');
-  }
-  loadNpsWidgetData();
+const { hasBeenVisible } = useLazyData({
+  load: () => {
+    if (shouldUseMock.value) {
+      setNpsWidgetType('AI');
+    } else if (npsWidgetType.value === 'AI' && !isNpsAiConfig.value) {
+      setNpsWidgetType('HUMAN');
+    } else if (npsWidgetType.value === 'HUMAN' && !isNpsHumanConfig.value) {
+      setNpsWidgetType('AI');
+    }
+    loadNpsWidgetData();
+  },
 });
 
 watch(
@@ -298,6 +302,7 @@ watch(
 watch(
   () => route.query,
   () => {
+    if (!hasBeenVisible.value) return;
     loadNpsWidgetData();
   },
   { deep: true },
@@ -306,6 +311,7 @@ watch(
 watch(
   () => conversational.refreshDataConversational,
   (newValue) => {
+    if (!hasBeenVisible.value) return;
     if (newValue) {
       conversational.setIsLoadingConversationalData('dynamicWidgets', true);
       loadNpsWidgetData().finally(() => {

--- a/src/components/insights/widgets/conversational/ConversationalSalesFunnel.vue
+++ b/src/components/insights/widgets/conversational/ConversationalSalesFunnel.vue
@@ -18,10 +18,12 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useRoute } from 'vue-router';
 import { useI18n } from 'vue-i18n';
+
+import { useLazyData } from '@/composables/useLazyData';
 
 import ProgressWidget from '@/components/insights/widgets/ProgressWidget.vue';
 import ModalRemoveWidget from '@/components/insights/conversations/CustomizableWidget/ModalRemoveWidget.vue';
@@ -65,13 +67,14 @@ const actions = computed(() => {
   ];
 });
 
-onMounted(() => {
-  loadSalesFunnelWidgetData();
+const { hasBeenVisible } = useLazyData({
+  load: loadSalesFunnelWidgetData,
 });
 
 watch(
   () => route.query,
   () => {
+    if (!hasBeenVisible.value) return;
     loadSalesFunnelWidgetData();
   },
   { deep: true },
@@ -80,6 +83,7 @@ watch(
 watch(
   () => conversational.refreshDataConversational,
   (newValue) => {
+    if (!hasBeenVisible.value) return;
     if (newValue) {
       conversational.setIsLoadingConversationalData('dynamicWidgets', true);
       loadSalesFunnelWidgetData().finally(() => {

--- a/src/components/insights/widgets/conversational/ConversationalSearchTerm.vue
+++ b/src/components/insights/widgets/conversational/ConversationalSearchTerm.vue
@@ -67,10 +67,12 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useRoute } from 'vue-router';
 import { useI18n } from 'vue-i18n';
+
+import { useLazyData } from '@/composables/useLazyData';
 
 import BaseConversationWidget from '@/components/insights/conversations/BaseConversationWidget.vue';
 import ProgressTable from '@/components/ProgressTable.vue';
@@ -151,13 +153,14 @@ const actions = computed(() => {
   ];
 });
 
-onMounted(() => {
-  loadSearchTermWidgetData();
+const { hasBeenVisible } = useLazyData({
+  load: loadSearchTermWidgetData,
 });
 
 watch(
   () => route.query,
   () => {
+    if (!hasBeenVisible.value) return;
     loadSearchTermWidgetData();
   },
   { deep: true },
@@ -166,6 +169,7 @@ watch(
 watch(
   () => conversational.refreshDataConversational,
   (newValue) => {
+    if (!hasBeenVisible.value) return;
     if (newValue) {
       conversational.setIsLoadingConversationalData('dynamicWidgets', true);
       loadSearchTermWidgetData().finally(() => {

--- a/src/components/insights/widgets/conversational/ConversationalToolResult.vue
+++ b/src/components/insights/widgets/conversational/ConversationalToolResult.vue
@@ -71,10 +71,12 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { useRoute } from 'vue-router';
 import { storeToRefs } from 'pinia';
 import { UnnnicDisclaimer } from '@weni/unnnic-system';
+
+import { useLazyData } from '@/composables/useLazyData';
 
 import BaseConversationWidget from '@/components/insights/conversations/BaseConversationWidget.vue';
 import ProgressTable from '@/components/ProgressTable.vue';
@@ -144,15 +146,18 @@ const widgetActions = computed(() => {
   return [deleteOption];
 });
 
-onMounted(() => {
-  if (!shouldUseMock.value) {
-    autoWidgetsStore.loadToolResultData();
-  }
+const { hasBeenVisible } = useLazyData({
+  load: () => {
+    if (!shouldUseMock.value) {
+      autoWidgetsStore.loadToolResultData();
+    }
+  },
 });
 
 watch(
   () => route.query,
   () => {
+    if (!hasBeenVisible.value) return;
     if (!shouldUseMock.value) {
       autoWidgetsStore.loadToolResultData();
     }
@@ -163,6 +168,7 @@ watch(
 watch(
   () => conversational.refreshDataConversational,
   (newValue) => {
+    if (!hasBeenVisible.value) return;
     if (newValue && !shouldUseMock.value) {
       conversational.setIsLoadingConversationalData('dynamicWidgets', true);
       autoWidgetsStore.loadToolResultData().finally(() => {

--- a/src/composables/__tests__/useLazyData.spec.ts
+++ b/src/composables/__tests__/useLazyData.spec.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { defineComponent, h, ref, type Ref } from 'vue';
+
+import { useLazyData, LazyVisibilityKey } from '../useLazyData';
+
+const createHost = (
+  load: () => void,
+  options: {
+    visibility?: {
+      isVisible: Ref<boolean>;
+      hasBeenVisible: Ref<boolean>;
+    };
+    watchSource?: Ref<unknown>;
+  } = {},
+) => {
+  const Host = defineComponent({
+    setup() {
+      useLazyData({
+        load,
+        watchSources: options.watchSource
+          ? [() => options.watchSource.value]
+          : [],
+      });
+      return () => h('div');
+    },
+  });
+
+  const provide = options.visibility
+    ? {
+        [LazyVisibilityKey as symbol]: {
+          ...options.visibility,
+          forceLoad: vi.fn(),
+        },
+      }
+    : {};
+
+  return mount(Host, { global: { provide } });
+};
+
+describe('useLazyData', () => {
+  let load: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    load = vi.fn();
+  });
+
+  describe('without a LazyWidget provider (eager fallback)', () => {
+    it('loads on mount', () => {
+      createHost(load);
+      expect(load).toHaveBeenCalledTimes(1);
+    });
+
+    it('reloads when a watch source changes', async () => {
+      const source = ref(0);
+      createHost(load, { watchSource: source });
+
+      expect(load).toHaveBeenCalledTimes(1);
+
+      source.value = 1;
+      await Promise.resolve();
+
+      expect(load).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('with a LazyWidget provider (gated)', () => {
+    it('does not load while never visible', () => {
+      const isVisible = ref(false);
+      const hasBeenVisible = ref(false);
+      createHost(load, { visibility: { isVisible, hasBeenVisible } });
+
+      expect(load).not.toHaveBeenCalled();
+    });
+
+    it('loads once when it becomes visible', async () => {
+      const isVisible = ref(false);
+      const hasBeenVisible = ref(false);
+      createHost(load, { visibility: { isVisible, hasBeenVisible } });
+
+      hasBeenVisible.value = true;
+      await Promise.resolve();
+
+      expect(load).toHaveBeenCalledTimes(1);
+    });
+
+    it('loads immediately if already visible on mount', () => {
+      const isVisible = ref(true);
+      const hasBeenVisible = ref(true);
+      createHost(load, { visibility: { isVisible, hasBeenVisible } });
+
+      expect(load).toHaveBeenCalledTimes(1);
+    });
+
+    it('ignores watch source changes while never visible', async () => {
+      const isVisible = ref(false);
+      const hasBeenVisible = ref(false);
+      const source = ref(0);
+      createHost(load, {
+        visibility: { isVisible, hasBeenVisible },
+        watchSource: source,
+      });
+
+      source.value = 1;
+      await Promise.resolve();
+
+      expect(load).not.toHaveBeenCalled();
+    });
+
+    it('reloads on watch source change once it has been visible', async () => {
+      const isVisible = ref(true);
+      const hasBeenVisible = ref(true);
+      const source = ref(0);
+      createHost(load, {
+        visibility: { isVisible, hasBeenVisible },
+        watchSource: source,
+      });
+
+      expect(load).toHaveBeenCalledTimes(1);
+
+      source.value = 1;
+      await Promise.resolve();
+
+      expect(load).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/src/composables/useLazyData.ts
+++ b/src/composables/useLazyData.ts
@@ -1,0 +1,81 @@
+import {
+  inject,
+  onMounted,
+  ref,
+  watch,
+  type InjectionKey,
+  type Ref,
+  type WatchSource,
+} from 'vue';
+
+/**
+ * Visibility contract provided by `LazyWidget` to its slotted content.
+ * Consumed by `useLazyData` to defer API calls until the widget is on screen.
+ */
+export interface LazyVisibility {
+  isVisible: Ref<boolean>;
+  hasBeenVisible: Ref<boolean>;
+  forceLoad: () => void;
+}
+
+export const LazyVisibilityKey: InjectionKey<LazyVisibility> =
+  Symbol('LazyVisibility');
+
+interface UseLazyDataOptions {
+  /** Callback that performs the API request(s) for the widget. */
+  load: () => void | Promise<void>;
+  /**
+   * Reactive sources (e.g. route query, refresh flags) that should re-run
+   * `load` — but only after the widget has already become visible once.
+   */
+  watchSources?: WatchSource[];
+}
+
+/**
+ * Gate a widget's data loading behind viewport visibility.
+ *
+ * When wrapped by a `LazyWidget`, the first `load()` only fires once the
+ * widget enters the scroll viewport, and `watchSources` re-fetches are skipped
+ * while the widget has never been visible. Without a `LazyWidget` provider it
+ * falls back to eager behavior (load on mount), preserving legacy behavior.
+ */
+export function useLazyData(options: UseLazyDataOptions) {
+  const { load, watchSources = [] } = options;
+
+  const injected = inject(LazyVisibilityKey, null);
+
+  const isVisible = injected?.isVisible ?? ref(true);
+  const hasBeenVisible = injected?.hasBeenVisible ?? ref(true);
+
+  let hasLoaded = false;
+
+  const triggerInitialLoad = () => {
+    if (hasLoaded) return;
+    hasLoaded = true;
+    load();
+  };
+
+  onMounted(() => {
+    if (hasBeenVisible.value) triggerInitialLoad();
+  });
+
+  watch(hasBeenVisible, (visible) => {
+    if (visible) triggerInitialLoad();
+  });
+
+  watchSources.forEach((source) => {
+    watch(
+      source,
+      () => {
+        if (hasBeenVisible.value) load();
+      },
+      { deep: true },
+    );
+  });
+
+  return {
+    isVisible,
+    hasBeenVisible,
+    reload: load,
+  };
+}

--- a/src/layouts/InsightsLayout.vue
+++ b/src/layouts/InsightsLayout.vue
@@ -11,7 +11,10 @@
       class="insights-layout__insights"
       data-testid="content-slot"
     >
-      <main class="insights__main">
+      <main
+        ref="insightsMain"
+        class="insights__main"
+      >
         <slot />
       </main>
     </section>
@@ -19,6 +22,7 @@
 </template>
 
 <script>
+import { computed } from 'vue';
 import { mapActions, mapState } from 'pinia';
 
 import { useDashboards } from '@/store/modules/dashboards';
@@ -36,10 +40,17 @@ export default {
     McpDisclaimer,
   },
 
+  provide() {
+    return {
+      insightsScrollContainer: computed(() => this.insightsMainEl),
+    };
+  },
+
   data() {
     return {
       showMcpDisclaimer:
         moduleStorage.getItem('mcp_news_show_disclaimer') === true,
+      insightsMainEl: null,
     };
   },
   computed: {
@@ -47,6 +58,8 @@ export default {
   },
 
   mounted() {
+    this.insightsMainEl = this.$refs.insightsMain || null;
+
     this.setOnboardingRef({
       key: 'insights-layout',
       ref: this.$el,

--- a/src/store/modules/humanSupport/__tests__/analysis.spec.js
+++ b/src/store/modules/humanSupport/__tests__/analysis.spec.js
@@ -199,13 +199,20 @@ describe('useHumanSupportAnalysis store', () => {
   });
 
   describe('Action: loadAllData', () => {
-    it('should load both data sources independently', async () => {
+    it('should reload both data sources once they have been loaded', async () => {
       ServiceStatusAnalysisService.getServiceStatusAnalysisData.mockResolvedValue(
         mockServiceStatusData,
       );
       ServicesOpenByHourAnalysisService.getServicesOpenByHourAnalysisData.mockResolvedValue(
         mockServicesOpenByHourData,
       );
+
+      // Prime the slices (simulate widgets becoming visible).
+      await Promise.all([
+        store.loadServiceStatusData(),
+        store.loadHumanSupportByHourData(),
+      ]);
+      vi.clearAllMocks();
 
       store.loadAllData();
 
@@ -219,6 +226,33 @@ describe('useHumanSupportAnalysis store', () => {
       ).toHaveBeenCalled();
       expect(store.serviceStatusData).toEqual(mockServiceStatusData);
       expect(store.servicesOpenByHourData).toEqual(mockServicesOpenByHourData);
+    });
+
+    it('should not load slices that were never visible/loaded', async () => {
+      store.loadAllData();
+
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      expect(
+        ServiceStatusAnalysisService.getServiceStatusAnalysisData,
+      ).not.toHaveBeenCalled();
+      expect(
+        ServicesOpenByHourAnalysisService.getServicesOpenByHourAnalysisData,
+      ).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Action: setForceLoadDetailed', () => {
+    it('should default forceLoadDetailed to false', () => {
+      expect(store.forceLoadDetailed).toBe(false);
+    });
+
+    it('should toggle forceLoadDetailed', () => {
+      store.setForceLoadDetailed(true);
+      expect(store.forceLoadDetailed).toBe(true);
+
+      store.setForceLoadDetailed(false);
+      expect(store.forceLoadDetailed).toBe(false);
     });
   });
 
@@ -236,6 +270,12 @@ describe('useHumanSupportAnalysis store', () => {
             setTimeout(() => resolve(mockServicesOpenByHourData), 30),
           ),
       );
+
+      // Prime the slices so loadAllData reloads them.
+      await Promise.all([
+        store.loadServiceStatusData(),
+        store.loadHumanSupportByHourData(),
+      ]);
 
       store.loadAllData();
 

--- a/src/store/modules/humanSupport/__tests__/monitoring.spec.js
+++ b/src/store/modules/humanSupport/__tests__/monitoring.spec.js
@@ -125,7 +125,7 @@ describe('useHumanSupportMonitoring store', () => {
   });
 
   describe('loadAllData action', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       vi.useFakeTimers();
 
       TimeMetricsService.getTimeMetricsData.mockResolvedValue({
@@ -133,10 +133,35 @@ describe('useHumanSupportMonitoring store', () => {
         average_time_first_response: { average: 30, max: 60 },
         average_time_chat: { average: 500, max: 1000 },
       });
+
+      // loadAllData only reloads slices that have already been loaded once
+      // (i.e. became visible). Prime them so the refresh paths can reload.
+      await Promise.all([
+        store.loadServiceStatusData(),
+        store.loadTimeMetricsData(),
+        store.loadHumanSupportByHourData(),
+      ]);
+      vi.clearAllMocks();
     });
 
     afterEach(() => {
       vi.useRealTimers();
+    });
+
+    it('should not load any slice that was never visible/loaded', async () => {
+      setActivePinia(createPinia());
+      const freshStore = useHumanSupportMonitoring();
+
+      const loadAllDataPromise = freshStore.loadAllData();
+
+      vi.advanceTimersByTime(3000);
+      await loadAllDataPromise;
+
+      expect(ServiceStatusService.getServiceStatusData).not.toHaveBeenCalled();
+      expect(TimeMetricsService.getTimeMetricsData).not.toHaveBeenCalled();
+      expect(
+        ServicesOpenByHourService.getServicesOpenByHourData,
+      ).not.toHaveBeenCalled();
     });
 
     it('should set isLoadingAllData to true when any individual load is running', async () => {
@@ -322,7 +347,7 @@ describe('useHumanSupportMonitoring store', () => {
   });
 
   describe('refresh data monitoring', () => {
-    it('should trigger loadAllData when refreshDataMonitoring is set to true', async () => {
+    it('should trigger loadAllData for loaded slices when refreshDataMonitoring is set to true', async () => {
       vi.useFakeTimers();
 
       TimeMetricsService.getTimeMetricsData.mockResolvedValue({
@@ -330,6 +355,14 @@ describe('useHumanSupportMonitoring store', () => {
         average_time_first_response: { average: 30, max: 60 },
         average_time_chat: { average: 500, max: 1000 },
       });
+
+      // Prime the slices (simulate widgets becoming visible).
+      await Promise.all([
+        store.loadServiceStatusData(),
+        store.loadTimeMetricsData(),
+        store.loadHumanSupportByHourData(),
+      ]);
+      vi.clearAllMocks();
 
       expect(store.refreshDataMonitoring).toBe(false);
 
@@ -344,6 +377,23 @@ describe('useHumanSupportMonitoring store', () => {
       expect(
         ServicesOpenByHourService.getServicesOpenByHourData,
       ).toHaveBeenCalled();
+
+      vi.useRealTimers();
+    });
+
+    it('should not refetch slices that were never loaded on refresh', async () => {
+      vi.useFakeTimers();
+      vi.clearAllMocks();
+
+      store.setRefreshDataMonitoring(true);
+
+      await vi.runAllTimersAsync();
+
+      expect(ServiceStatusService.getServiceStatusData).not.toHaveBeenCalled();
+      expect(TimeMetricsService.getTimeMetricsData).not.toHaveBeenCalled();
+      expect(
+        ServicesOpenByHourService.getServicesOpenByHourData,
+      ).not.toHaveBeenCalled();
 
       vi.useRealTimers();
     });
@@ -401,6 +451,20 @@ describe('useHumanSupportMonitoring store', () => {
         store.setActiveDetailedTab('in_progress');
         expect(store.activeDetailedTab).toBe('in_progress');
       });
+    });
+  });
+
+  describe('forceLoadDetailed', () => {
+    it('should default to false', () => {
+      expect(store.forceLoadDetailed).toBe(false);
+    });
+
+    it('should set forceLoadDetailed via setForceLoadDetailed', () => {
+      store.setForceLoadDetailed(true);
+      expect(store.forceLoadDetailed).toBe(true);
+
+      store.setForceLoadDetailed(false);
+      expect(store.forceLoadDetailed).toBe(false);
     });
   });
 });

--- a/src/store/modules/humanSupport/analysis.ts
+++ b/src/store/modules/humanSupport/analysis.ts
@@ -11,6 +11,7 @@ export const useHumanSupportAnalysis = defineStore(
   'humanSupportAnalysis',
   () => {
     const activeDetailedTab = ref<ActiveDetailedTab>('finished');
+    const forceLoadDetailed = ref<boolean>(false);
     const serviceStatusData = ref<ServiceStatusFormattedResponse>({
       finished: null,
       average_time_is_waiting: null,
@@ -22,6 +23,11 @@ export const useHumanSupportAnalysis = defineStore(
     const loadingServiceStatusData = ref(false);
     const loadingHumanSupportByHourData = ref(false);
 
+    // Tracks which data slices have already been requested (i.e. became
+    // visible) so the central refresh only reloads on-screen widgets.
+    const hasLoadedServiceStatus = ref(false);
+    const hasLoadedHumanSupportByHour = ref(false);
+
     const isLoadingAllData = computed(
       () =>
         loadingServiceStatusData.value || loadingHumanSupportByHourData.value,
@@ -31,12 +37,17 @@ export const useHumanSupportAnalysis = defineStore(
       activeDetailedTab.value = tab;
     };
 
+    const setForceLoadDetailed = (value: boolean) => {
+      forceLoadDetailed.value = value;
+    };
+
     const loadAllData = () => {
-      loadServiceStatusData();
-      loadHumanSupportByHourData();
+      if (hasLoadedServiceStatus.value) loadServiceStatusData();
+      if (hasLoadedHumanSupportByHour.value) loadHumanSupportByHourData();
     };
 
     const loadServiceStatusData = async () => {
+      hasLoadedServiceStatus.value = true;
       try {
         loadingServiceStatusData.value = true;
         const data =
@@ -51,6 +62,7 @@ export const useHumanSupportAnalysis = defineStore(
     };
 
     const loadHumanSupportByHourData = async () => {
+      hasLoadedHumanSupportByHour.value = true;
       try {
         loadingHumanSupportByHourData.value = true;
         const data =
@@ -71,10 +83,12 @@ export const useHumanSupportAnalysis = defineStore(
       loadingHumanSupportByHourData,
       servicesOpenByHourData,
       activeDetailedTab,
+      forceLoadDetailed,
       loadAllData,
       loadServiceStatusData,
       loadHumanSupportByHourData,
       setActiveDetailedTab,
+      setForceLoadDetailed,
     };
   },
 );

--- a/src/store/modules/humanSupport/monitoring.ts
+++ b/src/store/modules/humanSupport/monitoring.ts
@@ -20,6 +20,7 @@ export const useHumanSupportMonitoring = defineStore(
     const autoRefresh = ref<boolean>(true);
     const refreshDataMonitoring = ref<boolean>(false);
     const isSilentRefresh = ref<boolean>(false);
+    const forceLoadDetailed = ref<boolean>(false);
     const activeDetailedTab = ref<ActiveDetailedTab>('in_progress');
     const serviceStatusData = ref<ServiceStatusDataResponse>({
       is_waiting: null,
@@ -35,6 +36,13 @@ export const useHumanSupportMonitoring = defineStore(
     const loadingServiceStatusData = ref(false);
     const loadingTimeMetricsData = ref(false);
     const loadingHumanSupportByHourData = ref(false);
+
+    // Tracks which data slices have already been requested (i.e. became
+    // visible). The central refresh/polling only reloads loaded slices so
+    // off-screen widgets are never fetched until the user scrolls to them.
+    const hasLoadedServiceStatus = ref(false);
+    const hasLoadedTimeMetrics = ref(false);
+    const hasLoadedHumanSupportByHour = ref(false);
 
     const { updateLastUpdatedRequest } = useDashboards();
 
@@ -54,13 +62,18 @@ export const useHumanSupportMonitoring = defineStore(
       isSilentRefresh.value = silent;
     };
 
+    const setForceLoadDetailed = (value: boolean) => {
+      forceLoadDetailed.value = value;
+    };
+
     const loadAllData = () => {
-      loadServiceStatusData();
-      loadTimeMetricsData();
-      loadHumanSupportByHourData();
+      if (hasLoadedServiceStatus.value) loadServiceStatusData();
+      if (hasLoadedTimeMetrics.value) loadTimeMetricsData();
+      if (hasLoadedHumanSupportByHour.value) loadHumanSupportByHourData();
     };
 
     const loadServiceStatusData = async () => {
+      hasLoadedServiceStatus.value = true;
       try {
         if (!isSilentRefresh.value) {
           loadingServiceStatusData.value = true;
@@ -79,6 +92,7 @@ export const useHumanSupportMonitoring = defineStore(
     };
 
     const loadTimeMetricsData = async () => {
+      hasLoadedTimeMetrics.value = true;
       try {
         if (!isSilentRefresh.value) {
           loadingTimeMetricsData.value = true;
@@ -98,6 +112,7 @@ export const useHumanSupportMonitoring = defineStore(
     };
 
     const loadHumanSupportByHourData = async () => {
+      hasLoadedHumanSupportByHour.value = true;
       try {
         if (!isSilentRefresh.value) {
           loadingHumanSupportByHourData.value = true;
@@ -120,10 +135,6 @@ export const useHumanSupportMonitoring = defineStore(
       if (newValue) loadAllData();
     });
 
-    watch(refreshDataMonitoring, (value) => {
-      if (value) loadAllData();
-    });
-
     return {
       isLoadingAllData,
       serviceStatusData,
@@ -136,12 +147,14 @@ export const useHumanSupportMonitoring = defineStore(
       autoRefresh,
       refreshDataMonitoring,
       isSilentRefresh,
+      forceLoadDetailed,
       loadAllData,
       loadServiceStatusData,
       loadTimeMetricsData,
       loadHumanSupportByHourData,
       setActiveDetailedTab,
       setRefreshDataMonitoring,
+      setForceLoadDetailed,
     };
   },
 );


### PR DESCRIPTION
## Description
### Type of Change
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
Insights widgets were loading all their data on mount regardless of whether they were visible in the viewport. This caused unnecessary API calls for widgets that users might never scroll to, increasing load times and backend pressure.

### Summary of Changes
- Added a `LazyWidget` Vue component that uses `useIntersectionObserver` to track when a widget enters the scroll viewport. It provides `isVisible`, `hasBeenVisible`, and `forceLoad` state to its slotted content via `LazyVisibilityKey`. A `forceVisible` prop allows bypassing visibility gating for scroll/redirect targets. The scroll container is resolved from an injected `insightsScrollContainer` ref or falls back to `.insights__main`.

- Added a `useLazyData` composable that gates a widget's `load()` callback behind viewport visibility when used inside a `LazyWidget`. Without a `LazyWidget` provider it falls back to eager loading on mount, preserving existing behavior. `watchSources` re-fetches are also suppressed until the widget has been visible at least once.

- Updated `InsightsLayout` to expose its `<main>` element as a reactive `insightsScrollContainer` via `provide`, so `LazyWidget` instances nested anywhere in the layout can use it as the intersection observer root.

- Added a global `LazyWidget` stub in `setupVitest.js` that renders its slot without providing visibility context, causing `useLazyData` to fall back to eager loading in unit tests and preserving existing "loads on mount" test assertions. Tests can opt out with `stubs: { LazyWidget: false }`.

- Added unit tests for both `LazyWidget` and `useLazyData` covering visibility gating, `hasBeenVisible` persistence, `forceVisible` prop behavior, and watch source re-fetch logic.