### PR TITLE
feat: defer live-desk API calls until widgets enter viewport

### DIFF
--- a/src/components/insights/humanSupport/Analysis/Analysis.vue
+++ b/src/components/insights/humanSupport/Analysis/Analysis.vue
@@ -4,15 +4,24 @@
       v-if="!hasSectorsConfigured"
       :description="$t('human_support_dashboard.setup.disclaimer')"
     />
-    <StatusCards data-testid="status-cards" />
-    <ServicesOpenByHour data-testid="services-open-by-hour" />
-    <VolumePerTagAndQueueWidget context="analysis" />
-    <CsatRatings
-      v-if="isFeatureFlagEnabled('insightsCSAT')"
-      type="analysis"
-      data-testid="analysis-csat-ratings"
-    />
-    <DetailedAnalysis data-testid="detailed-analysis" />
+    <LazyWidget>
+      <StatusCards data-testid="status-cards" />
+    </LazyWidget>
+    <LazyWidget>
+      <ServicesOpenByHour data-testid="services-open-by-hour" />
+    </LazyWidget>
+    <LazyWidget>
+      <VolumePerTagAndQueueWidget context="analysis" />
+    </LazyWidget>
+    <LazyWidget v-if="isFeatureFlagEnabled('insightsCSAT')">
+      <CsatRatings
+        type="analysis"
+        data-testid="analysis-csat-ratings"
+      />
+    </LazyWidget>
+    <LazyWidget :forceVisible="forceLoadDetailed">
+      <DetailedAnalysis data-testid="detailed-analysis" />
+    </LazyWidget>
   </section>
 </template>
 
@@ -24,9 +33,11 @@ import ServicesOpenByHour from './ServicesOpenByHour.vue';
 import DetailedAnalysis from './DetailedAnalysis.vue';
 import CsatRatings from '../CommonWidgets/CsatRatings/CsatRatings.vue';
 import VolumePerTagAndQueueWidget from '../CommonWidgets/VolumePerTagAndQueue/index.vue';
+import LazyWidget from '@/components/insights/Layout/LazyWidget.vue';
 
 import { useFeatureFlag } from '@/store/modules/featureFlag';
 import { useProject } from '@/store/modules/project';
