### PR TITLE
feat: defer conversational dashboard API calls until widgets enter viewport

### DIFF
--- a/src/components/insights/conversations/AbandonedCartWidget/index.vue
+++ b/src/components/insights/conversations/AbandonedCartWidget/index.vue
@@ -78,9 +78,11 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { isBefore, parseISO, startOfDay, subDays } from 'date-fns';
 import { useI18n } from 'vue-i18n';
+
+import { useLazyData } from '@/composables/useLazyData';
 
 import Chart from './Chart.vue';
 import InfoCard from './InfoCard.vue';
@@ -231,13 +233,14 @@ const fetchData = async () => {
   }
 };
 
-onMounted(() => {
-  fetchData();
+const { hasBeenVisible } = useLazyData({
+  load: fetchData,
 });
 
 watch(
   () => appliedFilters.value,
   () => {
+    if (!hasBeenVisible.value) return;
     fetchData();
   },
   { deep: true },
@@ -246,6 +249,7 @@ watch(
 watch(
   () => refreshDataConversational.value,
   (val) => {
+    if (!hasBeenVisible.value) return;
     if (val) {
       fetchData();
     }

--- a/src/components/insights/conversations/ContactsHeader.vue
+++ b/src/components/insights/conversations/ContactsHeader.vue
@@ -27,11 +27,12 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted, watch } from 'vue';
+import { ref, computed, onUnmounted, watch } from 'vue';
 import CardConversations from '@/components/insights/cards/CardConversations.vue';
 import Unnnic from '@weni/unnnic-system';
 import { useI18n } from 'vue-i18n';
 import { useWidgetFormatting } from '@/composables/useWidgetFormatting';
+import { useLazyData } from '@/composables/useLazyData';
 import conversationalContactsApi from '@/services/api/resources/conversational/contacts';
 import { MOCK_CONTACTS_DATA } from '@/services/api/resources/conversational/mocks';
 import { useRoute } from 'vue-router';
@@ -141,6 +142,7 @@ let loadCardDataAbortController: AbortController | null = null;
 watch(
   () => route.query,
   () => {
+    if (!hasBeenVisible.value) return;
     if (shouldUseMock.value) return;
     dashboardsStore.updateLastUpdatedRequest();
     loadCardData();
@@ -150,6 +152,7 @@ watch(
 watch(
   () => conversationalStore.refreshDataConversational,
   (newValue) => {
+    if (!hasBeenVisible.value) return;
     if (newValue && !shouldUseMock.value) {
       dashboardsStore.updateLastUpdatedRequest();
       conversationalStore.setIsLoadingConversationalData(
@@ -246,9 +249,11 @@ const loadCardData = async () => {
   }
 };
 
-onMounted(() => {
-  dashboardsStore.updateLastUpdatedRequest();
-  loadCardData();
+const { hasBeenVisible } = useLazyData({
+  load: () => {
+    dashboardsStore.updateLastUpdatedRequest();
+    return loadCardData();
+  },
 });
 
 onUnmounted(() => {

--- a/src/components/insights/conversations/ConversationalDynamicWidget.vue
+++ b/src/components/insights/conversations/ConversationalDynamicWidget.vue
@@ -1,27 +1,31 @@
 <template>
-  <section
-    class="conversational-dynamic-widget"
-    :class="{ 'conversational-dynamic-widget--mock-hover': showMockOverlay }"
-  >
-    <component
-      :is="currentComponent"
-      :uuid="uuid"
-    />
+  <LazyWidget>
+    <section
+      class="conversational-dynamic-widget"
+      :class="{ 'conversational-dynamic-widget--mock-hover': showMockOverlay }"
+    >
+      <component
+        :is="currentComponent"
+        :uuid="uuid"
+      />
 
-    <AddWidget
-      v-if="showMockOverlay"
-      class="conversational-dynamic-widget__mock-overlay"
-      :title="$t('conversations_dashboard.customize_your_dashboard.title')"
-      :description="
-        $t('conversations_dashboard.customize_your_dashboard.description')
-      "
-      :actionText="
-        $t('conversations_dashboard.customize_your_dashboard.add_first_widget')
-      "
-      data-testid="mock-widget-overlay"
-      @action="handleOpenDrawer"
-    />
-  </section>
+      <AddWidget
+        v-if="showMockOverlay"
+        class="conversational-dynamic-widget__mock-overlay"
+        :title="$t('conversations_dashboard.customize_your_dashboard.title')"
+        :description="
+          $t('conversations_dashboard.customize_your_dashboard.description')
+        "
+        :actionText="
+          $t(
+            'conversations_dashboard.customize_your_dashboard.add_first_widget',
+          )
+        "
+        data-testid="mock-widget-overlay"
+        @action="handleOpenDrawer"
+      />
+    </section>
+  </LazyWidget>
 </template>
 
 <script setup lang="ts">
@@ -40,6 +44,7 @@ import ConversationalSearchTerm from '@/components/insights/widgets/conversation
 import ConversationalAddedToCart from '@/components/insights/widgets/conversational/ConversationalAddedToCart.vue';
 import ConversationalAdd from '@/components/insights/widgets/conversational/ConversationalAdd.vue';
 import AddWidget from '@/components/insights/conversations/AddWidget.vue';
+import LazyWidget from '@/components/insights/Layout/LazyWidget.vue';
 import { useConversational } from '@/store/modules/conversational/conversational';
 
 type ConversationalWidgetType =

--- a/src/components/insights/conversations/DashboardHeader.vue
+++ b/src/components/insights/conversations/DashboardHeader.vue
@@ -28,11 +28,12 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, watch } from 'vue';
+import { ref, computed, watch } from 'vue';
 import CardConversations from '@/components/insights/cards/CardConversations.vue';
 import Unnnic from '@weni/unnnic-system';
 import { useI18n } from 'vue-i18n';
 import { useWidgetFormatting } from '@/composables/useWidgetFormatting';
+import { useLazyData } from '@/composables/useLazyData';
 import conversationalHeaderApi from '@/services/api/resources/conversational/header';
 import { MOCK_HEADER_DATA } from '@/services/api/resources/conversational/mocks';
 import { useRoute } from 'vue-router';
@@ -127,6 +128,7 @@ const cards = computed(() =>
 watch(
   () => route.query,
   () => {
+    if (!hasBeenVisible.value) return;
     if (shouldUseMock.value) return;
     dashboardsStore.updateLastUpdatedRequest();
     loadCardData();
@@ -136,6 +138,7 @@ watch(
 watch(
   () => conversationalStore.refreshDataConversational,
   (newValue) => {
+    if (!hasBeenVisible.value) return;
     if (newValue && !shouldUseMock.value) {
       dashboardsStore.updateLastUpdatedRequest();
       conversationalStore.setIsLoadingConversationalData('header', true);
@@ -234,9 +237,11 @@ const handleCardClick = (cardId: string) => {
   );
 };
 
-onMounted(() => {
-  dashboardsStore.updateLastUpdatedRequest();
-  loadCardData();
+const { hasBeenVisible } = useLazyData({
+  load: () => {
+    dashboardsStore.updateLastUpdatedRequest();
+    return loadCardData();
+  },
 });
 </script>
 

--- a/src/components/insights/conversations/MostTalkedAboutTopicsWidget/index.vue
+++ b/src/components/insights/conversations/MostTalkedAboutTopicsWidget/index.vue
@@ -59,9 +59,10 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useI18n } from 'vue-i18n';
+import { useLazyData } from '@/composables/useLazyData';
 import BaseConversationWidget from '@/components/insights/conversations/BaseConversationWidget.vue';
 import TreemapChart from '@/components/insights/charts/TreemapChart.vue';
 import SeeAllDrawer from './SeeAllDrawer.vue';
@@ -132,13 +133,19 @@ const handleTabChange = (tab: Tab) => {
   setTopicType(tab === 'artificial-intelligence' ? 'AI' : 'HUMAN');
 };
 
+const { hasBeenVisible } = useLazyData({
+  load: loadTopicsDistribution,
+});
+
 watch(topicType, () => {
+  if (!hasBeenVisible.value) return;
   loadTopicsDistribution();
 });
 
 watch(
   () => route.query,
   () => {
+    if (!hasBeenVisible.value) return;
     loadTopicsDistribution();
   },
 );
@@ -146,6 +153,7 @@ watch(
 watch(
   () => conversationalStore.refreshDataConversational,
   (newValue) => {
+    if (!hasBeenVisible.value) return;
     if (newValue) {
       conversationalStore.setIsLoadingConversationalData(
         'mostTalkedAboutTopics',
@@ -160,10 +168,6 @@ watch(
     }
   },
 );
-
-onMounted(() => {
-  loadTopicsDistribution();
-});
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/insights/conversations/__tests__/ConversationalDynamicWidget.spec.js
+++ b/src/components/insights/conversations/__tests__/ConversationalDynamicWidget.spec.js
@@ -150,6 +150,15 @@ describe('ConversationalDynamicWidget', () => {
       );
     });
 
+    it('wraps the widget in a LazyWidget boundary', () => {
+      const wrapper = createWrapper({ type: 'csat' });
+      const lazyWidget = wrapper.findComponent({ name: 'LazyWidget' });
+      expect(lazyWidget.exists()).toBe(true);
+      expect(
+        lazyWidget.findComponent({ name: 'ConversationalCsat' }).exists(),
+      ).toBe(true);
+    });
+
     it('computes currentComponent correctly', () => {
       const wrapper = createWrapper({ type: 'csat' });
       expect(wrapper.vm.currentComponent).toBeDefined();

--- a/src/components/insights/conversations/__tests__/DashboardHeader.spec.js
+++ b/src/components/insights/conversations/__tests__/DashboardHeader.spec.js
@@ -3,6 +3,7 @@ import { ref as vueRef, reactive } from 'vue';
 import { mount, config } from '@vue/test-utils';
 
 import DashboardHeader from '../DashboardHeader.vue';
+import { LazyVisibilityKey } from '@/composables/useLazyData';
 
 import { createI18n } from 'vue-i18n';
 import Unnnic from '@weni/unnnic-system';
@@ -117,6 +118,23 @@ const createWrapper = () => {
   });
 };
 
+const createLazyWrapper = (hasBeenVisible) => {
+  const hasBeenVisibleRef = vueRef(hasBeenVisible);
+  const wrapper = mount(DashboardHeader, {
+    global: {
+      plugins: [Unnnic],
+      provide: {
+        [LazyVisibilityKey]: {
+          hasBeenVisible: hasBeenVisibleRef,
+          isVisible: vueRef(hasBeenVisible),
+          forceLoad: vi.fn(),
+        },
+      },
+    },
+  });
+  return { wrapper, hasBeenVisibleRef };
+};
+
 describe('DashboardHeader.vue', () => {
   let wrapper;
 
@@ -124,6 +142,41 @@ describe('DashboardHeader.vue', () => {
     vi.clearAllMocks();
 
     wrapper = createWrapper();
+  });
+
+  describe('Lazy loading', () => {
+    it('should not load card data while off screen', async () => {
+      const conversationalHeaderApi = await import(
+        '@/services/api/resources/conversational/header'
+      );
+      conversationalHeaderApi.default.getConversationalHeaderTotals.mockClear();
+
+      createLazyWrapper(false);
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(
+        conversationalHeaderApi.default.getConversationalHeaderTotals,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('should load card data once it becomes visible', async () => {
+      const conversationalHeaderApi = await import(
+        '@/services/api/resources/conversational/header'
+      );
+      conversationalHeaderApi.default.getConversationalHeaderTotals.mockClear();
+
+      const { hasBeenVisibleRef } = createLazyWrapper(false);
+      expect(
+        conversationalHeaderApi.default.getConversationalHeaderTotals,
+      ).not.toHaveBeenCalled();
+
+      hasBeenVisibleRef.value = true;
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(
+        conversationalHeaderApi.default.getConversationalHeaderTotals,
+      ).toHaveBeenCalled();
+    });
   });
 
   describe('Component Structure', () => {

--- a/src/components/insights/dashboards/Conversational.vue
+++ b/src/components/insights/dashboards/Conversational.vue
@@ -9,7 +9,9 @@
       <h2 class="dashboard-conversational__section-title">
         {{ $t('conversations_dashboard.sections.conversations') }}
       </h2>
-      <DashboardHeader class="dashboard-conversational__header" />
+      <LazyWidget class="dashboard-conversational__header">
+        <DashboardHeader />
+      </LazyWidget>
     </section>
 
     <section
@@ -19,17 +21,21 @@
       <h2 class="dashboard-conversational__section-title">
         {{ $t('conversations_dashboard.sections.contacts') }}
       </h2>
-      <ContactsHeader class="dashboard-conversational__header" />
+      <LazyWidget class="dashboard-conversational__header">
+        <ContactsHeader />
+      </LazyWidget>
     </section>
 
-    <MostTalkedAboutTopicsWidget
-      class="dashboard-conversational__most-talked-about-topics"
-    />
+    <LazyWidget class="dashboard-conversational__most-talked-about-topics">
+      <MostTalkedAboutTopicsWidget />
+    </LazyWidget>
 
-    <AbandonedCartWidget
+    <LazyWidget
       v-if="isAbandonedCartRecoveryConfigured"
       class="dashboard-conversational__abandoned-cart-widget"
-    />
+    >
+      <AbandonedCartWidget />
+    </LazyWidget>
 
     <ConversationalDynamicWidget
       v-for="(widget, index) in orderedDynamicWidgets"
@@ -67,6 +73,7 @@ import CustomizableDrawer from '@/components/insights/conversations/Customizable
 import Info from '@/components/insights/conversations/Info.vue';
 import DataFeedbackModal from '@/components/insights/conversations/Feedback/DataFeedbackModal.vue';
 import AbandonedCartWidget from '@/components/insights/conversations/AbandonedCartWidget/index.vue';
+import LazyWidget from '@/components/insights/Layout/LazyWidget.vue';
 
 import { useWidgets } from '@/store/modules/widgets';
 import { useCustomWidgets } from '@/store/modules/conversational/customWidgets';
@@ -223,13 +230,12 @@ const waitForDashboardWidgets = () =>
 
 const initializeConfiguration = async () => {
   const topicsPromise = topicsStore.loadFormTopics();
-  const autoWidgetsPromise = autoWidgets.loadAllAutoWidgets();
   project.getAgentsTeam();
 
   await waitForDashboardWidgets();
   setDynamicWidgets();
 
-  await Promise.all([topicsPromise, autoWidgetsPromise]);
+  await topicsPromise;
   conversational.setConfigurationLoaded(true);
 
   if (conversational.shouldUseMock) {

--- a/src/components/insights/dashboards/__tests__/Conversational.spec.js
+++ b/src/components/insights/dashboards/__tests__/Conversational.spec.js
@@ -185,6 +185,13 @@ describe('Conversational.vue', () => {
     });
   });
 
+  describe('Lazy loading', () => {
+    it('should not eagerly load auto widgets on init (lazy-loaded per widget)', async () => {
+      await nextTick();
+      expect(autoWidgetsStore.loadAllAutoWidgets).not.toHaveBeenCalled();
+    });
+  });
+
   it('should always include agent_invocation and tool_result first', async () => {
     widgetsStore.currentDashboardWidgets.value = [];
     await nextTick();

--- a/src/components/insights/widgets/conversational/ConversacionalAbsoluteNumbers/AbsoluteNumbersMetric.vue
+++ b/src/components/insights/widgets/conversational/ConversacionalAbsoluteNumbers/AbsoluteNumbersMetric.vue
@@ -37,8 +37,10 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { useRoute } from 'vue-router';
+
+import { useLazyData } from '@/composables/useLazyData';
 
 import CardWidgetContainer from '../../layout/CardWidgetContainer.vue';
 import WidgetService, {
@@ -118,13 +120,14 @@ const actions = computed(() => {
   return [editOption, deleteOption];
 });
 
-onMounted(() => {
-  getChildrenValue();
+const { hasBeenVisible } = useLazyData({
+  load: getChildrenValue,
 });
 
 watch(
   () => route.query,
   () => {
+    if (!hasBeenVisible.value) return;
     getChildrenValue();
   },
   { deep: true },
@@ -133,6 +136,7 @@ watch(
 watch(
   () => conversationalStore.refreshDataConversational,
   (newValue) => {
+    if (!hasBeenVisible.value) return;
     if (newValue) {
       getChildrenValue();
     }

--- a/src/components/insights/widgets/conversational/ConversacionalAbsoluteNumbers/index.vue
+++ b/src/components/insights/widgets/conversational/ConversacionalAbsoluteNumbers/index.vue
@@ -77,9 +77,11 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue';
+import { computed, ref } from 'vue';
 import { storeToRefs } from 'pinia';
 import { cloneDeep } from 'lodash-es';
+
+import { useLazyData } from '@/composables/useLazyData';
 
 import CardWidgetContainer from '@/components/insights/widgets/layout/CardWidgetContainer.vue';
 import AbsoluteNumbersMetric from './AbsoluteNumbersMetric.vue';
@@ -105,8 +107,8 @@ const props = defineProps<{
   uuid: string;
 }>();
 
-onMounted(() => {
-  loadChildren();
+useLazyData({
+  load: () => loadChildren(),
 });
 
 const customWidgetsStore = useCustomWidgets();

--- a/src/components/insights/widgets/conversational/ConversationalAddedToCart.vue
+++ b/src/components/insights/widgets/conversational/ConversationalAddedToCart.vue
@@ -67,10 +67,12 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useRoute } from 'vue-router';
 import { useI18n } from 'vue-i18n';
+
+import { useLazyData } from '@/composables/useLazyData';
 
 import BaseConversationWidget from '@/components/insights/conversations/BaseConversationWidget.vue';
 import ProgressTable from '@/components/ProgressTable.vue';
@@ -151,13 +153,14 @@ const actions = computed(() => {
   ];
 });
 
-onMounted(() => {
-  loadAddedToCartWidgetData();
+const { hasBeenVisible } = useLazyData({
+  load: loadAddedToCartWidgetData,
 });
 
 watch(
   () => route.query,
   () => {
+    if (!hasBeenVisible.value) return;
     loadAddedToCartWidgetData();
   },
   { deep: true },
@@ -166,6 +169,7 @@ watch(
 watch(
   () => conversational.refreshDataConversational,
   (newValue) => {
+    if (!hasBeenVisible.value) return;
     if (newValue) {
       conversational.setIsLoadingConversationalData('dynamicWidgets', true);
       loadAddedToCartWidgetData().finally(() => {

--- a/src/components/insights/widgets/conversational/ConversationalAgentInvocation.vue
+++ b/src/components/insights/widgets/conversational/ConversationalAgentInvocation.vue
@@ -73,10 +73,12 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { useRoute } from 'vue-router';
 import { storeToRefs } from 'pinia';
 import { UnnnicDisclaimer } from '@weni/unnnic-system';
+
+import { useLazyData } from '@/composables/useLazyData';
 
 import BaseConversationWidget from '@/components/insights/conversations/BaseConversationWidget.vue';
 import ProgressTable from '@/components/ProgressTable.vue';
@@ -163,18 +165,21 @@ const widgetActions = computed(() => {
   return [deleteOption];
 });
 
-onMounted(() => {
-  if (!shouldUseMock.value) {
-    autoWidgetsStore.loadAgentInvocationData();
-    if (!projectStore.agentsTeam.agents.length) {
-      projectStore.getAgentsTeam();
+const { hasBeenVisible } = useLazyData({
+  load: () => {
+    if (!shouldUseMock.value) {
+      autoWidgetsStore.loadAgentInvocationData();
+      if (!projectStore.agentsTeam.agents.length) {
+        projectStore.getAgentsTeam();
+      }
     }
-  }
+  },
 });
 
 watch(
   () => route.query,
   () => {
+    if (!hasBeenVisible.value) return;
     if (!shouldUseMock.value) {
       autoWidgetsStore.loadAgentInvocationData();
     }
@@ -185,6 +190,7 @@ watch(
 watch(
   () => conversational.refreshDataConversational,
   (newValue) => {
+    if (!hasBeenVisible.value) return;
     if (newValue && !shouldUseMock.value) {
       conversational.setIsLoadingConversationalData('dynamicWidgets', true);
       autoWidgetsStore.loadAgentInvocationData().finally(() => {

--- a/src/components/insights/widgets/conversational/ConversationalCrosstab.vue
+++ b/src/components/insights/widgets/conversational/ConversationalCrosstab.vue
@@ -33,10 +33,12 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { useRoute } from 'vue-router';
 import { useI18n } from 'vue-i18n';
 import { storeToRefs } from 'pinia';
+
+import { useLazyData } from '@/composables/useLazyData';
 
 import ProgressWidget from '@/components/insights/widgets/ProgressWidget.vue';
 import ModalRemoveWidget from '@/components/insights/conversations/CustomizableWidget/ModalRemoveWidget.vue';
@@ -165,15 +167,18 @@ const handleOpenExpanded = () => {
   isSeeAllDrawerOpen.value = true;
 };
 
-onMounted(() => {
-  if (!shouldUseMock.value) {
-    loadCustomWidgetData(props.uuid);
-  }
+const { hasBeenVisible } = useLazyData({
+  load: () => {
+    if (!shouldUseMock.value) {
+      loadCustomWidgetData(props.uuid);
+    }
+  },
 });
 
 watch(
   () => route.query,
   () => {
+    if (!hasBeenVisible.value) return;
     if (!shouldUseMock.value) {
       loadCustomWidgetData(props.uuid);
     }
@@ -184,6 +189,7 @@ watch(
 watch(
   () => conversational.refreshDataConversational,
   (newValue) => {
+    if (!hasBeenVisible.value) return;
     if (newValue && !shouldUseMock.value) {
       conversational.setIsLoadingConversationalData('dynamicWidgets', true);
       loadCustomWidgetData(props.uuid).finally(() => {

--- a/src/components/insights/widgets/conversational/ConversationalCsat.vue
+++ b/src/components/insights/widgets/conversational/ConversationalCsat.vue
@@ -45,10 +45,12 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useRoute } from 'vue-router';
 import { useI18n } from 'vue-i18n';
+
+import { useLazyData } from '@/composables/useLazyData';
 
 import ProgressWidget from '@/components/insights/widgets/ProgressWidget.vue';
 import SetupWidget from '@/components/insights/conversations/SetupWidget.vue';
@@ -220,15 +222,17 @@ const handleTabChange = (tab: Tab) => {
   }
 };
 
-onMounted(() => {
-  if (shouldUseMock.value) {
-    setCsatWidgetType('AI');
-  } else if (csatWidgetType.value === 'AI' && !isCsatAiConfig.value) {
-    setCsatWidgetType('HUMAN');
-  } else if (csatWidgetType.value === 'HUMAN' && !isCsatHumanConfig.value) {
-    setCsatWidgetType('AI');
-  }
-  loadCsatWidgetData();
+const { hasBeenVisible } = useLazyData({
+  load: () => {
+    if (shouldUseMock.value) {
+      setCsatWidgetType('AI');
+    } else if (csatWidgetType.value === 'AI' && !isCsatAiConfig.value) {
+      setCsatWidgetType('HUMAN');
+    } else if (csatWidgetType.value === 'HUMAN' && !isCsatHumanConfig.value) {
+      setCsatWidgetType('AI');
+    }
+    loadCsatWidgetData();
+  },
 });
 
 watch(
@@ -248,6 +252,7 @@ watch(
 watch(
   () => route.query,
   () => {
+    if (!hasBeenVisible.value) return;
     loadCsatWidgetData();
   },
   { deep: true },
@@ -256,6 +261,7 @@ watch(
 watch(
   () => conversational.refreshDataConversational,
   (newValue) => {
+    if (!hasBeenVisible.value) return;
     if (newValue) {
       conversational.setIsLoadingConversationalData('dynamicWidgets', true);
       loadCsatWidgetData().finally(() => {

--- a/src/components/insights/widgets/conversational/ConversationalCustom.vue
+++ b/src/components/insights/widgets/conversational/ConversationalCustom.vue
@@ -32,10 +32,12 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { useRoute } from 'vue-router';
 import { useI18n } from 'vue-i18n';
 import { storeToRefs } from 'pinia';
+
+import { useLazyData } from '@/composables/useLazyData';
 
 import ProgressWidget from '@/components/insights/widgets/ProgressWidget.vue';
 import ModalRemoveWidget from '@/components/insights/conversations/CustomizableWidget/ModalRemoveWidget.vue';
@@ -181,15 +183,18 @@ const handleOpenExpanded = () => {
   isSeeAllDrawerOpen.value = true;
 };
 
-onMounted(() => {
-  if (!shouldUseMock.value) {
-    loadCustomWidgetData(props.uuid);
-  }
+const { hasBeenVisible } = useLazyData({
+  load: () => {
+    if (!shouldUseMock.value) {
+      loadCustomWidgetData(props.uuid);
+    }
+  },
 });
 
 watch(
   () => route.query,
   () => {
+    if (!hasBeenVisible.value) return;
     if (!shouldUseMock.value) {
       loadCustomWidgetData(props.uuid);
     }
@@ -200,6 +205,7 @@ watch(
 watch(
   () => conversational.refreshDataConversational,
   (newValue) => {
+    if (!hasBeenVisible.value) return;
     if (newValue && !shouldUseMock.value) {
       conversational.setIsLoadingConversationalData('dynamicWidgets', true);
       loadCustomWidgetData(props.uuid).finally(() => {

--- a/src/components/insights/widgets/conversational/ConversationalNps.vue
+++ b/src/components/insights/widgets/conversational/ConversationalNps.vue
@@ -46,10 +46,12 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useRoute } from 'vue-router';
 import { useI18n } from 'vue-i18n';
+
+import { useLazyData } from '@/composables/useLazyData';
 
 import ProgressWidget from '@/components/insights/widgets/ProgressWidget.vue';
 import SetupWidget from '@/components/insights/conversations/SetupWidget.vue';
@@ -270,15 +272,17 @@ const handleTabChange = (tab: Tab) => {
   }
 };
 
-onMounted(() => {
-  if (shouldUseMock.value) {
-    setNpsWidgetType('AI');
-  } else if (npsWidgetType.value === 'AI' && !isNpsAiConfig.value) {
-    setNpsWidgetType('HUMAN');
-  } else if (npsWidgetType.value === 'HUMAN' && !isNpsHumanConfig.value) {
-    setNpsWidgetType('AI');
-  }
-  loadNpsWidgetData();
+const { hasBeenVisible } = useLazyData({
+  load: () => {
+    if (shouldUseMock.value) {
+      setNpsWidgetType('AI');
+    } else if (npsWidgetType.value === 'AI' && !isNpsAiConfig.value) {
+      setNpsWidgetType('HUMAN');
+    } else if (npsWidgetType.value === 'HUMAN' && !isNpsHumanConfig.value) {
+      setNpsWidgetType('AI');
+    }
+    loadNpsWidgetData();
+  },
 });
 
 watch(
@@ -298,6 +302,7 @@ watch(
 watch(
   () => route.query,
   () => {
+    if (!hasBeenVisible.value) return;
     loadNpsWidgetData();
   },
   { deep: true },
@@ -306,6 +311,7 @@ watch(
 watch(
   () => conversational.refreshDataConversational,
   (newValue) => {
+    if (!hasBeenVisible.value) return;
     if (newValue) {
       conversational.setIsLoadingConversationalData('dynamicWidgets', true);
       loadNpsWidgetData().finally(() => {

--- a/src/components/insights/widgets/conversational/ConversationalSalesFunnel.vue
+++ b/src/components/insights/widgets/conversational/ConversationalSalesFunnel.vue
@@ -18,10 +18,12 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useRoute } from 'vue-router';
 import { useI18n } from 'vue-i18n';
+
+import { useLazyData } from '@/composables/useLazyData';
 
 import ProgressWidget from '@/components/insights/widgets/ProgressWidget.vue';
 import ModalRemoveWidget from '@/components/insights/conversations/CustomizableWidget/ModalRemoveWidget.vue';
@@ -65,13 +67,14 @@ const actions = computed(() => {
   ];
 });
 
-onMounted(() => {
-  loadSalesFunnelWidgetData();
+const { hasBeenVisible } = useLazyData({
+  load: loadSalesFunnelWidgetData,
 });
 
 watch(
   () => route.query,
   () => {
+    if (!hasBeenVisible.value) return;
     loadSalesFunnelWidgetData();
   },
   { deep: true },
@@ -80,6 +83,7 @@ watch(
 watch(
   () => conversational.refreshDataConversational,
   (newValue) => {
+    if (!hasBeenVisible.value) return;
     if (newValue) {
       conversational.setIsLoadingConversationalData('dynamicWidgets', true);
       loadSalesFunnelWidgetData().finally(() => {

--- a/src/components/insights/widgets/conversational/ConversationalSearchTerm.vue
+++ b/src/components/insights/widgets/conversational/ConversationalSearchTerm.vue
@@ -67,10 +67,12 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useRoute } from 'vue-router';
 import { useI18n } from 'vue-i18n';
+
+import { useLazyData } from '@/composables/useLazyData';
 
 import BaseConversationWidget from '@/components/insights/conversations/BaseConversationWidget.vue';
 import ProgressTable from '@/components/ProgressTable.vue';
@@ -151,13 +153,14 @@ const actions = computed(() => {
   ];
 });
 
-onMounted(() => {
-  loadSearchTermWidgetData();
+const { hasBeenVisible } = useLazyData({
+  load: loadSearchTermWidgetData,
 });
 
 watch(
   () => route.query,
   () => {
+    if (!hasBeenVisible.value) return;
     loadSearchTermWidgetData();
   },
   { deep: true },
@@ -166,6 +169,7 @@ watch(
 watch(
   () => conversational.refreshDataConversational,
   (newValue) => {
+    if (!hasBeenVisible.value) return;
     if (newValue) {
       conversational.setIsLoadingConversationalData('dynamicWidgets', true);
       loadSearchTermWidgetData().finally(() => {

--- a/src/components/insights/widgets/conversational/ConversationalToolResult.vue
+++ b/src/components/insights/widgets/conversational/ConversationalToolResult.vue
@@ -71,10 +71,12 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { useRoute } from 'vue-router';
 import { storeToRefs } from 'pinia';
 import { UnnnicDisclaimer } from '@weni/unnnic-system';
+
+import { useLazyData } from '@/composables/useLazyData';
 
 import BaseConversationWidget from '@/components/insights/conversations/BaseConversationWidget.vue';
 import ProgressTable from '@/components/ProgressTable.vue';
@@ -144,15 +146,18 @@ const widgetActions = computed(() => {
   return [deleteOption];
 });
 
-onMounted(() => {
-  if (!shouldUseMock.value) {
-    autoWidgetsStore.loadToolResultData();
-  }
+const { hasBeenVisible } = useLazyData({
+  load: () => {
+    if (!shouldUseMock.value) {
+      autoWidgetsStore.loadToolResultData();
+    }
+  },
 });
 
 watch(
   () => route.query,
   () => {
+    if (!hasBeenVisible.value) return;
     if (!shouldUseMock.value) {
       autoWidgetsStore.loadToolResultData();
     }
@@ -163,6 +168,7 @@ watch(
 watch(
   () => conversational.refreshDataConversational,
   (newValue) => {
+    if (!hasBeenVisible.value) return;
     if (newValue && !shouldUseMock.value) {
       conversational.setIsLoadingConversationalData('dynamicWidgets', true);
       autoWidgetsStore.loadToolResultData().finally(() => {


### PR DESCRIPTION
## Description
### Type of Change
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [x] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
Dashboard widgets were eagerly fetching data on mount regardless of whether they were visible in the viewport. This caused unnecessary API calls on page load, increasing initial load time and backend pressure, especially for widgets that may never be scrolled into view.

### Summary of Changes
A `useLazyData` composable is used across all conversational dashboard widgets to defer data fetching until each widget becomes visible. The `LazyWidget` boundary component is introduced and wraps `DashboardHeader`, `ContactsHeader`, `MostTalkedAboutTopicsWidget`, `AbandonedCartWidget`, and all `ConversationalDynamicWidget` instances in the Conversational dashboard.

Each widget's `onMounted` fetch call has been replaced with `useLazyData({ load: ... })`, and all reactive watchers (route query changes and `refreshDataConversational`) now guard against firing when the widget has not yet been visible, using the `hasBeenVisible` ref returned by the composable.

The eager `autoWidgets.loadAllAutoWidgets()` call during dashboard initialization has been removed, as each auto widget (`ConversationalAgentInvocation`, `ConversationalToolResult`) now loads its own data lazily when it enters the viewport.

Tests have been added to verify that `DashboardHeader` does not fetch data while off-screen and correctly fetches once it becomes visible, that `ConversationalDynamicWidget` is wrapped in a `LazyWidget` boundary, and that `loadAllAutoWidgets` is no longer called eagerly on dashboard init.