+import { useHumanSupportAnalysis } from '@/store/modules/humanSupport/analysis';
 
 defineOptions({
   name: 'AnalysisView',
@@ -34,6 +45,8 @@ defineOptions({
 
 const projectStore = useProject();
 const { hasSectorsConfigured } = storeToRefs(projectStore);
+
+const { forceLoadDetailed } = storeToRefs(useHumanSupportAnalysis());
 
 const { isFeatureFlagEnabled } = useFeatureFlag();
 </script>

--- a/src/components/insights/humanSupport/Analysis/ServicesOpenByHour.vue
+++ b/src/components/insights/humanSupport/Analysis/ServicesOpenByHour.vue
@@ -19,12 +19,14 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, computed, useTemplateRef } from 'vue';
+import { computed, useTemplateRef } from 'vue';
 import { useMouseInElement } from '@vueuse/core';
 import { storeToRefs } from 'pinia';
 
 import LineChart from '@/components/insights/charts/LineChart.vue';
 import BlurSetupWidget from '@/components/insights/Layout/BlurSetupWidget.vue';
+
+import { useLazyData } from '@/composables/useLazyData';
 
 import { useHumanSupport } from '@/store/modules/humanSupport/humanSupport';
 import { useHumanSupportAnalysis } from '@/store/modules/humanSupport/analysis';
@@ -76,9 +78,7 @@ const isLoading = computed(() => {
   return loadingHumanSupportByHourData.value;
 });
 
-onMounted(() => {
-  loadHumanSupportByHourData();
-});
+useLazyData({ load: loadHumanSupportByHourData });
 </script>
 
 <style scoped lang="scss">

--- a/src/components/insights/humanSupport/Analysis/StatusCards.vue
+++ b/src/components/insights/humanSupport/Analysis/StatusCards.vue
@@ -54,12 +54,14 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, computed, useTemplateRef } from 'vue';
+import { computed, useTemplateRef } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useMouseInElement } from '@vueuse/core';
 
 import CardConversations from '@/components/insights/cards/CardConversations.vue';
 import BlurSetupWidget from '@/components/insights/Layout/BlurSetupWidget.vue';
+
+import { useLazyData } from '@/composables/useLazyData';
 
 import { useProject } from '@/store/modules/project';
 import { useHumanSupport } from '@/store/modules/humanSupport/humanSupport';
@@ -135,9 +137,12 @@ const cardDefinitions: CardData[] = [
 ];
 
 const humanSupportAnalysis = useHumanSupportAnalysis();
-const { loadServiceStatusData, setActiveDetailedTab } = humanSupportAnalysis;
+const { loadServiceStatusData, setActiveDetailedTab, setForceLoadDetailed } =
+  humanSupportAnalysis;
 const { serviceStatusData, loadingServiceStatusData } =
   storeToRefs(humanSupportAnalysis);
+
+useLazyData({ load: loadServiceStatusData });
 
 const isLoadingCards = computed(() => loadingServiceStatusData.value);
 
@@ -170,13 +175,13 @@ const getTooltipSide = (index: number) => {
   return 'top';
 };
 
-const scrollToDetailedMonitoring = () => {
-  const detailedMonitoringElement = document.querySelector(
-    '[id="detailed-monitoring"]',
+const scrollToDetailedAnalysis = () => {
+  const detailedAnalysisElement = document.querySelector(
+    '[id="detailed-analysis"]',
   );
 
-  if (detailedMonitoringElement) {
-    detailedMonitoringElement.scrollIntoView({
+  if (detailedAnalysisElement) {
+    detailedAnalysisElement.scrollIntoView({
       behavior: 'smooth',
       block: 'start',
     });
@@ -191,12 +196,9 @@ const handleCardClick = (id: CardId) => {
   };
 
   setActiveDetailedTab(status[id] as ActiveDetailedTab);
-  setTimeout(scrollToDetailedMonitoring, 100);
+  setForceLoadDetailed(true);
+  setTimeout(scrollToDetailedAnalysis, 100);
 };
-
-onMounted(() => {
-  loadServiceStatusData();
-});
 </script>
 
 <style scoped lang="scss">

--- a/src/components/insights/humanSupport/Analysis/Tables/Finished.vue
+++ b/src/components/insights/humanSupport/Analysis/Tables/Finished.vue
@@ -110,6 +110,7 @@ import { useHumanSupport } from '@/store/modules/humanSupport/humanSupport';
 import { useProject } from '@/store/modules/project';
 import { formatSecondsToTime } from '@/utils/time';
 import { useInfiniteScrollTable } from '@/composables/useInfiniteScrollTable';
+import { useLazyData } from '@/composables/useLazyData';
 import { analysisDetailedAnalysisFinishedMock } from '../mocks';
 import { openNewTabLink } from '@/utils/redirect';
 import DynamicCellText from '../../Common/DynamicCellText.vue';
@@ -237,6 +238,10 @@ const redirectItem = (item: FinishedDataResult) => {
   window.parent.postMessage({ event: 'redirect', path: url }, '*');
 };
 
+const { hasBeenVisible } = useLazyData({
+  load: () => resetAndLoadData(currentSort.value),
+});
+
 watch(
   [
     currentSort,
@@ -247,9 +252,9 @@ watch(
     () => humanSupport.appliedDetailFilters.ticketId,
   ],
   () => {
+    if (!hasBeenVisible.value) return;
     resetAndLoadData(currentSort.value);
   },
-  { immediate: true },
 );
 </script>
 

--- a/src/components/insights/humanSupport/Common/Tables/Pauses.vue
+++ b/src/components/insights/humanSupport/Common/Tables/Pauses.vue
@@ -58,6 +58,7 @@ import { useHumanSupportMonitoring } from '@/store/modules/humanSupport/monitori
 import { useHumanSupport } from '@/store/modules/humanSupport/humanSupport';
 import { formatSecondsToTime } from '@/utils/time';
 import { useInfiniteScrollTable } from '@/composables/useInfiniteScrollTable';
+import { useLazyData } from '@/composables/useLazyData';
 import { storeToRefs } from 'pinia';
 import { openNewTabLink } from '@/utils/redirect';
 import DynamicCellText from '../DynamicCellText.vue';
@@ -214,6 +215,10 @@ const loadDataSafely = async (sortValue: typeof currentSort.value) => {
   }
 };
 
+const { hasBeenVisible } = useLazyData({
+  load: () => loadDataSafely(currentSort.value),
+});
+
 watch(
   [
     currentSort,
@@ -222,14 +227,15 @@ watch(
     () => humanSupport.appliedDateRange,
   ],
   () => {
+    if (!hasBeenVisible.value) return;
     loadDataSafely(currentSort.value);
   },
-  { immediate: true },
 );
 
 watch(
   () => humanSupportMonitoring.refreshDataMonitoring,
   (newValue) => {
+    if (!hasBeenVisible.value) return;
     if (newValue && humanSupportMonitoring.activeDetailedTab === 'pauses') {
       loadDataSafely(currentSort.value);
     }

--- a/src/components/insights/humanSupport/CommonWidgets/CsatRatings/CsatRatings.vue
+++ b/src/components/insights/humanSupport/CommonWidgets/CsatRatings/CsatRatings.vue
@@ -102,10 +102,12 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, useTemplateRef, watch } from 'vue';
+import { computed, ref, useTemplateRef, watch } from 'vue';
 import { useInfiniteScroll, useMouseInElement } from '@vueuse/core';
 import { useI18n } from 'vue-i18n';
 import { storeToRefs } from 'pinia';
+
+import { useLazyData } from '@/composables/useLazyData';
 
 import type {
   AgentsTotalsResponse,
@@ -155,8 +157,8 @@ interface Props {
 
 const props = defineProps<Props>();
 
-onMounted(() => {
-  configStore.checkEnableCsat().then(() => {
+const loadCsatData = () => {
+  return configStore.checkEnableCsat().then(() => {
     if (configStore.enableCsat) {
       loadAgentsData();
       loadRatingsData();
@@ -165,7 +167,9 @@ onMounted(() => {
       isLoadingRatingsData.value = false;
     }
   });
-});
+};
+
+const { hasBeenVisible } = useLazyData({ load: loadCsatData });
 
 const { t, locale: localeI18n } = useI18n();
 
@@ -325,6 +329,7 @@ watch(activeAgentEmail, () => {
 watch(
   () => [appliedFilters.value, appliedDateRange.value],
   () => {
+    if (!hasBeenVisible.value) return;
     if (!configStore.enableCsat) return;
     loadAgentsData();
     if (!activeAgentEmail.value) {
@@ -337,6 +342,7 @@ watch(
 watch(
   () => humanSupportMonitoringStore.refreshDataMonitoring,
   (value) => {
+    if (!hasBeenVisible.value) return;
     if (!configStore.enableCsat) return;
     if (value) {
       agentsTotalNext.value = null;

--- a/src/components/insights/humanSupport/CommonWidgets/VolumePerTagAndQueue/VolumeBarListWidget.vue
+++ b/src/components/insights/humanSupport/CommonWidgets/VolumePerTagAndQueue/VolumeBarListWidget.vue
@@ -26,12 +26,14 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, watch } from 'vue';
+import { ref, computed, watch } from 'vue';
 import { storeToRefs } from 'pinia';
 
 import { useHumanSupport } from '@/store/modules/humanSupport/humanSupport';
 import { useHumanSupportMonitoring } from '@/store/modules/humanSupport/monitoring';
 import { useProject } from '@/store/modules/project';
+
+import { useLazyData } from '@/composables/useLazyData';
 
 import BarList from '../BarList/index.vue';
 import SeeAllDrawer from './SeeAllDrawer.vue';
@@ -270,8 +272,8 @@ const seeAllDrawerTitle = computed(() => {
   return `${t(props.seeAllTitleKey)} - ${statusLabel}`;
 });
 
-onMounted(async () => {
-  await getItems({ silent: false, concat: false });
+const { hasBeenVisible } = useLazyData({
+  load: () => getItems({ silent: false, concat: false }),
 });
 
 watch(
@@ -282,12 +284,14 @@ watch(
 );
 
 watch([currentTab, appliedFilters, appliedDateRange], async () => {
+  if (!hasBeenVisible.value) return;
   itemsNext.value = null;
   itemsPrevious.value = null;
   await getItems({ silent: false, concat: false });
 });
 
 watch(refreshDataMonitoring, async () => {
+  if (!hasBeenVisible.value) return;
   if (refreshDataMonitoring.value && autoRefresh.value) {
     itemsNext.value = null;
     itemsPrevious.value = null;

--- a/src/components/insights/humanSupport/Monitoring/Monitoring.vue
+++ b/src/components/insights/humanSupport/Monitoring/Monitoring.vue
@@ -8,16 +8,27 @@
       v-if="!hasSectorsConfigured"
       :description="$t('human_support_dashboard.setup.disclaimer')"
     />
-    <StatusCards data-testid="monitoring-status-cards" />
-    <TimeMetrics data-testid="monitoring-time-metrics" />
-    <ServicesOpenByHour data-testid="monitoring-services-open-by-hour" />
-    <VolumePerTagAndQueueWidget context="monitoring" />
-    <CsatRatings
-      v-if="isFeatureFlagEnabled('insightsCSAT')"
-      type="monitoring"
-      data-testid="monitoring-csat-ratings"
-    />
-    <DetailedMonitoring data-testid="monitoring-detailed-monitoring" />
+    <LazyWidget>
+      <StatusCards data-testid="monitoring-status-cards" />
+    </LazyWidget>
+    <LazyWidget>
+      <TimeMetrics data-testid="monitoring-time-metrics" />
+    </LazyWidget>
+    <LazyWidget>
+      <ServicesOpenByHour data-testid="monitoring-services-open-by-hour" />
+    </LazyWidget>
+    <LazyWidget>
+      <VolumePerTagAndQueueWidget context="monitoring" />
+    </LazyWidget>
+    <LazyWidget v-if="isFeatureFlagEnabled('insightsCSAT')">
+      <CsatRatings
+        type="monitoring"
+        data-testid="monitoring-csat-ratings"
+      />
+    </LazyWidget>
+    <LazyWidget :forceVisible="forceLoadDetailed">
+      <DetailedMonitoring data-testid="monitoring-detailed-monitoring" />
+    </LazyWidget>
   </section>
 </template>
 
@@ -36,6 +47,7 @@ import ServicesOpenByHour from './ServicesOpenByHour.vue';
 import DetailedMonitoring from './DetailedMonitoring.vue';
 import CsatRatings from '../CommonWidgets/CsatRatings/CsatRatings.vue';
 import VolumePerTagAndQueueWidget from '../CommonWidgets/VolumePerTagAndQueue/index.vue';
+import LazyWidget from '@/components/insights/Layout/LazyWidget.vue';
 
 const { isFeatureFlagEnabled } = useFeatureFlag();
 
@@ -54,7 +66,9 @@ const AUTO_REFRESH_INTERVAL = 60 * 1000;
 const humanSupportMonitoringStore = useHumanSupportMonitoring();
 
 const { setRefreshDataMonitoring } = humanSupportMonitoringStore;
-const { autoRefresh } = storeToRefs(humanSupportMonitoringStore);
+const { autoRefresh, forceLoadDetailed } = storeToRefs(
+  humanSupportMonitoringStore,
+);
 
 const monitoringRef = ref(null);
 const isVisible = useElementVisibility(monitoringRef);

--- a/src/components/insights/humanSupport/Monitoring/ServicesOpenByHour.vue
+++ b/src/components/insights/humanSupport/Monitoring/ServicesOpenByHour.vue
@@ -24,12 +24,14 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, computed, useTemplateRef } from 'vue';
+import { computed, useTemplateRef } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useMouseInElement } from '@vueuse/core';
 
 import LineChart from '@/components/insights/charts/LineChart.vue';
 import BlurSetupWidget from '@/components/insights/Layout/BlurSetupWidget.vue';
+
+import { useLazyData } from '@/composables/useLazyData';
 
 import { useHumanSupportMonitoring } from '@/store/modules/humanSupport/monitoring';
 import { useProject } from '@/store/modules/project';
@@ -80,9 +82,7 @@ const showSetup = computed(() => {
   return !isOutside.value && !hasSectorsConfigured.value;
 });
 
-onMounted(() => {
-  loadHumanSupportByHourData();
-});
+useLazyData({ load: loadHumanSupportByHourData });
 </script>
 
 <style scoped lang="scss">

--- a/src/components/insights/humanSupport/Monitoring/StatusCards.vue
+++ b/src/components/insights/humanSupport/Monitoring/StatusCards.vue
@@ -39,12 +39,14 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, computed, useTemplateRef } from 'vue';
+import { computed, useTemplateRef } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useMouseInElement } from '@vueuse/core';
 
 import CardConversations from '@/components/insights/cards/CardConversations.vue';
 import BlurSetupWidget from '@/components/insights/Layout/BlurSetupWidget.vue';
+
+import { useLazyData } from '@/composables/useLazyData';
 
 import {
   ActiveDetailedTab,
@@ -96,10 +98,13 @@ const cardDefinitions: CardData[] = [
 ];
 
 const humanSupportMonitoring = useHumanSupportMonitoring();
-const { loadServiceStatusData, setActiveDetailedTab } = humanSupportMonitoring;
+const { loadServiceStatusData, setActiveDetailedTab, setForceLoadDetailed } =
+  humanSupportMonitoring;
 const { serviceStatusData, loadingServiceStatusData } = storeToRefs(
   humanSupportMonitoring,
 );
+
+useLazyData({ load: loadServiceStatusData });
 
 const isLoadingCards = computed(() => loadingServiceStatusData.value);
 
@@ -144,12 +149,9 @@ const handleCardClick = (id: CardId) => {
   };
 
   setActiveDetailedTab(status[id] as ActiveDetailedTab);
+  setForceLoadDetailed(true);
   setTimeout(scrollToDetailedMonitoring, 100);
 };
-
-onMounted(() => {
-  loadServiceStatusData();
-});
 </script>
 
 <style scoped lang="scss">

--- a/src/components/insights/humanSupport/Monitoring/Tables/Attendant.vue
+++ b/src/components/insights/humanSupport/Monitoring/Tables/Attendant.vue
@@ -61,6 +61,7 @@ import AgentStatus from '@/components/insights/widgets/HumanServiceAgentsTable/A
 import DynamicCellText from '../../Common/DynamicCellText.vue';
 import { formatSecondsToTime } from '@/utils/time';
 import { useInfiniteScrollTable } from '@/composables/useInfiniteScrollTable';
+import { useLazyData } from '@/composables/useLazyData';
 import { storeToRefs } from 'pinia';
 import { openNewTabLink } from '@/utils/redirect';
 
@@ -241,9 +242,14 @@ const loadDataSafely = async (sortValue: typeof currentSort.value) => {
   }
 };
 
+const { hasBeenVisible } = useLazyData({
+  load: () => loadDataSafely(currentSort.value),
+});
+
 watchDebounced(
   () => humanSupport.appliedDetailFilters.status,
   async () => {
+    if (!hasBeenVisible.value) return;
     await resetAndLoadData(currentSort.value);
   },
   { deep: true, debounce: 700 },
@@ -256,14 +262,16 @@ watch(
     () => humanSupport.appliedFilters,
   ],
   () => {
+    if (!hasBeenVisible.value) return;
     loadDataSafely(currentSort.value);
   },
-  { immediate: true, deep: true },
+  { deep: true },
 );
 
 watch(
   () => humanSupportMonitoring.refreshDataMonitoring,
   (newValue) => {
+    if (!hasBeenVisible.value) return;
     if (newValue && humanSupportMonitoring.activeDetailedTab === 'attendant') {
       loadDataSafely(currentSort.value);
     }

--- a/src/components/insights/humanSupport/Monitoring/Tables/InAwaiting.vue
+++ b/src/components/insights/humanSupport/Monitoring/Tables/InAwaiting.vue
@@ -32,6 +32,7 @@ import { useHumanSupportMonitoring } from '@/store/modules/humanSupport/monitori
 import { useHumanSupport } from '@/store/modules/humanSupport/humanSupport';
 import { formatSecondsToTime } from '@/utils/time';
 import { useInfiniteScrollTable } from '@/composables/useInfiniteScrollTable';
+import { useLazyData } from '@/composables/useLazyData';
 import { storeToRefs } from 'pinia';
 import { openNewTabLink } from '@/utils/redirect';
 
@@ -139,6 +140,10 @@ const loadDataSafely = async (sortValue: typeof currentSort.value) => {
   }
 };
 
+const { hasBeenVisible } = useLazyData({
+  load: () => loadDataSafely(currentSort.value),
+});
+
 watch(
   [
     currentSort,
@@ -146,14 +151,16 @@ watch(
     () => humanSupport.appliedDetailFilters.contactInput,
   ],
   () => {
+    if (!hasBeenVisible.value) return;
     loadDataSafely(currentSort.value);
   },
-  { immediate: true, deep: true },
+  { deep: true },
 );
 
 watch(
   () => humanSupportMonitoring.refreshDataMonitoring,
   (newValue) => {
+    if (!hasBeenVisible.value) return;
     if (
       newValue &&
       humanSupportMonitoring.activeDetailedTab === 'in_awaiting'

--- a/src/components/insights/humanSupport/Monitoring/Tables/InProgress.vue
+++ b/src/components/insights/humanSupport/Monitoring/Tables/InProgress.vue
@@ -71,6 +71,7 @@ import { useProject } from '@/store/modules/project';
 import { formatSecondsToTime } from '@/utils/time';
 
 import { useInfiniteScrollTable } from '@/composables/useInfiniteScrollTable';
+import { useLazyData } from '@/composables/useLazyData';
 
 import { InProgressDataResult } from '@/services/api/resources/humanSupport/monitoring/detailedMonitoring/inProgress';
 import service from '@/services/api/resources/humanSupport/monitoring/detailedMonitoring/inProgress';
@@ -189,6 +190,10 @@ const loadDataSafely = async (sortValue: typeof currentSort.value) => {
   }
 };
 
+const { hasBeenVisible } = useLazyData({
+  load: () => loadDataSafely(currentSort.value),
+});
+
 watch(
   [
     currentSort,
@@ -196,14 +201,16 @@ watch(
     () => humanSupport.appliedDetailFilters.contactInput,
   ],
   () => {
+    if (!hasBeenVisible.value) return;
     loadDataSafely(currentSort.value);
   },
-  { immediate: true, deep: true },
+  { deep: true },
 );
 
 watch(
   () => humanSupportMonitoring.refreshDataMonitoring,
   (newValue) => {
+    if (!hasBeenVisible.value) return;
     if (
       newValue &&
       humanSupportMonitoring.activeDetailedTab === 'in_progress'

--- a/src/components/insights/humanSupport/Monitoring/TimeMetrics.vue
+++ b/src/components/insights/humanSupport/Monitoring/TimeMetrics.vue
@@ -42,13 +42,15 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, computed, useTemplateRef } from 'vue';
+import { computed, useTemplateRef } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useI18n } from 'vue-i18n';
 import { useMouseInElement } from '@vueuse/core';
 
 import CardConversations from '@/components/insights/cards/CardConversations.vue';
 import BlurSetupWidget from '@/components/insights/Layout/BlurSetupWidget.vue';
+
+import { useLazyData } from '@/composables/useLazyData';
 
 import {
   ActiveDetailedTab,
@@ -109,10 +111,13 @@ const cardDefinitions: CardData[] = [
 const { t } = useI18n();
 
 const humanSupportMonitoring = useHumanSupportMonitoring();
-const { loadTimeMetricsData, setActiveDetailedTab } = humanSupportMonitoring;
+const { loadTimeMetricsData, setActiveDetailedTab, setForceLoadDetailed } =
+  humanSupportMonitoring;
 const { timeMetricsData, loadingTimeMetricsData } = storeToRefs(
   humanSupportMonitoring,
 );
+
+useLazyData({ load: loadTimeMetricsData });
 
 const widgetData = computed(() => {
   if (!hasSectorsConfigured.value) {
@@ -165,12 +170,9 @@ const handleCardClick = (id: CardId) => {
   };
 
   setActiveDetailedTab(status[id] as ActiveDetailedTab);
+  setForceLoadDetailed(true);
   setTimeout(scrollToDetailedMonitoring, 100);
 };
-
-onMounted(() => {
-  loadTimeMetricsData();
-});
 </script>
 
 <style scoped lang="scss">

--- a/src/components/insights/humanSupport/Monitoring/__tests__/StatusCards.spec.js
+++ b/src/components/insights/humanSupport/Monitoring/__tests__/StatusCards.spec.js
@@ -5,6 +5,7 @@ import { createTestingPinia } from '@pinia/testing';
 import { ref } from 'vue';
 
 import ServiceStatus from '../StatusCards.vue';
+import { LazyVisibilityKey } from '@/composables/useLazyData';
 
 const defaultServiceStatusData = {
   is_waiting: 25,
@@ -15,6 +16,8 @@ const defaultServiceStatusData = {
 const mockMonitoringStore = {
   $id: 'humanSupportMonitoring',
   loadServiceStatusData: vi.fn(),
+  setActiveDetailedTab: vi.fn(),
+  setForceLoadDetailed: vi.fn(),
   serviceStatusData: { value: { ...defaultServiceStatusData } },
   loadingServiceStatusData: { value: false },
 };
@@ -104,10 +107,35 @@ describe('ServiceStatus', () => {
   const title = () => wrapper.find('[data-testid="service-status-title"]');
   const cards = () => wrapper.find('[data-testid="service-status-cards"]');
 
+  const createLazyWrapper = (hasBeenVisible) => {
+    const hasBeenVisibleRef = ref(hasBeenVisible);
+    const isVisibleRef = ref(hasBeenVisible);
+    const lazyWrapper = mount(ServiceStatus, {
+      global: {
+        plugins: [
+          createTestingPinia({
+            initialState: { project: { hasSectorsConfigured: true } },
+          }),
+        ],
+        stubs: { CardConversations: true },
+        provide: {
+          [LazyVisibilityKey]: {
+            hasBeenVisible: hasBeenVisibleRef,
+            isVisible: isVisibleRef,
+            forceLoad: vi.fn(),
+          },
+        },
+      },
+    });
+    return { lazyWrapper, hasBeenVisibleRef };
+  };
+
   beforeEach(() => {
     vi.clearAllMocks();
     Object.assign(mockMonitoringStore, {
       loadServiceStatusData: vi.fn(),
+      setActiveDetailedTab: vi.fn(),
+      setForceLoadDetailed: vi.fn(),
       serviceStatusData: { value: { ...defaultServiceStatusData } },
       loadingServiceStatusData: { value: false },
     });
@@ -294,6 +322,47 @@ describe('ServiceStatus', () => {
   describe('Lifecycle', () => {
     it('should load service status data on mounted', () => {
       expect(mockMonitoringStore.loadServiceStatusData).toHaveBeenCalled();
+    });
+  });
+
+  describe('Lazy loading', () => {
+    it('should not load data while the widget is off screen', () => {
+      mockMonitoringStore.loadServiceStatusData.mockClear();
+      createLazyWrapper(false);
+      expect(mockMonitoringStore.loadServiceStatusData).not.toHaveBeenCalled();
+    });
+
+    it('should load data once the widget becomes visible', async () => {
+      mockMonitoringStore.loadServiceStatusData.mockClear();
+      const { hasBeenVisibleRef } = createLazyWrapper(false);
+      expect(mockMonitoringStore.loadServiceStatusData).not.toHaveBeenCalled();
+
+      hasBeenVisibleRef.value = true;
+      await Promise.resolve();
+
+      expect(mockMonitoringStore.loadServiceStatusData).toHaveBeenCalledTimes(
+        1,
+      );
+    });
+  });
+
+  describe('Card click navigation', () => {
+    it('should force-load the detailed section and switch tab on click', () => {
+      wrapper.vm.handleCardClick('is_waiting');
+
+      expect(mockMonitoringStore.setActiveDetailedTab).toHaveBeenCalledWith(
+        'in_awaiting',
+      );
+      expect(mockMonitoringStore.setForceLoadDetailed).toHaveBeenCalledWith(
+        true,
+      );
+    });
+
+    it('should not navigate when the finished card is clicked', () => {
+      wrapper.vm.handleCardClick('finished');
+
+      expect(mockMonitoringStore.setActiveDetailedTab).not.toHaveBeenCalled();
+      expect(mockMonitoringStore.setForceLoadDetailed).not.toHaveBeenCalled();
     });
   });
 

--- a/src/store/modules/humanSupport/__tests__/analysis.spec.js
+++ b/src/store/modules/humanSupport/__tests__/analysis.spec.js
@@ -199,13 +199,20 @@ describe('useHumanSupportAnalysis store', () => {
   });
 
   describe('Action: loadAllData', () => {
-    it('should load both data sources independently', async () => {
+    it('should reload both data sources once they have been loaded', async () => {
       ServiceStatusAnalysisService.getServiceStatusAnalysisData.mockResolvedValue(
         mockServiceStatusData,
       );
       ServicesOpenByHourAnalysisService.getServicesOpenByHourAnalysisData.mockResolvedValue(
         mockServicesOpenByHourData,
       );
+
+      // Prime the slices (simulate widgets becoming visible).
+      await Promise.all([
+        store.loadServiceStatusData(),
+        store.loadHumanSupportByHourData(),
+      ]);
+      vi.clearAllMocks();
 
       store.loadAllData();
 
@@ -219,6 +226,33 @@ describe('useHumanSupportAnalysis store', () => {
       ).toHaveBeenCalled();
       expect(store.serviceStatusData).toEqual(mockServiceStatusData);
       expect(store.servicesOpenByHourData).toEqual(mockServicesOpenByHourData);
+    });
+
+    it('should not load slices that were never visible/loaded', async () => {
+      store.loadAllData();
+
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      expect(
+        ServiceStatusAnalysisService.getServiceStatusAnalysisData,
+      ).not.toHaveBeenCalled();
+      expect(
+        ServicesOpenByHourAnalysisService.getServicesOpenByHourAnalysisData,
+      ).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Action: setForceLoadDetailed', () => {
+    it('should default forceLoadDetailed to false', () => {
+      expect(store.forceLoadDetailed).toBe(false);
+    });
+
+    it('should toggle forceLoadDetailed', () => {
+      store.setForceLoadDetailed(true);
+      expect(store.forceLoadDetailed).toBe(true);
+
+      store.setForceLoadDetailed(false);
+      expect(store.forceLoadDetailed).toBe(false);
     });
   });
 
@@ -236,6 +270,12 @@ describe('useHumanSupportAnalysis store', () => {
             setTimeout(() => resolve(mockServicesOpenByHourData), 30),
           ),
       );
+
+      // Prime the slices so loadAllData reloads them.
+      await Promise.all([
+        store.loadServiceStatusData(),
+        store.loadHumanSupportByHourData(),
+      ]);
 
       store.loadAllData();
 

--- a/src/store/modules/humanSupport/__tests__/monitoring.spec.js
+++ b/src/store/modules/humanSupport/__tests__/monitoring.spec.js
@@ -125,7 +125,7 @@ describe('useHumanSupportMonitoring store', () => {
   });
 
   describe('loadAllData action', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       vi.useFakeTimers();
 
       TimeMetricsService.getTimeMetricsData.mockResolvedValue({
@@ -133,10 +133,35 @@ describe('useHumanSupportMonitoring store', () => {
         average_time_first_response: { average: 30, max: 60 },
         average_time_chat: { average: 500, max: 1000 },
       });
+
+      // loadAllData only reloads slices that have already been loaded once
+      // (i.e. became visible). Prime them so the refresh paths can reload.
+      await Promise.all([
+        store.loadServiceStatusData(),
+        store.loadTimeMetricsData(),
+        store.loadHumanSupportByHourData(),
+      ]);
+      vi.clearAllMocks();
     });
 
     afterEach(() => {
       vi.useRealTimers();
+    });
+
+    it('should not load any slice that was never visible/loaded', async () => {
+      setActivePinia(createPinia());
+      const freshStore = useHumanSupportMonitoring();
+
+      const loadAllDataPromise = freshStore.loadAllData();
+
+      vi.advanceTimersByTime(3000);
+      await loadAllDataPromise;
+
+      expect(ServiceStatusService.getServiceStatusData).not.toHaveBeenCalled();
+      expect(TimeMetricsService.getTimeMetricsData).not.toHaveBeenCalled();
+      expect(
+        ServicesOpenByHourService.getServicesOpenByHourData,
+      ).not.toHaveBeenCalled();
     });
 
     it('should set isLoadingAllData to true when any individual load is running', async () => {
@@ -322,7 +347,7 @@ describe('useHumanSupportMonitoring store', () => {
   });
 
   describe('refresh data monitoring', () => {
-    it('should trigger loadAllData when refreshDataMonitoring is set to true', async () => {
+    it('should trigger loadAllData for loaded slices when refreshDataMonitoring is set to true', async () => {
       vi.useFakeTimers();
 
       TimeMetricsService.getTimeMetricsData.mockResolvedValue({
@@ -330,6 +355,14 @@ describe('useHumanSupportMonitoring store', () => {
         average_time_first_response: { average: 30, max: 60 },
         average_time_chat: { average: 500, max: 1000 },
       });
+
+      // Prime the slices (simulate widgets becoming visible).
+      await Promise.all([
+        store.loadServiceStatusData(),
+        store.loadTimeMetricsData(),
+        store.loadHumanSupportByHourData(),
+      ]);
+      vi.clearAllMocks();
 
       expect(store.refreshDataMonitoring).toBe(false);
 
@@ -344,6 +377,23 @@ describe('useHumanSupportMonitoring store', () => {
       expect(
         ServicesOpenByHourService.getServicesOpenByHourData,
       ).toHaveBeenCalled();
+
+      vi.useRealTimers();
+    });
+
+    it('should not refetch slices that were never loaded on refresh', async () => {
+      vi.useFakeTimers();
+      vi.clearAllMocks();
+
+      store.setRefreshDataMonitoring(true);
+
+      await vi.runAllTimersAsync();
+
+      expect(ServiceStatusService.getServiceStatusData).not.toHaveBeenCalled();
+      expect(TimeMetricsService.getTimeMetricsData).not.toHaveBeenCalled();
+      expect(
+        ServicesOpenByHourService.getServicesOpenByHourData,
+      ).not.toHaveBeenCalled();
 
       vi.useRealTimers();
     });
@@ -401,6 +451,20 @@ describe('useHumanSupportMonitoring store', () => {
         store.setActiveDetailedTab('in_progress');
         expect(store.activeDetailedTab).toBe('in_progress');
       });
+    });
+  });
+
+  describe('forceLoadDetailed', () => {
+    it('should default to false', () => {
+      expect(store.forceLoadDetailed).toBe(false);
+    });
+
+    it('should set forceLoadDetailed via setForceLoadDetailed', () => {
+      store.setForceLoadDetailed(true);
+      expect(store.forceLoadDetailed).toBe(true);
+
+      store.setForceLoadDetailed(false);
+      expect(store.forceLoadDetailed).toBe(false);
     });
   });
 });

--- a/src/store/modules/humanSupport/analysis.ts
+++ b/src/store/modules/humanSupport/analysis.ts
@@ -11,6 +11,7 @@ export const useHumanSupportAnalysis = defineStore(
   'humanSupportAnalysis',
   () => {
     const activeDetailedTab = ref<ActiveDetailedTab>('finished');
+    const forceLoadDetailed = ref<boolean>(false);
     const serviceStatusData = ref<ServiceStatusFormattedResponse>({
       finished: null,
       average_time_is_waiting: null,
@@ -22,6 +23,11 @@ export const useHumanSupportAnalysis = defineStore(
     const loadingServiceStatusData = ref(false);
     const loadingHumanSupportByHourData = ref(false);
 
+    // Tracks which data slices have already been requested (i.e. became
+    // visible) so the central refresh only reloads on-screen widgets.
+    const hasLoadedServiceStatus = ref(false);
+    const hasLoadedHumanSupportByHour = ref(false);
+
     const isLoadingAllData = computed(
       () =>
         loadingServiceStatusData.value || loadingHumanSupportByHourData.value,
@@ -31,12 +37,17 @@ export const useHumanSupportAnalysis = defineStore(
       activeDetailedTab.value = tab;
     };
 
+    const setForceLoadDetailed = (value: boolean) => {
+      forceLoadDetailed.value = value;
+    };
+
     const loadAllData = () => {
-      loadServiceStatusData();
-      loadHumanSupportByHourData();
+      if (hasLoadedServiceStatus.value) loadServiceStatusData();
+      if (hasLoadedHumanSupportByHour.value) loadHumanSupportByHourData();
     };
 
     const loadServiceStatusData = async () => {
+      hasLoadedServiceStatus.value = true;
       try {
         loadingServiceStatusData.value = true;
         const data =
@@ -51,6 +62,7 @@ export const useHumanSupportAnalysis = defineStore(
     };
 
     const loadHumanSupportByHourData = async () => {
+      hasLoadedHumanSupportByHour.value = true;
       try {
         loadingHumanSupportByHourData.value = true;
         const data =
@@ -71,10 +83,12 @@ export const useHumanSupportAnalysis = defineStore(
       loadingHumanSupportByHourData,
       servicesOpenByHourData,
       activeDetailedTab,
+      forceLoadDetailed,
       loadAllData,
       loadServiceStatusData,
       loadHumanSupportByHourData,
       setActiveDetailedTab,
+      setForceLoadDetailed,
     };
   },
 );

--- a/src/store/modules/humanSupport/monitoring.ts
+++ b/src/store/modules/humanSupport/monitoring.ts
@@ -20,6 +20,7 @@ export const useHumanSupportMonitoring = defineStore(
     const autoRefresh = ref<boolean>(true);
     const refreshDataMonitoring = ref<boolean>(false);
     const isSilentRefresh = ref<boolean>(false);
+    const forceLoadDetailed = ref<boolean>(false);
     const activeDetailedTab = ref<ActiveDetailedTab>('in_progress');
     const serviceStatusData = ref<ServiceStatusDataResponse>({
       is_waiting: null,
@@ -35,6 +36,13 @@ export const useHumanSupportMonitoring = defineStore(
     const loadingServiceStatusData = ref(false);
     const loadingTimeMetricsData = ref(false);
     const loadingHumanSupportByHourData = ref(false);
+
+    // Tracks which data slices have already been requested (i.e. became
+    // visible). The central refresh/polling only reloads loaded slices so
+    // off-screen widgets are never fetched until the user scrolls to them.
+    const hasLoadedServiceStatus = ref(false);
+    const hasLoadedTimeMetrics = ref(false);
+    const hasLoadedHumanSupportByHour = ref(false);
 
     const { updateLastUpdatedRequest } = useDashboards();
 
@@ -54,13 +62,18 @@ export const useHumanSupportMonitoring = defineStore(
       isSilentRefresh.value = silent;
     };
 
+    const setForceLoadDetailed = (value: boolean) => {
+      forceLoadDetailed.value = value;
+    };
+
     const loadAllData = () => {
-      loadServiceStatusData();
-      loadTimeMetricsData();
-      loadHumanSupportByHourData();
+      if (hasLoadedServiceStatus.value) loadServiceStatusData();
+      if (hasLoadedTimeMetrics.value) loadTimeMetricsData();
+      if (hasLoadedHumanSupportByHour.value) loadHumanSupportByHourData();
     };
 
     const loadServiceStatusData = async () => {
+      hasLoadedServiceStatus.value = true;
       try {
         if (!isSilentRefresh.value) {
           loadingServiceStatusData.value = true;
@@ -79,6 +92,7 @@ export const useHumanSupportMonitoring = defineStore(
     };
 
     const loadTimeMetricsData = async () => {
+      hasLoadedTimeMetrics.value = true;
       try {
         if (!isSilentRefresh.value) {
           loadingTimeMetricsData.value = true;
@@ -98,6 +112,7 @@ export const useHumanSupportMonitoring = defineStore(
     };
 
     const loadHumanSupportByHourData = async () => {
+      hasLoadedHumanSupportByHour.value = true;
       try {
         if (!isSilentRefresh.value) {
           loadingHumanSupportByHourData.value = true;
@@ -120,10 +135,6 @@ export const useHumanSupportMonitoring = defineStore(
       if (newValue) loadAllData();
     });
 
-    watch(refreshDataMonitoring, (value) => {
-      if (value) loadAllData();
-    });
-
     return {
       isLoadingAllData,
       serviceStatusData,
@@ -136,12 +147,14 @@ export const useHumanSupportMonitoring = defineStore(
       autoRefresh,
       refreshDataMonitoring,
       isSilentRefresh,
+      forceLoadDetailed,
       loadAllData,
       loadServiceStatusData,
       loadTimeMetricsData,
       loadHumanSupportByHourData,
       setActiveDetailedTab,
       setRefreshDataMonitoring,
+      setForceLoadDetailed,
     };
   },
 );


### PR DESCRIPTION
## Description
### Type of Change
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [x] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
Dashboard widgets were fetching data on mount regardless of whether they were visible in the viewport. This caused unnecessary API calls for off-screen widgets, including the detailed analysis/monitoring sections that are only reached by scrolling. Additionally, clicking a status card to navigate to the detailed section would attempt to scroll to it before its data had been loaded.

### Summary of Changes
- Introduced a `LazyWidget` wrapper component in both the Analysis and Monitoring dashboard views. Each widget is now wrapped in `LazyWidget`, deferring rendering and data fetching until the widget enters the viewport.
- Replaced `onMounted` data-loading calls across `StatusCards`, `TimeMetrics`, `ServicesOpenByHour`, `VolumeBarListWidget`, `CsatRatings`, and all detailed table components (`Attendant`, `InAwaiting`, `InProgress`, `Finished`, `Pauses`) with the `useLazyData` composable, which triggers the initial load only when the component becomes visible.
- Added `hasBeenVisible` guards to all reactive watchers so that filter/sort/refresh changes do not trigger API calls for widgets that have never been visible.
- Introduced `forceLoadDetailed` state and `setForceLoadDetailed` action to both the `humanSupportAnalysis` and `humanSupportMonitoring` stores. When a status or time-metrics card is clicked to navigate to the detailed section, `setForceLoadDetailed(true)` is called, which forces the `LazyWidget` wrapping the detailed section to become visible and load its data before the scroll animation runs.
- Added `hasLoadedServiceStatus`, `hasLoadedTimeMetrics`, and `hasLoadedHumanSupportByHour` tracking flags to both stores so that `loadAllData` (used by polling and refresh) only reloads slices that have already been fetched at least once, preventing background refreshes from loading off-screen widgets.
- Removed a duplicate `watch(refreshDataMonitoring)` in the monitoring store that was triggering `loadAllData` redundantly.
- Updated and extended tests for the monitoring and analysis stores and the `StatusCards` component to cover lazy-loading behaviour, the `forceLoadDetailed` flag, and the card-click navigation flow.