### PR TITLE
feat: add operational alerts configuration for live desk monitoring

### DIFF
--- a/src/components/insights/Layout/HeaderFilters/FilterMultiSelect.vue
+++ b/src/components/insights/Layout/HeaderFilters/FilterMultiSelect.vue
@@ -126,7 +126,7 @@ async function fetchSource() {
 
     options.value = (response || []).map((source) => ({
       value: source[props.keyValueField] || source.uuid,
-      label: source.name,
+      label: source.name?.trim() || source.email || '',
     }));
   } catch (e) {
     console.error('getProjectSource error', e);

--- a/src/components/insights/Layout/Headers/HeaderHumanSupport.vue
+++ b/src/components/insights/Layout/Headers/HeaderHumanSupport.vue
@@ -13,6 +13,8 @@
   />
 
   <HumanSupportExport />
+
+  <OperationalAlertsButton v-if="showOperationalAlerts" />
 </template>
 
 <script setup lang="ts">
@@ -23,10 +25,12 @@ import InsightsLayoutHeaderFilters from '../HeaderFilters/index.vue';
 import HumanSupportExport from '../../export/HumanSupportExport.vue';
 import LastUpdatedText from '../HeaderFilters/LastUpdatedText.vue';
 import HeaderRefresh from '../HeaderRefresh.vue';
+import OperationalAlertsButton from '../../humanSupport/Header/OperationalAlertsButton.vue';
 
 import { useHumanSupport } from '@/store/modules/humanSupport/humanSupport';
 import { useDashboards } from '@/store/modules/dashboards';
 import { useProject } from '@/store/modules/project';
+import { useFeatureFlag } from '@/store/modules/featureFlag';
 
 const projectStore = useProject();
 const { hasSectorsConfigured } = storeToRefs(projectStore);
@@ -37,7 +41,13 @@ const { activeTab } = storeToRefs(humanSupportStore);
 const dashboardsStore = useDashboards();
 const { currentDashboardFilters } = storeToRefs(dashboardsStore);
 
+const { isFeatureFlagEnabled } = useFeatureFlag();
+
 const isMonitoring = computed(() => activeTab.value === 'monitoring');
 
 const hasFilters = computed(() => !!currentDashboardFilters.value.length);
+
+const showOperationalAlerts = computed(
+  () => isMonitoring.value && isFeatureFlagEnabled('insightsOperationalAlerts'),
+);
 </script>

--- a/src/components/insights/humanSupport/Header/OperationalAlertsButton.vue
+++ b/src/components/insights/humanSupport/Header/OperationalAlertsButton.vue
@@ -1,0 +1,151 @@
+<template>
+  <section
+    class="operational-alerts-button"
+    data-testid="operational-alerts-button"
+  >
+    <UnnnicPopover
+      :open="isPopoverOpen"
+      @update:open="handlePopoverToggle"
+    >
+      <UnnnicPopoverTrigger>
+        <section class="operational-alerts-button__trigger">
+          <UnnnicButton
+            type="tertiary"
+            size="large"
+            :pressed="isPopoverOpen"
+            iconCenter="more_vert"
+            data-testid="operational-alerts-trigger"
+            :disabled="!hasSectorsConfigured"
+          />
+          <UnnnicTag
+            v-if="!hasOpenedDrawer"
+            class="operational-alerts-button__new-tag"
+            data-testid="operational-alerts-new-tag"
+            :text="$t('operational_alerts.popover.new_tag')"
+            scheme="aux-blue"
+            size="small"
+            type="default"
+          />
+        </section>
+      </UnnnicPopoverTrigger>
+      <UnnnicPopoverContent size="small">
+        <section
+          class="operational-alerts-button__option"
+          data-testid="operational-alerts-option"
+          @click="handleOpenDrawer"
+        >
+          <UnnnicIcon
+            icon="settings"
+            size="sm"
+            scheme="fg-emphasized"
+          />
+          <p class="operational-alerts-button__option-label">
+            {{ $t('operational_alerts.popover.option_label') }}
+          </p>
+        </section>
+      </UnnnicPopoverContent>
+    </UnnnicPopover>
+
+    <OperationalAlertsDrawer
+      v-if="showDrawer"
+      v-model="showDrawer"
+      data-testid="operational-alerts-drawer"
+      @close="handleCloseDrawer"
+    />
+  </section>
+</template>
+
+<script setup lang="ts">
+import {
+  UnnnicButton,
+  UnnnicIcon,
+  UnnnicPopover,
+  UnnnicPopoverTrigger,
+  UnnnicPopoverContent,
+  UnnnicTag,
+} from '@weni/unnnic-system';
+import { onMounted, ref } from 'vue';
+import { storeToRefs } from 'pinia';
+
+import OperationalAlertsDrawer from '../Monitoring/OperationalAlerts/OperationalAlertsDrawer.vue';
+
+import { useMetricGoals } from '@/store/modules/humanSupport/metricGoals';
+import { useProject } from '@/store/modules/project';
+
+const projectStore = useProject();
+const { hasSectorsConfigured } = storeToRefs(projectStore);
+
+const metricGoalsStore = useMetricGoals();
+const { hasSeenPopover, hasOpenedDrawer } = storeToRefs(metricGoalsStore);
+const { loadGoals, setHasSeenPopover, setHasOpenedDrawer } = metricGoalsStore;
+
+const isPopoverOpen = ref(false);
+const showDrawer = ref(false);
+
+const handlePopoverToggle = (open: boolean) => {
+  isPopoverOpen.value = open;
+  if (!open && !hasSeenPopover.value) {
+    setHasSeenPopover(true);
+  }
+};
+
+const handleOpenDrawer = async () => {
+  isPopoverOpen.value = false;
+  setHasSeenPopover(true);
+  try {
+    await loadGoals();
+  } finally {
+    showDrawer.value = true;
+  }
+};
+
+const handleCloseDrawer = () => {
+  showDrawer.value = false;
+  setHasOpenedDrawer(true);
+};
+
+onMounted(() => {
+  if (!hasSeenPopover.value) {
+    isPopoverOpen.value = true;
+  }
+});
+</script>
+
+<style scoped lang="scss">
+.operational-alerts-button {
+  display: flex;
+
+  &__trigger {
+    position: relative;
+    display: inline-flex;
+  }
+
+  &__new-tag {
+    position: absolute;
+    top: 0;
+    left: 50%;
+    z-index: 1;
+    transform: translate(-50%, -50%);
+    pointer-events: none;
+  }
+
+  &__option {
+    display: flex;
+    align-items: center;
+    gap: $unnnic-space-2;
+    padding: $unnnic-space-2;
+    border-radius: $unnnic-radius-1;
+    cursor: pointer;
+
+    &:hover {
+      background-color: $unnnic-color-gray-1;
+    }
+  }
+
+  &__option-label {
+    color: $unnnic-color-fg-emphasized;
+    font: $unnnic-font-emphasis;
+    white-space: nowrap;
+  }
+}
+</style>

--- a/src/components/insights/humanSupport/Header/__tests__/OperationalAlertsButton.spec.js
+++ b/src/components/insights/humanSupport/Header/__tests__/OperationalAlertsButton.spec.js
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createTestingPinia } from '@pinia/testing';
+
+import OperationalAlertsButton from '../OperationalAlertsButton.vue';
+import { useMetricGoals } from '@/store/modules/humanSupport/metricGoals';
+
+vi.mock('@weni/unnnic-system', async (importOriginal) => {
+  const actual = await importOriginal();
+  const slotStub = (name) => ({ name, template: '<div><slot /></div>' });
+  return {
+    ...actual,
+    UnnnicPopover: {
+      name: 'UnnnicPopover',
+      props: ['open'],
+      emits: ['update:open'],
+      template: '<div><slot /></div>',
+    },
+    UnnnicPopoverTrigger: slotStub('UnnnicPopoverTrigger'),
+    UnnnicPopoverContent: slotStub('UnnnicPopoverContent'),
+    UnnnicButton: {
+      name: 'UnnnicButton',
+      props: ['disabled'],
+      template: '<button v-bind="$attrs"><slot /></button>',
+    },
+    UnnnicIcon: { name: 'UnnnicIcon', template: '<i />' },
+    UnnnicTag: {
+      name: 'UnnnicTag',
+      props: ['text'],
+      template: '<span v-bind="$attrs">{{ text }}</span>',
+    },
+  };
+});
+
+const OperationalAlertsDrawerStub = {
+  name: 'OperationalAlertsDrawer',
+  props: ['modelValue'],
+  emits: ['close', 'update:modelValue'],
+  template: '<button class="drawer-close" @click="$emit(\'close\')" />',
+};
+
+const createWrapper = (initialState = {}) => {
+  const wrapper = mount(OperationalAlertsButton, {
+    global: {
+      plugins: [
+        createTestingPinia({
+          createSpy: vi.fn,
+          initialState: {
+            project: { hasSectorsConfigured: true },
+            ...initialState,
+          },
+        }),
+      ],
+      stubs: {
+        OperationalAlertsDrawer: OperationalAlertsDrawerStub,
+      },
+    },
+  });
+
+  const store = useMetricGoals();
+
+  return { wrapper, store };
+};
+
+describe('OperationalAlertsButton.vue', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  it('should not load goals on mount', () => {
+    const { store } = createWrapper();
+    expect(store.loadGoals).not.toHaveBeenCalled();
+  });
+
+  it('should load goals when the drawer option is clicked', async () => {
+    const { wrapper, store } = createWrapper();
+
+    await wrapper
+      .find('[data-testid="operational-alerts-option"]')
+      .trigger('click');
+
+    expect(store.loadGoals).toHaveBeenCalled();
+  });
+
+  it('should render the trigger and the New tag when the drawer was never opened', () => {
+    const { wrapper } = createWrapper();
+    expect(
+      wrapper.find('[data-testid="operational-alerts-trigger"]').exists(),
+    ).toBe(true);
+    expect(
+      wrapper.find('[data-testid="operational-alerts-new-tag"]').exists(),
+    ).toBe(true);
+  });
+
+  it('should hide the New tag once the drawer has been opened', () => {
+    const { wrapper } = createWrapper({
+      metricGoals: { hasOpenedDrawer: true },
+    });
+    expect(
+      wrapper.find('[data-testid="operational-alerts-new-tag"]').exists(),
+    ).toBe(false);
+  });
+
+  it('should open the drawer and mark the popover as seen when the option is clicked', async () => {
+    const { wrapper, store } = createWrapper();
+
+    await wrapper
+      .find('[data-testid="operational-alerts-option"]')
+      .trigger('click');
+
+    expect(store.setHasSeenPopover).toHaveBeenCalledWith(true);
+    expect(wrapper.findComponent(OperationalAlertsDrawerStub).exists()).toBe(
+      true,
+    );
+  });
+
+  it('should open the drawer even when loading goals fails', async () => {
+    const { wrapper, store } = createWrapper();
+    store.loadGoals = vi.fn().mockRejectedValue(new Error('network error'));
+
+    await wrapper
+      .find('[data-testid="operational-alerts-option"]')
+      .trigger('click');
+    await vi.waitFor(() =>
+      expect(
+        wrapper.findComponent(OperationalAlertsDrawerStub).exists(),
+      ).toBe(true),
+    );
+  });
+
+  it('should mark the drawer as opened when it closes', async () => {
+    const { wrapper, store } = createWrapper();
+
+    await wrapper
+      .find('[data-testid="operational-alerts-option"]')
+      .trigger('click');
+    await wrapper.find('.drawer-close').trigger('click');
+
+    expect(store.setHasOpenedDrawer).toHaveBeenCalledWith(true);
+  });
+});

--- a/src/components/insights/humanSupport/Monitoring/OperationalAlerts/OperationalAlertForm.vue
+++ b/src/components/insights/humanSupport/Monitoring/OperationalAlerts/OperationalAlertForm.vue
@@ -1,0 +1,252 @@
+<template>
+  <section
+    class="operational-alert-form"
+    :data-testid="`operational-alert-form-${metric}`"
+  >
+    <section class="operational-alert-form__row">
+      <section
+        class="operational-alert-form__field operational-alert-form__field--threshold"
+      >
+        <UnnnicLabel
+          :label="$t(`operational_alerts.form.threshold_labels.${metric}`)"
+        />
+        <UnnnicInput
+          v-model="thresholdModel"
+          type="number"
+          nativeType="number"
+          :placeholder="$t('operational_alerts.form.threshold_placeholder')"
+          :data-testid="`threshold-input-${metric}`"
+        />
+      </section>
+      <section
+        class="operational-alert-form__field operational-alert-form__field--unit"
+      >
+        <UnnnicLabel :label="$t('operational_alerts.form.unit_label')" />
+        <UnnnicSelect
+          v-model="unitModel"
+          :options="unitOptions"
+          itemLabel="label"
+          itemValue="value"
+          :data-testid="`unit-select-${metric}`"
+        />
+      </section>
+    </section>
+
+    <section class="operational-alert-form__field">
+      <section class="operational-alert-form__email-label">
+        <UnnnicLabel
+          :label="$t('operational_alerts.form.email_notification_label')"
+        />
+        <UnnnicToolTip
+          enabled
+          :text="$t('operational_alerts.form.email_notification_tooltip')"
+          side="right"
+          maxWidth="570px"
+          :data-testid="`email-tooltip-${metric}`"
+        >
+          <UnnnicIcon
+            icon="info"
+            size="sm"
+            scheme="neutral-cloudy"
+          />
+        </UnnnicToolTip>
+      </section>
+
+      <section class="operational-alert-form__row">
+        <section
+          class="operational-alert-form__field operational-alert-form__field--recipients"
+        >
+          <UnnnicLabel
+            :label="$t('operational_alerts.form.send_email_to_label')"
+          />
+          <FilterMultiSelect
+            ref="filterMultiSelectRef"
+            :modelValue="selectedRecipients"
+            source="agents"
+            keyValueField="uuid"
+            :placeholder="
+              $t('operational_alerts.form.send_email_to_placeholder')
+            "
+            :data-testid="`recipients-select-${metric}`"
+            @update:model-value="updateRecipients"
+          />
+          <p class="operational-alert-form__helper">
+            {{ $t('operational_alerts.form.recipients_helper') }}
+          </p>
+        </section>
+
+        <section
+          class="operational-alert-form__field operational-alert-form__field--when"
+        >
+          <UnnnicLabel :label="$t('operational_alerts.form.when_label')" />
+          <UnnnicInput
+            v-model="roomsThresholdModel"
+            type="number"
+            nativeType="number"
+            :placeholder="$t('operational_alerts.form.when_placeholder')"
+            :data-testid="`when-input-${metric}`"
+          />
+          <p class="operational-alert-form__helper">
+            {{ $t('operational_alerts.form.when_helper') }}
+          </p>
+        </section>
+      </section>
+    </section>
+  </section>
+</template>
+
+<script setup lang="ts">
+import {
+  UnnnicLabel,
+  UnnnicInput,
+  UnnnicSelect,
+  UnnnicToolTip,
+  UnnnicIcon,
+} from '@weni/unnnic-system';
+import { computed, ref, useTemplateRef, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import FilterMultiSelect from '@/components/insights/Layout/HeaderFilters/FilterMultiSelect.vue';
+
+import { MetricFormState } from '@/store/modules/humanSupport/metricGoals';
+import {
+  MetricKey,
+  TimeUnit,
+} from '@/services/api/resources/humanSupport/monitoring/metricGoals';
+
+interface RecipientOption {
+  value: string;
+  label: string;
+}
+
+defineProps<{
+  metric: MetricKey;
+}>();
+
+const model = defineModel<MetricFormState>({ required: true });
+
+const { t } = useI18n();
+
+const filterMultiSelectRef = useTemplateRef('filterMultiSelectRef');
+const selectedRecipients = ref<RecipientOption[]>([]);
+
+const unitOptions = computed<{ value: TimeUnit; label: string }[]>(() => [
+  { value: 's', label: t('operational_alerts.form.units.seconds') },
+  { value: 'm', label: t('operational_alerts.form.units.minutes') },
+  { value: 'h', label: t('operational_alerts.form.units.hours') },
+]);
+
+const syncRecipientsFromModel = () => {
+  const loadedOptions = filterMultiSelectRef.value?.options || [];
+  const presetOptions = model.value.recipientOptions || [];
+
+  selectedRecipients.value = model.value.recipients.map((recipientId) => {
+    const fromOptions = loadedOptions.find(
+      (option) => option.value === recipientId,
+    );
+    const fromPreset = presetOptions.find(
+      (option) => option.value === recipientId,
+    );
+    const fromSelected = selectedRecipients.value.find(
+      (option) => option.value === recipientId,
+    );
+
+    return (
+      fromOptions ||
+      fromPreset ||
+      fromSelected || { value: recipientId, label: recipientId }
+    );
+  });
+};
+
+watch(() => model.value.recipients, syncRecipientsFromModel, {
+  immediate: true,
+  deep: true,
+});
+
+watch(() => filterMultiSelectRef.value?.options, syncRecipientsFromModel, {
+  deep: true,
+});
+
+const updateRecipients = (value: RecipientOption[]) => {
+  selectedRecipients.value = value || [];
+  model.value.recipients = selectedRecipients.value.map(
+    (option) => option.value,
+  );
+};
+
+const thresholdModel = computed<string>({
+  get: () =>
+    model.value.threshold === null ? '' : String(model.value.threshold),
+  set: (value) => {
+    const parsed = value === '' ? null : Number(value);
+    model.value.threshold =
+      parsed === null || Number.isNaN(parsed) ? null : parsed;
+  },
+});
+
+const unitModel = computed<TimeUnit>({
+  get: () => model.value.unit,
+  set: (value) => {
+    model.value.unit = value;
+  },
+});
+
+const roomsThresholdModel = computed<string>({
+  get: () =>
+    model.value.roomsThresholdCount === null
+      ? ''
+      : String(model.value.roomsThresholdCount),
+  set: (value) => {
+    const parsed = value === '' ? null : Number(value);
+    model.value.roomsThresholdCount =
+      parsed === null || Number.isNaN(parsed) ? null : parsed;
+  },
+});
+</script>
+
+<style scoped lang="scss">
+.operational-alert-form {
+  display: flex;
+  flex-direction: column;
+  gap: $unnnic-space-4;
+
+  &__row {
+    display: flex;
+    gap: $unnnic-space-4;
+  }
+
+  &__field {
+    display: flex;
+    flex-direction: column;
+
+    &--threshold {
+      flex: 1;
+    }
+
+    &--unit {
+      flex: 1;
+    }
+
+    &--recipients {
+      flex: 1;
+    }
+
+    &--when {
+      flex: 1;
+    }
+  }
+
+  &__email-label {
+    display: flex;
+    align-items: center;
+    gap: $unnnic-space-1;
+  }
+
+  &__helper {
+    margin-top: $unnnic-space-1;
+    color: $unnnic-color-fg-muted;
+    font: $unnnic-font-caption-2;
+  }
+}
+</style>

--- a/src/components/insights/humanSupport/Monitoring/OperationalAlerts/OperationalAlertsDrawer.vue
+++ b/src/components/insights/humanSupport/Monitoring/OperationalAlerts/OperationalAlertsDrawer.vue
@@ -1,0 +1,226 @@
+<template>
+  <UnnnicDrawerNext
+    :open="modelValue"
+    @update:open="handleOpenChange"
+  >
+    <UnnnicDrawerContent
+      class="operational-alerts-drawer"
+      size="extra-large"
+      data-testid="operational-alerts-drawer"
+    >
+      <UnnnicDrawerHeader>
+        <UnnnicDrawerTitle>
+          {{ $t('operational_alerts.drawer.title') }}
+        </UnnnicDrawerTitle>
+        <UnnnicDrawerDescription>
+          {{ $t('operational_alerts.drawer.description') }}
+        </UnnnicDrawerDescription>
+      </UnnnicDrawerHeader>
+
+      <section class="operational-alerts-drawer__body">
+        <section
+          v-for="metric in metricKeys"
+          :key="metric"
+          class="operational-alerts-drawer__section"
+          :data-testid="`operational-alerts-section-${metric}`"
+        >
+          <UnnnicSwitch
+            v-model="formState[metric].enabled"
+            :textRight="$t(`operational_alerts.sections.${metric}`)"
+            :data-testid="`operational-alerts-switch-${metric}`"
+          />
+
+          <template v-if="formState[metric].enabled">
+            <UnnnicDisclaimer
+              v-if="metric === 'first_response_time'"
+              type="informational"
+              :description="$t('operational_alerts.first_response_info')"
+              data-testid="operational-alerts-first-response-info"
+            />
+            <OperationalAlertForm
+              v-model="formState[metric]"
+              :metric="metric"
+            />
+          </template>
+        </section>
+      </section>
+
+      <UnnnicDrawerFooter class="operational-alerts-drawer__footer">
+        <UnnnicDrawerClose>
+          <UnnnicButton
+            class="secondary"
+            type="tertiary"
+            :text="$t('cancel')"
+            :disabled="savingGoals"
+          />
+        </UnnnicDrawerClose>
+        <UnnnicButton
+          class="primary"
+          type="primary"
+          :text="$t('save')"
+          :disabled="!isValid || savingGoals"
+          :loading="savingGoals"
+          @click="handleSave"
+        />
+      </UnnnicDrawerFooter>
+    </UnnnicDrawerContent>
+  </UnnnicDrawerNext>
+</template>
+
+<script setup lang="ts">
+import {
+  UnnnicButton,
+  UnnnicDrawerNext,
+  UnnnicDrawerContent,
+  UnnnicDrawerHeader,
+  UnnnicDrawerTitle,
+  UnnnicDrawerDescription,
+  UnnnicDrawerFooter,
+  UnnnicDrawerClose,
+  UnnnicSwitch,
+  UnnnicDisclaimer,
+  unnnicCallAlert,
+} from '@weni/unnnic-system';
+import { reactive, computed } from 'vue';
+import { storeToRefs } from 'pinia';
+import { useI18n } from 'vue-i18n';
+
+import OperationalAlertForm from './OperationalAlertForm.vue';
+
+import {
+  useMetricGoals,
+  METRIC_KEYS,
+  DEFAULT_ROOMS_THRESHOLD,
+  MetricFormState,
+  OperationalAlertsFormState,
+} from '@/store/modules/humanSupport/metricGoals';
+import {
+  MetricKey,
+  formatRecipientLabel,
+} from '@/services/api/resources/humanSupport/monitoring/metricGoals';
+
+defineProps<{
+  modelValue: boolean;
+}>();
+
+const emit = defineEmits<{
+  (_e: 'close'): void;
+  (_e: 'update:modelValue', _value: boolean): void;
+}>();
+
+const { t } = useI18n();
+
+const metricGoalsStore = useMetricGoals();
+const { savingGoals } = storeToRefs(metricGoalsStore);
+const { getGoalForMetric, saveGoals } = metricGoalsStore;
+
+const metricKeys = METRIC_KEYS;
+
+const buildMetricFormState = (metric: MetricKey): MetricFormState => {
+  const goal = getGoalForMetric(metric);
+
+  if (!goal?.isActive) {
+    return {
+      enabled: false,
+      threshold: null,
+      unit: 'm',
+      recipients: [],
+      roomsThresholdCount: DEFAULT_ROOMS_THRESHOLD,
+    };
+  }
+
+  return {
+    enabled: true,
+    threshold: goal.thresholdValue,
+    unit: goal.unit,
+    recipients: [...goal.recipients],
+    recipientOptions: goal.recipientDetails.map((recipient) => ({
+      value: recipient.uuid,
+      label: formatRecipientLabel(recipient),
+    })),
+    roomsThresholdCount:
+      goal.roomsThresholdCount ?? DEFAULT_ROOMS_THRESHOLD,
+  };
+};
+
+const formState = reactive<OperationalAlertsFormState>({
+  waiting_time: buildMetricFormState('waiting_time'),
+  first_response_time: buildMetricFormState('first_response_time'),
+  conversation_duration: buildMetricFormState('conversation_duration'),
+});
+
+const isValid = computed(() =>
+  metricKeys.every((metric) => {
+    const metricForm = formState[metric];
+    if (!metricForm.enabled) return true;
+    return metricForm.threshold !== null && metricForm.threshold > 0;
+  }),
+);
+
+const handleOpenChange = (open: boolean) => {
+  emit('update:modelValue', open);
+  if (!open) {
+    emit('close');
+  }
+};
+
+const close = () => {
+  emit('update:modelValue', false);
+  emit('close');
+};
+
+const handleSave = async () => {
+  if (!isValid.value) return;
+
+  try {
+    await saveGoals(formState);
+    unnnicCallAlert({
+      props: {
+        text: t('operational_alerts.alerts.save_success'),
+        type: 'success',
+      },
+      seconds: 5,
+    });
+    close();
+  } catch (error) {
+    console.error('Error saving operational alerts:', error);
+    unnnicCallAlert({
+      props: {
+        text: t('operational_alerts.alerts.save_error'),
+        type: 'error',
+      },
+      seconds: 5,
+    });
+  }
+};
+
+defineExpose({ formState });
+</script>
+
+<style lang="scss">
+.operational-alerts-drawer__footer.unnnic-drawer__footer {
+  justify-content: flex-end;
+
+  > * {
+    flex-grow: 0;
+    width: auto;
+  }
+}
+</style>
+
+<style scoped lang="scss">
+.operational-alerts-drawer__body {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: $unnnic-space-6;
+  overflow-y: auto;
+  padding: $unnnic-space-6;
+}
+
+.operational-alerts-drawer__section {
+  display: flex;
+  flex-direction: column;
+  gap: $unnnic-space-4;
+}
+</style>

--- a/src/components/insights/humanSupport/Monitoring/OperationalAlerts/__tests__/OperationalAlertForm.spec.js
+++ b/src/components/insights/humanSupport/Monitoring/OperationalAlerts/__tests__/OperationalAlertForm.spec.js
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+import OperationalAlertForm from '../OperationalAlertForm.vue';
+import Projects from '@/services/api/resources/projects';
+
+vi.mock('@/services/api/resources/projects', () => ({
+  default: {
+    getProjectSource: vi.fn(),
+  },
+}));
+
+const FilterMultiSelectStub = {
+  name: 'FilterMultiSelect',
+  props: ['modelValue', 'source', 'keyValueField', 'placeholder'],
+  emits: ['update:model-value'],
+  template: '<div data-testid="recipients-select-stub" />',
+};
+
+const defaultModel = () => ({
+  enabled: true,
+  threshold: 5,
+  unit: 'm',
+  recipients: [],
+  roomsThresholdCount: 5,
+});
+
+const createWrapper = (modelValue = defaultModel()) => {
+  const wrapper = mount(OperationalAlertForm, {
+    global: {
+      stubs: {
+        FilterMultiSelect: FilterMultiSelectStub,
+      },
+    },
+    props: {
+      metric: 'waiting_time',
+      modelValue,
+      'onUpdate:modelValue': (value) => wrapper.setProps({ modelValue: value }),
+    },
+  });
+
+  return { wrapper };
+};
+
+describe('OperationalAlertForm.vue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Projects.getProjectSource.mockResolvedValue([
+      {
+        uuid: 'agent-1',
+        uuid_project_permission: 'perm-1',
+        name: 'Ana Silva',
+        email: 'ana@example.com',
+      },
+      {
+        uuid: 'agent-2',
+        uuid_project_permission: 'perm-2',
+        name: '',
+        email: 'bob@example.com',
+      },
+    ]);
+  });
+
+  it('should render threshold, unit and recipients fields', () => {
+    const { wrapper } = createWrapper();
+    expect(
+      wrapper.find('[data-testid="threshold-input-waiting_time"]').exists(),
+    ).toBe(true);
+    expect(
+      wrapper.find('[data-testid="unit-select-waiting_time"]').exists(),
+    ).toBe(true);
+    expect(wrapper.findComponent(FilterMultiSelectStub).exists()).toBe(true);
+  });
+
+  it('should load agents through FilterMultiSelect using the agents source', () => {
+    const { wrapper } = createWrapper();
+    const select = wrapper.findComponent(FilterMultiSelectStub);
+
+    expect(select.props('source')).toBe('agents');
+    expect(select.props('keyValueField')).toBe('uuid');
+  });
+
+  it('should update recipients when FilterMultiSelect emits selected agents', async () => {
+    const { wrapper } = createWrapper();
+    const select = wrapper.findComponent(FilterMultiSelectStub);
+
+    await select.vm.$emit('update:model-value', [
+      { value: 'agent-1', label: 'Ana Silva' },
+      { value: 'agent-2', label: 'bob@example.com' },
+    ]);
+
+    expect(wrapper.props('modelValue').recipients).toEqual([
+      'agent-1',
+      'agent-2',
+    ]);
+  });
+
+  it('should always show the when field', async () => {
+    const { wrapper } = createWrapper();
+    expect(
+      wrapper.find('[data-testid="when-input-waiting_time"]').exists(),
+    ).toBe(true);
+  });
+
+  it('should expose the unit options including the default minutes', () => {
+    const { wrapper } = createWrapper();
+    const select = wrapper.findComponent({ name: 'UnnnicSelect' });
+    const optionValues = select.props('options').map((option) => option.value);
+    expect(optionValues).toEqual(['s', 'm', 'h']);
+  });
+});

--- a/src/components/insights/humanSupport/Monitoring/OperationalAlerts/__tests__/OperationalAlertsDrawer.spec.js
+++ b/src/components/insights/humanSupport/Monitoring/OperationalAlerts/__tests__/OperationalAlertsDrawer.spec.js
@@ -1,0 +1,235 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createTestingPinia } from '@pinia/testing';
+
+import OperationalAlertsDrawer from '../OperationalAlertsDrawer.vue';
+import { useMetricGoals } from '@/store/modules/humanSupport/metricGoals';
+import { unnnicCallAlert } from '@weni/unnnic-system';
+
+vi.mock('@weni/unnnic-system', async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, unnnicCallAlert: vi.fn() };
+});
+
+const drawerSlotStub = (name) => ({
+  name,
+  template: '<div><slot /></div>',
+});
+
+const UnnnicDrawerNextStub = {
+  name: 'UnnnicDrawerNext',
+  props: ['open'],
+  emits: ['update:open'],
+  provide() {
+    return {
+      closeOperationalAlertsDrawer: () => this.$emit('update:open', false),
+    };
+  },
+  template: '<div class="drawer-next-stub"><slot /></div>',
+};
+
+const UnnnicDrawerContentStub = {
+  name: 'UnnnicDrawerContent',
+  template: '<div class="drawer-content-stub"><slot /></div>',
+};
+
+const UnnnicDrawerFooterStub = {
+  name: 'UnnnicDrawerFooter',
+  template: '<div class="drawer-footer-stub"><slot /></div>',
+};
+
+const UnnnicDrawerCloseStub = {
+  name: 'UnnnicDrawerClose',
+  inject: {
+    closeOperationalAlertsDrawer: {
+      default: null,
+    },
+  },
+  template:
+    '<div @click="closeOperationalAlertsDrawer && closeOperationalAlertsDrawer()"><slot /></div>',
+};
+
+const UnnnicButtonStub = {
+  name: 'UnnnicButton',
+  props: ['disabled', 'loading', 'text'],
+  emits: ['click'],
+  template:
+    '<button v-bind="$attrs" :disabled="disabled" @click="$emit(\'click\')">{{ text }}</button>',
+};
+
+const UnnnicSwitchStub = {
+  name: 'UnnnicSwitch',
+  props: ['modelValue', 'textRight'],
+  emits: ['update:modelValue'],
+  template:
+    '<button class="switch-stub" @click="$emit(\'update:modelValue\', !modelValue)">{{ textRight }}</button>',
+};
+
+const createWrapper = (goals = {}) => {
+  const wrapper = mount(OperationalAlertsDrawer, {
+    global: {
+      plugins: [createTestingPinia({ createSpy: vi.fn })],
+      stubs: {
+        UnnnicDrawerNext: UnnnicDrawerNextStub,
+        UnnnicDrawerContent: UnnnicDrawerContentStub,
+        UnnnicDrawerHeader: drawerSlotStub('UnnnicDrawerHeader'),
+        UnnnicDrawerTitle: drawerSlotStub('UnnnicDrawerTitle'),
+        UnnnicDrawerDescription: drawerSlotStub('UnnnicDrawerDescription'),
+        UnnnicDrawerFooter: UnnnicDrawerFooterStub,
+        UnnnicDrawerClose: UnnnicDrawerCloseStub,
+        UnnnicButton: UnnnicButtonStub,
+        UnnnicSwitch: UnnnicSwitchStub,
+        UnnnicDisclaimer: true,
+        OperationalAlertForm: true,
+      },
+    },
+    props: { modelValue: true },
+  });
+
+  const store = useMetricGoals();
+  store.getGoalForMetric.mockImplementation((metric) => goals[metric]);
+
+  return { wrapper, store };
+};
+
+describe('OperationalAlertsDrawer.vue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render a section for each metric', () => {
+    const { wrapper } = createWrapper();
+    expect(
+      wrapper
+        .find('[data-testid="operational-alerts-section-waiting_time"]')
+        .exists(),
+    ).toBe(true);
+    expect(
+      wrapper
+        .find('[data-testid="operational-alerts-section-first_response_time"]')
+        .exists(),
+    ).toBe(true);
+    expect(
+      wrapper
+        .find(
+          '[data-testid="operational-alerts-section-conversation_duration"]',
+        )
+        .exists(),
+    ).toBe(true);
+  });
+
+  it('should emit close on cancel button click', async () => {
+    const { wrapper } = createWrapper();
+    await wrapper.find('.secondary').trigger('click');
+    expect(wrapper.emitted('close')).toBeTruthy();
+    expect(wrapper.emitted('update:modelValue')[0]).toEqual([false]);
+  });
+
+  it('should initialize form state from goals loaded before mount', async () => {
+    const waitingGoal = {
+      metric: 'waiting_time',
+      thresholdSeconds: 300,
+      thresholdValue: 5,
+      unit: 'm',
+      isActive: true,
+      emailEnabled: false,
+      recipients: [],
+      recipientDetails: [],
+      roomsThresholdCount: 3,
+    };
+
+    const pinia = createTestingPinia({ createSpy: vi.fn });
+    const store = useMetricGoals(pinia);
+    store.goals = { waiting_time: waitingGoal };
+    store.getGoalForMetric.mockImplementation((metric) => store.goals[metric]);
+
+    const wrapper = mount(OperationalAlertsDrawer, {
+      global: {
+        plugins: [pinia],
+        stubs: {
+          UnnnicDrawerNext: UnnnicDrawerNextStub,
+          UnnnicDrawerContent: UnnnicDrawerContentStub,
+          UnnnicDrawerHeader: drawerSlotStub('UnnnicDrawerHeader'),
+          UnnnicDrawerTitle: drawerSlotStub('UnnnicDrawerTitle'),
+          UnnnicDrawerDescription: drawerSlotStub('UnnnicDrawerDescription'),
+          UnnnicDrawerFooter: UnnnicDrawerFooterStub,
+          UnnnicDrawerClose: UnnnicDrawerCloseStub,
+          UnnnicButton: UnnnicButtonStub,
+          UnnnicSwitch: UnnnicSwitchStub,
+          UnnnicDisclaimer: true,
+          OperationalAlertForm: true,
+        },
+      },
+      props: { modelValue: true },
+    });
+
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.formState.waiting_time).toMatchObject({
+      enabled: true,
+      threshold: 5,
+      unit: 'm',
+      roomsThresholdCount: 3,
+    });
+  });
+
+  it('should not reset form state after mount', async () => {
+    const { wrapper } = createWrapper();
+
+    wrapper.vm.formState.waiting_time.threshold = 99;
+    await wrapper.vm.$nextTick();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.formState.waiting_time.threshold).toBe(99);
+  });
+
+  it('should keep save disabled when an enabled metric has no threshold', async () => {
+    const { wrapper } = createWrapper();
+    await wrapper.findAllComponents(UnnnicSwitchStub)[0].trigger('click');
+    expect(wrapper.find('.primary').attributes('disabled')).toBeDefined();
+  });
+
+  const enableValidWaitingTime = async (wrapper) => {
+    wrapper.vm.formState.waiting_time = {
+      enabled: true,
+      threshold: 5,
+      unit: 'm',
+      recipients: [],
+      roomsThresholdCount: 5,
+    };
+    await wrapper.vm.$nextTick();
+  };
+
+  it('should save and show success alert when valid', async () => {
+    const { wrapper, store } = createWrapper();
+    store.saveGoals.mockResolvedValue(undefined);
+
+    await enableValidWaitingTime(wrapper);
+    await wrapper.find('.primary').trigger('click');
+    await Promise.resolve();
+
+    expect(store.saveGoals).toHaveBeenCalled();
+    expect(unnnicCallAlert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        props: expect.objectContaining({ type: 'success' }),
+      }),
+    );
+  });
+
+  it('should show an error alert when saving fails', async () => {
+    const { wrapper, store } = createWrapper();
+    store.saveGoals.mockRejectedValue(new Error('fail'));
+
+    await enableValidWaitingTime(wrapper);
+    await wrapper.find('.primary').trigger('click');
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(unnnicCallAlert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        props: expect.objectContaining({ type: 'error' }),
+      }),
+    );
+    expect(wrapper.emitted('close')).toBeFalsy();
+  });
+});

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1013,6 +1013,48 @@
     "error_message": "Error disconnecting agent {agent}",
     "tooltip_disabled": "This representative can't be disconnected because they are offline"
   },
+  "operational_alerts": {
+    "alerts": {
+      "save_error": "Operational alerts couldn't be saved due to a technical issue",
+      "save_success": "Operational alerts saved successfully"
+    },
+    "drawer": {
+      "description": "Configure alerts to identify chats that exceed the defined time limits for an operation:",
+      "title": "Operational alerts"
+    },
+    "first_response_info": "Time to first response is counted from the moment the chat is assigned to a representative",
+    "form": {
+      "email_notification_label": "Email notification (optional)",
+      "email_notification_tooltip": "This alert is always displayed in the Live Desk dashboard when a chat reaches the defined threshold.\n\nYou can also configure email notifications for selected moderators and choose when they should be sent - for example, when one or more chats reach the defined threshold.",
+      "recipients_helper": "Only moderators can receive alerts",
+      "send_email_to_label": "Send email to",
+      "send_email_to_placeholder": "Select the moderators",
+      "threshold_labels": {
+        "conversation_duration": "Maximum chat duration",
+        "first_response_time": "Maximum time to first response",
+        "waiting_time": "Maximum wait time"
+      },
+      "threshold_placeholder": "Example: 10",
+      "unit_label": "Unit",
+      "units": {
+        "hours": "Hours",
+        "minutes": "Minutes",
+        "seconds": "Seconds"
+      },
+      "when_helper": "Number of chats with active alerts",
+      "when_label": "When",
+      "when_placeholder": "Example: 5"
+    },
+    "popover": {
+      "new_tag": "New",
+      "option_label": "Operational alerts"
+    },
+    "sections": {
+      "conversation_duration": "Alert in the Live Desk dashboard when a chat's duration exceeds the defined threshold",
+      "first_response_time": "Alert in the Live Desk dashboard when a chat's first response time exceeds the defined threshold",
+      "waiting_time": "Alert in the Live Desk dashboard when a chat's wait time exceeds the defined threshold"
+    }
+  },
   "human_support_dashboard": {
     "title": "Live desk",
     "monitoring": "Monitoring",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1013,6 +1013,48 @@
     "error_message": "Error al desconectar el agente {agent}",
     "tooltip_disabled": "Este representante no puede ser desconectado porque está offline"
   },
+  "operational_alerts": {
+    "alerts": {
+      "save_error": "No se pudieron guardar las alertas operativas debido a un problema técnico",
+      "save_success": "Alertas operativas guardadas con éxito"
+    },
+    "drawer": {
+      "description": "Configura alertas para identificar chats que superan los límites de tiempo definidos para una operación:",
+      "title": "Alertas operativas"
+    },
+    "first_response_info": "El tiempo a la primera respuesta se cuenta desde el momento en que el chat se asigna a un representante",
+    "form": {
+      "email_notification_label": "Notificación por correo (opcional)",
+      "email_notification_tooltip": "Esta alerta siempre se muestra en el dashboard Live Desk cuando un chat alcanza el límite definido.\n\nTambién puedes configurar notificaciones por correo para moderadores seleccionados y elegir cuándo deben enviarse - por ejemplo, cuando uno o más chats alcanzan el límite definido.",
+      "recipients_helper": "Solo los moderadores pueden recibir alertas",
+      "send_email_to_label": "Enviar correo a",
+      "send_email_to_placeholder": "Seleccionar moderadores",
+      "threshold_labels": {
+        "conversation_duration": "Duración máxima del chat",
+        "first_response_time": "Tiempo máximo a la primera respuesta",
+        "waiting_time": "Tiempo máximo de espera"
+      },
+      "threshold_placeholder": "Ejemplo: 10",
+      "unit_label": "Unidad",
+      "units": {
+        "hours": "Horas",
+        "minutes": "Minutos",
+        "seconds": "Segundos"
+      },
+      "when_helper": "Número de chats con alertas activas",
+      "when_label": "Cuándo",
+      "when_placeholder": "Ejemplo: 5"
+    },
+    "popover": {
+      "new_tag": "Nuevo",
+      "option_label": "Alertas operativas"
+    },
+    "sections": {
+      "conversation_duration": "Alertar en el dashboard Live Desk cuando la duración de un chat supera el límite definido",
+      "first_response_time": "Alertar en el dashboard Live Desk cuando el tiempo a la primera respuesta de un chat supera el límite definido",
+      "waiting_time": "Alertar en el dashboard Live Desk cuando el tiempo de espera de un chat supera el límite definido"
+    }
+  },
   "human_support_dashboard": {
     "title": "Live desk",
     "monitoring": "Monitorización",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -1013,6 +1013,48 @@
     "error_message": "Erro ao desconectar o agente {agent}",
     "tooltip_disabled": "Este atendente não pode ser desconectado porque ele não está online"
   },
+  "operational_alerts": {
+    "alerts": {
+      "save_error": "Não foi possível salvar os alertas operacionais devido a um problema técnico",
+      "save_success": "Alertas operacionais salvos com sucesso"
+    },
+    "drawer": {
+      "description": "Configure alertas para identificar chats que ultrapassam os limites de tempo definidos para uma operação:",
+      "title": "Alertas operacionais"
+    },
+    "first_response_info": "O tempo para primeira resposta é contado a partir do momento em que o chat é atribuído a um representante",
+    "form": {
+      "email_notification_label": "Notificação por e-mail (opcional)",
+      "email_notification_tooltip": "Este alerta é sempre exibido no dashboard Live Desk quando um chat atinge o limite definido.\n\nVocê também pode configurar notificações por e-mail para moderadores selecionados e escolher quando elas devem ser enviadas - por exemplo, quando um ou mais chats atingem o limite definido.",
+      "recipients_helper": "Apenas moderadores podem receber alertas",
+      "send_email_to_label": "Enviar e-mail para",
+      "send_email_to_placeholder": "Selecionar moderadores",
+      "threshold_labels": {
+        "conversation_duration": "Duração máxima do chat",
+        "first_response_time": "Tempo máximo para primeira resposta",
+        "waiting_time": "Tempo máximo de espera"
+      },
+      "threshold_placeholder": "Exemplo: 10",
+      "unit_label": "Unidade",
+      "units": {
+        "hours": "Horas",
+        "minutes": "Minutos",
+        "seconds": "Segundos"
+      },
+      "when_helper": "Número de chats com alertas ativos",
+      "when_label": "Quando",
+      "when_placeholder": "Exemplo: 5"
+    },
+    "popover": {
+      "new_tag": "Novo",
+      "option_label": "Alertas operacionais"
+    },
+    "sections": {
+      "conversation_duration": "Alertar no dashboard Live Desk quando a duração de um chat ultrapassa o limite definido",
+      "first_response_time": "Alertar no dashboard Live Desk quando o tempo para primeira resposta de um chat ultrapassa o limite definido",
+      "waiting_time": "Alertar no dashboard Live Desk quando o tempo de espera de um chat ultrapassa o limite definido"
+    }
+  },
   "human_support_dashboard": {
     "title": "Live desk",
     "monitoring": "Monitoramento",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -1003,6 +1003,48 @@
     "error_message": "Eroare la deconectarea agentului {agent}",
     "tooltip_disabled": "Acest reprezentant nu poate fi deconectat deoarece este offline"
   },
+  "operational_alerts": {
+    "alerts": {
+      "save_error": "Alertele operaționale nu au putut fi salvate din cauza unei probleme tehnice",
+      "save_success": "Alerte operaționale salvate cu succes"
+    },
+    "drawer": {
+      "description": "Configure alertele pentru a identifica conversațiile care depășesc limitele de timp definite pentru o operațiune:",
+      "title": "Alerte operaționale"
+    },
+    "first_response_info": "Timpul până la primul răspuns este calculat din momentul în care conversația este atribuită unui reprezentant",
+    "form": {
+      "email_notification_label": "Notificare prin e-mail (opțional)",
+      "email_notification_tooltip": "Această alertă este afișată întotdeauna în dashboard-ul Live Desk când o conversație atinge limita definită.\n\nPoți configura și notificări prin e-mail pentru moderatorii selectați și poți alege când trebuie trimise - de exemplu, când una sau mai multe conversații ating limita definită.",
+      "recipients_helper": "Doar moderatorii pot primi alerte",
+      "send_email_to_label": "Trimite e-mail către",
+      "send_email_to_placeholder": "Selectează moderatorii",
+      "threshold_labels": {
+        "conversation_duration": "Durata maximă a conversației",
+        "first_response_time": "Timp maxim până la primul răspuns",
+        "waiting_time": "Timp maxim de așteptare"
+      },
+      "threshold_placeholder": "Exemplu: 10",
+      "unit_label": "Unitate",
+      "units": {
+        "hours": "Ore",
+        "minutes": "Minute",
+        "seconds": "Secunde"
+      },
+      "when_helper": "Numărul de conversații cu alerte active",
+      "when_label": "Când",
+      "when_placeholder": "Exemplu: 5"
+    },
+    "popover": {
+      "new_tag": "Nou",
+      "option_label": "Alerte operaționale"
+    },
+    "sections": {
+      "conversation_duration": "Alertă în dashboard-ul Live Desk când durata unei conversații depășește limita definită",
+      "first_response_time": "Alertă în dashboard-ul Live Desk când timpul până la primul răspuns al unei conversații depășește limita definită",
+      "waiting_time": "Alertă în dashboard-ul Live Desk când timpul de așteptare al unei conversații depășește limita definită"
+    }
+  },
   "human_support_dashboard": {
     "title": "Asistență umană",
     "monitoring": "Monitorizare",

--- a/src/services/api/resources/humanSupport/monitoring/__tests__/metricGoals.spec.js
+++ b/src/services/api/resources/humanSupport/monitoring/__tests__/metricGoals.spec.js
@@ -1,0 +1,226 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+
+import metricGoalsService from '../metricGoals';
+import chatsHttp from '@/services/api/chatsHttp';
+import { useConfig } from '@/store/modules/config';
+
+vi.mock('@/services/api/chatsHttp', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock('@/store/modules/config', () => ({
+  useConfig: vi.fn(),
+}));
+
+describe('metricGoalsService', () => {
+  const mockProjectUuid = 'test-project-uuid';
+  const mockApiError = new Error('Network Error');
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setActivePinia(createPinia());
+    useConfig.mockReturnValue({ project: { uuid: mockProjectUuid } });
+  });
+
+  describe('getMetricGoals', () => {
+    it('should fetch and normalize goals from the API response', async () => {
+      const apiGoals = [
+        {
+          metric: 'waiting_time',
+          threshold_seconds: 600,
+          threshold_value: 10,
+          unit: 'm',
+          is_active: true,
+          email_enabled: true,
+          recipients: [
+            {
+              uuid: 'user-1',
+              first_name: 'Marcus',
+              last_name: 'L S',
+              email: 'marcus@example.com',
+            },
+          ],
+          rooms_threshold_count: 5,
+          rooms_threshold_percent: null,
+        },
+      ];
+      chatsHttp.get.mockResolvedValue({ goals: apiGoals });
+
+      const result = await metricGoalsService.getMetricGoals();
+
+      expect(chatsHttp.get).toHaveBeenCalledWith(
+        `project/${mockProjectUuid}/metric-goals/`,
+      );
+      expect(result).toEqual({
+        goals: [
+          {
+            metric: 'waiting_time',
+            thresholdSeconds: 600,
+            thresholdValue: 10,
+            unit: 'm',
+            isActive: true,
+            emailEnabled: true,
+            recipients: ['user-1'],
+            recipientDetails: [
+              {
+                uuid: 'user-1',
+                firstName: 'Marcus',
+                lastName: 'L S',
+                email: 'marcus@example.com',
+              },
+            ],
+            roomsThresholdCount: 5,
+          },
+        ],
+      });
+    });
+
+    it('should normalize recipients from uuid_project_permission objects', async () => {
+      chatsHttp.get.mockResolvedValue({
+        goals: [
+          {
+            metric: 'waiting_time',
+            threshold_seconds: 3600,
+            threshold_value: 1,
+            unit: 'h',
+            is_active: true,
+            email_enabled: true,
+            recipients: [{ uuid_project_permission: 'perm-1' }],
+            rooms_threshold_count: 2,
+          },
+        ],
+      });
+
+      const result = await metricGoalsService.getMetricGoals();
+
+      expect(result.goals[0]).toEqual({
+        metric: 'waiting_time',
+        thresholdSeconds: 3600,
+        thresholdValue: 1,
+        unit: 'h',
+        isActive: true,
+        emailEnabled: true,
+        recipients: ['perm-1'],
+        recipientDetails: [{ uuid: 'perm-1' }],
+        roomsThresholdCount: 2,
+      });
+    });
+
+    it('should default goals to an empty array when missing', async () => {
+      chatsHttp.get.mockResolvedValue({});
+      const result = await metricGoalsService.getMetricGoals();
+      expect(result).toEqual({ goals: [] });
+    });
+
+    it('should propagate API errors', async () => {
+      chatsHttp.get.mockRejectedValue(mockApiError);
+      await expect(metricGoalsService.getMetricGoals()).rejects.toThrow(
+        'Network Error',
+      );
+    });
+  });
+
+  describe('saveMetricGoal', () => {
+    it('should POST the payload to the metric endpoint', async () => {
+      const params = {
+        threshold: 10,
+        unit: 'm',
+        isActive: true,
+        emailEnabled: true,
+        recipients: ['perm-1'],
+        roomsThresholdCount: 5,
+      };
+      const mockResponse = {
+        metric: 'first_response_time',
+        threshold_seconds: 600,
+        threshold_value: 10,
+        unit: 'm',
+        is_active: true,
+        email_enabled: true,
+        recipients: [
+          {
+            uuid: 'perm-1',
+            first_name: 'Alan',
+            last_name: 'Vale',
+            email: 'alan@example.com',
+          },
+        ],
+        rooms_threshold_count: 5,
+      };
+      chatsHttp.post.mockResolvedValue(mockResponse);
+
+      const result = await metricGoalsService.saveMetricGoal(
+        'first_response_time',
+        params,
+      );
+
+      expect(chatsHttp.post).toHaveBeenCalledWith(
+        `project/${mockProjectUuid}/metric-goals/first_response_time/`,
+        {
+          threshold: 10,
+          unit: 'm',
+          is_active: true,
+          email_enabled: true,
+          recipients: [{ uuid_project_permission: 'perm-1' }],
+          rooms_threshold_count: 5,
+        },
+      );
+      expect(result).toEqual({
+        metric: 'first_response_time',
+        thresholdSeconds: 600,
+        thresholdValue: 10,
+        unit: 'm',
+        isActive: true,
+        emailEnabled: true,
+        recipients: ['perm-1'],
+        recipientDetails: [
+          {
+            uuid: 'perm-1',
+            firstName: 'Alan',
+            lastName: 'Vale',
+            email: 'alan@example.com',
+          },
+        ],
+        roomsThresholdCount: 5,
+      });
+    });
+
+    it('should propagate API errors', async () => {
+      chatsHttp.post.mockRejectedValue(mockApiError);
+      await expect(
+        metricGoalsService.saveMetricGoal('waiting_time', {
+          threshold: 1,
+          unit: 'm',
+          isActive: true,
+          emailEnabled: false,
+          recipients: [],
+          roomsThresholdCount: 0,
+        }),
+      ).rejects.toThrow('Network Error');
+    });
+  });
+
+  describe('deleteMetricGoal', () => {
+    it('should DELETE the metric endpoint', async () => {
+      chatsHttp.delete.mockResolvedValue(undefined);
+
+      await metricGoalsService.deleteMetricGoal('conversation_duration');
+
+      expect(chatsHttp.delete).toHaveBeenCalledWith(
+        `project/${mockProjectUuid}/metric-goals/conversation_duration/`,
+      );
+    });
+
+    it('should propagate API errors', async () => {
+      chatsHttp.delete.mockRejectedValue(mockApiError);
+      await expect(
+        metricGoalsService.deleteMetricGoal('waiting_time'),
+      ).rejects.toThrow('Network Error');
+    });
+  });
+});

--- a/src/services/api/resources/humanSupport/monitoring/metricGoals.ts
+++ b/src/services/api/resources/humanSupport/monitoring/metricGoals.ts
@@ -1,0 +1,271 @@
+import chatsHttp from '@/services/api/chatsHttp';
+import { useConfig } from '@/store/modules/config';
+
+type MetricKey =
+  | 'waiting_time'
+  | 'first_response_time'
+  | 'conversation_duration';
+
+type TimeUnit = 's' | 'm' | 'h';
+
+interface MetricGoalBreach {
+  thresholdSeconds: number;
+  thresholdValue: number;
+  unit: TimeUnit;
+  isBreached: boolean;
+  breachedRoomsCount: number;
+}
+
+interface MetricGoalRecipientApi {
+  uuid: string;
+  first_name?: string;
+  last_name?: string;
+  email?: string;
+  uuid_project_permission?: string;
+}
+
+interface MetricGoalRecipientApiPayload {
+  uuid_project_permission: string;
+}
+
+interface MetricGoalApi {
+  metric: MetricKey;
+  threshold_seconds?: number;
+  threshold_value?: number;
+  threshold?: number;
+  unit: TimeUnit;
+  is_active: boolean;
+  email_enabled: boolean;
+  recipients: MetricGoalRecipientApi[] | MetricGoalRecipientApiPayload[] | string[];
+  rooms_threshold_count: number;
+  rooms_threshold_percent?: number | null;
+}
+
+interface MetricGoalRecipientDetail {
+  uuid: string;
+  firstName?: string;
+  lastName?: string;
+  email?: string;
+}
+
+interface MetricGoal {
+  metric: MetricKey;
+  thresholdSeconds: number;
+  thresholdValue: number;
+  unit: TimeUnit;
+  isActive: boolean;
+  emailEnabled: boolean;
+  recipients: string[];
+  recipientDetails: MetricGoalRecipientDetail[];
+  roomsThresholdCount: number;
+}
+
+interface MetricGoalsResponse {
+  goals: MetricGoal[];
+}
+
+interface MetricGoalSaveParams {
+  threshold: number;
+  unit: TimeUnit;
+  isActive: boolean;
+  emailEnabled: boolean;
+  roomsThresholdCount: number;
+  recipients: string[];
+}
+
+interface MetricGoalSavePayload {
+  threshold: number;
+  unit: TimeUnit;
+  is_active: boolean;
+  email_enabled: boolean;
+  rooms_threshold_count: number;
+  recipients: MetricGoalRecipientApiPayload[];
+}
+
+const UNIT_SECONDS: Record<TimeUnit, number> = {
+  s: 1,
+  m: 60,
+  h: 3600,
+};
+
+const thresholdToSeconds = (threshold: number, unit: TimeUnit): number =>
+  Math.round(threshold * UNIT_SECONDS[unit]);
+
+const formatRecipientLabel = (recipient: MetricGoalRecipientDetail): string => {
+  const name = [recipient.firstName, recipient.lastName]
+    .filter(Boolean)
+    .join(' ')
+    .trim();
+
+  return name || recipient.email || recipient.uuid;
+};
+
+const normalizeRecipientId = (
+  recipient: MetricGoalRecipientApi | MetricGoalRecipientApiPayload | string,
+): string => {
+  if (typeof recipient === 'string') return recipient;
+
+  if ('uuid' in recipient) {
+    return recipient.uuid || recipient.uuid_project_permission || '';
+  }
+
+  return recipient.uuid_project_permission || '';
+};
+
+const normalizeRecipientDetail = (
+  recipient: MetricGoalRecipientApi | MetricGoalRecipientApiPayload | string,
+): MetricGoalRecipientDetail | null => {
+  if (typeof recipient === 'string') {
+    return { uuid: recipient };
+  }
+
+  const uuid = normalizeRecipientId(recipient);
+  if (!uuid) return null;
+
+  if (
+    'first_name' in recipient ||
+    'last_name' in recipient ||
+    'email' in recipient
+  ) {
+    return {
+      uuid,
+      firstName: recipient.first_name,
+      lastName: recipient.last_name,
+      email: recipient.email,
+    };
+  }
+
+  return { uuid };
+};
+
+const resolveThresholdSeconds = (goal: MetricGoalApi): number => {
+  if (goal.threshold_seconds !== undefined && goal.threshold_seconds !== null) {
+    return goal.threshold_seconds;
+  }
+
+  const thresholdValue = goal.threshold_value ?? goal.threshold ?? 0;
+  return thresholdToSeconds(thresholdValue, goal.unit);
+};
+
+const resolveThresholdValue = (
+  goal: MetricGoalApi,
+  thresholdSeconds: number,
+): number => {
+  if (goal.threshold_value !== undefined && goal.threshold_value !== null) {
+    return goal.threshold_value;
+  }
+
+  if (goal.threshold !== undefined && goal.threshold !== null) {
+    return goal.threshold;
+  }
+
+  if (goal.unit === 'h' && thresholdSeconds % 3600 === 0) {
+    return thresholdSeconds / 3600;
+  }
+
+  if (goal.unit === 'm' && thresholdSeconds % 60 === 0) {
+    return thresholdSeconds / 60;
+  }
+
+  if (goal.unit === 's') {
+    return thresholdSeconds;
+  }
+
+  return thresholdSeconds / UNIT_SECONDS[goal.unit];
+};
+
+const normalizeGoal = (goal: MetricGoalApi): MetricGoal => {
+  const thresholdSeconds = resolveThresholdSeconds(goal);
+  const recipientDetails = (goal.recipients || [])
+    .map(normalizeRecipientDetail)
+    .filter((recipient): recipient is MetricGoalRecipientDetail => !!recipient);
+
+  return {
+    metric: goal.metric,
+    thresholdSeconds,
+    thresholdValue: resolveThresholdValue(goal, thresholdSeconds),
+    unit: goal.unit,
+    isActive: goal.is_active,
+    emailEnabled: goal.email_enabled,
+    recipients: recipientDetails.map((recipient) => recipient.uuid),
+    recipientDetails,
+    roomsThresholdCount: goal.rooms_threshold_count,
+  };
+};
+
+const toSavePayload = (params: MetricGoalSaveParams): MetricGoalSavePayload => ({
+  threshold: params.threshold,
+  unit: params.unit,
+  is_active: params.isActive,
+  email_enabled: params.emailEnabled,
+  rooms_threshold_count: params.roomsThresholdCount,
+  recipients: params.recipients.map((permissionUuid) => ({
+    uuid_project_permission: permissionUuid,
+  })),
+});
+
+const extractGoalsFromResponse = (
+  response:
+    | MetricGoalApi[]
+    | { goals?: MetricGoalApi[]; results?: MetricGoalApi[] },
+): MetricGoalApi[] => {
+  if (Array.isArray(response)) return response;
+  if (Array.isArray(response?.goals)) return response.goals;
+  if (Array.isArray(response?.results)) return response.results;
+  return [];
+};
+
+const metricGoalsPath = (projectUuid: string, metric?: MetricKey): string => {
+  const base = `project/${projectUuid}/metric-goals/`;
+  return metric ? `${base}${metric}/` : base;
+};
+
+export default {
+  async getMetricGoals(): Promise<MetricGoalsResponse> {
+    const { project } = useConfig();
+
+    const response = (await chatsHttp.get(metricGoalsPath(project.uuid))) as
+      | MetricGoalApi[]
+      | {
+          goals?: MetricGoalApi[];
+          results?: MetricGoalApi[];
+        };
+
+    const goals = extractGoalsFromResponse(response).map(normalizeGoal);
+
+    return { goals };
+  },
+
+  async saveMetricGoal(
+    metric: MetricKey,
+    params: MetricGoalSaveParams,
+  ): Promise<MetricGoal> {
+    const { project } = useConfig();
+
+    const response = (await chatsHttp.post(
+      metricGoalsPath(project.uuid, metric),
+      toSavePayload(params),
+    )) as MetricGoalApi;
+
+    return normalizeGoal(response);
+  },
+
+  async deleteMetricGoal(metric: MetricKey): Promise<void> {
+    const { project } = useConfig();
+
+    await chatsHttp.delete(metricGoalsPath(project.uuid, metric));
+  },
+};
+
+export type {
+  MetricGoal,
+  MetricGoalApi,
+  MetricGoalBreach,
+  MetricGoalRecipientDetail,
+  MetricGoalSaveParams,
+  MetricKey,
+  TimeUnit,
+  MetricGoalsResponse,
+};
+
+export { formatRecipientLabel };

--- a/src/store/modules/humanSupport/__tests__/metricGoals.unit.spec.js
+++ b/src/store/modules/humanSupport/__tests__/metricGoals.unit.spec.js
@@ -1,0 +1,235 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+
+import { useMetricGoals } from '../metricGoals';
+import MetricGoalsService from '@/services/api/resources/humanSupport/monitoring/metricGoals';
+import { useConfig } from '@/store/modules/config';
+import { moduleStorage } from '@/utils/storage';
+
+vi.mock('@/services/api/resources/humanSupport/monitoring/metricGoals', () => ({
+  default: {
+    getMetricGoals: vi.fn(),
+    saveMetricGoal: vi.fn(),
+    deleteMetricGoal: vi.fn(),
+  },
+}));
+
+vi.mock('@/store/modules/config', () => ({
+  useConfig: vi.fn(),
+}));
+
+const waitingGoal = {
+  metric: 'waiting_time',
+  thresholdSeconds: 300,
+  thresholdValue: 5,
+  unit: 'm',
+  isActive: true,
+  emailEnabled: false,
+  recipients: [],
+  recipientDetails: [],
+  roomsThresholdCount: 0,
+};
+
+describe('useMetricGoals Store', () => {
+  let store;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    localStorage.clear();
+    vi.clearAllMocks();
+    useConfig.mockReturnValue({ project: { uuid: 'project-1' } });
+    store = useMetricGoals();
+  });
+
+  describe('loadGoals', () => {
+    it('should load goals into a map keyed by metric', async () => {
+      MetricGoalsService.getMetricGoals.mockResolvedValue({
+        goals: [waitingGoal],
+      });
+
+      await store.loadGoals();
+
+      expect(store.goals.waiting_time).toEqual(waitingGoal);
+      expect(store.hasLoadedGoals).toBe(true);
+      expect(store.hasConfiguredGoals).toBe(true);
+    });
+
+    it('should throw when loading goals fails', async () => {
+      MetricGoalsService.getMetricGoals.mockRejectedValue(new Error('fail'));
+
+      await expect(store.loadGoals()).rejects.toThrow('fail');
+      expect(store.goals).toEqual({});
+      expect(store.hasLoadedGoals).toBe(true);
+    });
+  });
+
+  describe('saveGoals', () => {
+    const buildFormState = (overrides = {}) => ({
+      waiting_time: {
+        enabled: false,
+        threshold: null,
+        unit: 'm',
+        recipients: [],
+        roomsThresholdCount: 5,
+      },
+      first_response_time: {
+        enabled: false,
+        threshold: null,
+        unit: 'm',
+        recipients: [],
+        roomsThresholdCount: 5,
+      },
+      conversation_duration: {
+        enabled: false,
+        threshold: null,
+        unit: 'm',
+        recipients: [],
+        roomsThresholdCount: 5,
+      },
+      ...overrides,
+    });
+
+    beforeEach(() => {
+      MetricGoalsService.getMetricGoals.mockResolvedValue({ goals: [] });
+    });
+
+    it('should POST enabled metrics with threshold and unit', async () => {
+      MetricGoalsService.saveMetricGoal.mockResolvedValue({});
+
+      await store.saveGoals(
+        buildFormState({
+          waiting_time: {
+            enabled: true,
+            threshold: 5,
+            unit: 'm',
+            recipients: [],
+            roomsThresholdCount: 5,
+          },
+        }),
+      );
+
+      expect(MetricGoalsService.saveMetricGoal).toHaveBeenCalledWith(
+        'waiting_time',
+        {
+          threshold: 5,
+          unit: 'm',
+          isActive: true,
+          emailEnabled: false,
+          recipients: [],
+          roomsThresholdCount: 0,
+        },
+      );
+    });
+
+    it('should include recipients and rooms_threshold_count when email enabled', async () => {
+      MetricGoalsService.saveMetricGoal.mockResolvedValue({});
+
+      await store.saveGoals(
+        buildFormState({
+          first_response_time: {
+            enabled: true,
+            threshold: 2,
+            unit: 'h',
+            recipients: ['perm-1', 'perm-2'],
+            roomsThresholdCount: 3,
+          },
+        }),
+      );
+
+      expect(MetricGoalsService.saveMetricGoal).toHaveBeenCalledWith(
+        'first_response_time',
+        {
+          threshold: 2,
+          unit: 'h',
+          isActive: true,
+          emailEnabled: true,
+          recipients: ['perm-1', 'perm-2'],
+          roomsThresholdCount: 3,
+        },
+      );
+    });
+
+    it('should preserve rooms_threshold_count of 0 when email enabled', async () => {
+      MetricGoalsService.saveMetricGoal.mockResolvedValue({});
+
+      await store.saveGoals(
+        buildFormState({
+          first_response_time: {
+            enabled: true,
+            threshold: 2,
+            unit: 'h',
+            recipients: ['perm-1'],
+            roomsThresholdCount: 0,
+          },
+        }),
+      );
+
+      expect(MetricGoalsService.saveMetricGoal).toHaveBeenCalledWith(
+        'first_response_time',
+        expect.objectContaining({
+          emailEnabled: true,
+          roomsThresholdCount: 0,
+        }),
+      );
+    });
+
+    it('should DELETE metrics that were disabled but previously configured', async () => {
+      MetricGoalsService.getMetricGoals.mockResolvedValue({
+        goals: [waitingGoal],
+      });
+      await store.loadGoals();
+
+      MetricGoalsService.deleteMetricGoal.mockResolvedValue(undefined);
+      MetricGoalsService.getMetricGoals.mockResolvedValue({ goals: [] });
+
+      await store.saveGoals(buildFormState());
+
+      expect(MetricGoalsService.deleteMetricGoal).toHaveBeenCalledWith(
+        'waiting_time',
+      );
+    });
+
+    it('should throw when reload fails after save', async () => {
+      MetricGoalsService.saveMetricGoal.mockResolvedValue({});
+      MetricGoalsService.getMetricGoals.mockRejectedValue(new Error('reload fail'));
+
+      await expect(
+        store.saveGoals(
+          buildFormState({
+            waiting_time: {
+              enabled: true,
+              threshold: 5,
+              unit: 'm',
+              recipients: [],
+              roomsThresholdCount: 5,
+            },
+          }),
+        ),
+      ).rejects.toThrow('reload fail');
+    });
+
+    it('should not call save or delete for untouched disabled metrics', async () => {
+      await store.saveGoals(buildFormState());
+      expect(MetricGoalsService.saveMetricGoal).not.toHaveBeenCalled();
+      expect(MetricGoalsService.deleteMetricGoal).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('popover persistence', () => {
+    it('should persist hasSeenPopover scoped to the project', () => {
+      store.setHasSeenPopover(true);
+      expect(store.hasSeenPopover).toBe(true);
+      expect(
+        moduleStorage.getItem('operational_alerts_seen_popover_project-1'),
+      ).toBe(true);
+    });
+
+    it('should persist hasOpenedDrawer scoped to the project', () => {
+      store.setHasOpenedDrawer(true);
+      expect(store.hasOpenedDrawer).toBe(true);
+      expect(
+        moduleStorage.getItem('operational_alerts_opened_drawer_project-1'),
+      ).toBe(true);
+    });
+  });
+});

--- a/src/store/modules/humanSupport/metricGoals.ts
+++ b/src/store/modules/humanSupport/metricGoals.ts
@@ -1,0 +1,152 @@
+import { defineStore } from 'pinia';
+import { computed, ref } from 'vue';
+
+import MetricGoalsService from '@/services/api/resources/humanSupport/monitoring/metricGoals';
+import {
+  MetricGoal,
+  MetricKey,
+  TimeUnit,
+} from '@/services/api/resources/humanSupport/monitoring/metricGoals';
+
+import { useConfig } from '@/store/modules/config';
+import { moduleStorage } from '@/utils/storage';
+
+const SEEN_POPOVER_KEY = 'operational_alerts_seen_popover';
+const OPENED_DRAWER_KEY = 'operational_alerts_opened_drawer';
+
+const DEFAULT_ROOMS_THRESHOLD = 5;
+
+export { DEFAULT_ROOMS_THRESHOLD };
+
+export const METRIC_KEYS: MetricKey[] = [
+  'waiting_time',
+  'first_response_time',
+  'conversation_duration',
+];
+
+interface MetricFormState {
+  enabled: boolean;
+  threshold: number | null;
+  unit: TimeUnit;
+  recipients: string[];
+  recipientOptions?: { value: string; label: string }[];
+  roomsThresholdCount: number | null;
+}
+
+type OperationalAlertsFormState = Record<MetricKey, MetricFormState>;
+
+const projectStorageKey = (key: string): string => {
+  const { project } = useConfig();
+  const projectUuid = project?.uuid || moduleStorage.getItem('projectUuid');
+  return projectUuid ? `${key}_${projectUuid}` : key;
+};
+
+export const useMetricGoals = defineStore('metricGoals', () => {
+  const goals = ref<Partial<Record<MetricKey, MetricGoal>>>({});
+
+  const loadingGoals = ref(false);
+  const savingGoals = ref(false);
+  const hasLoadedGoals = ref(false);
+
+  const hasSeenPopover = ref<boolean>(
+    !!moduleStorage.getItem(projectStorageKey(SEEN_POPOVER_KEY)),
+  );
+  const hasOpenedDrawer = ref<boolean>(
+    !!moduleStorage.getItem(projectStorageKey(OPENED_DRAWER_KEY)),
+  );
+
+  const hasConfiguredGoals = computed(() =>
+    METRIC_KEYS.some((metric) => !!goals.value[metric]),
+  );
+
+  const getGoalForMetric = (metric: MetricKey): MetricGoal | undefined =>
+    goals.value[metric];
+
+  const setHasSeenPopover = (value: boolean) => {
+    hasSeenPopover.value = value;
+    moduleStorage.setItem(projectStorageKey(SEEN_POPOVER_KEY), value);
+  };
+
+  const setHasOpenedDrawer = (value: boolean) => {
+    hasOpenedDrawer.value = value;
+    moduleStorage.setItem(projectStorageKey(OPENED_DRAWER_KEY), value);
+  };
+
+  const loadGoals = async () => {
+    try {
+      loadingGoals.value = true;
+      const { goals: loadedGoals } = await MetricGoalsService.getMetricGoals();
+
+      goals.value = loadedGoals.reduce(
+        (acc, goal) => {
+          acc[goal.metric] = goal;
+          return acc;
+        },
+        {} as Partial<Record<MetricKey, MetricGoal>>,
+      );
+    } catch (error) {
+      console.error('Error loading metric goals:', error);
+      throw error;
+    } finally {
+      hasLoadedGoals.value = true;
+      loadingGoals.value = false;
+    }
+  };
+
+  const saveGoals = async (formState: OperationalAlertsFormState) => {
+    savingGoals.value = true;
+    try {
+      const requests: Promise<unknown>[] = [];
+
+      METRIC_KEYS.forEach((metric) => {
+        const metricForm = formState[metric];
+        const hasExistingGoal = !!goals.value[metric];
+
+        const isValid =
+          metricForm?.enabled &&
+          metricForm.threshold !== null &&
+          metricForm.threshold > 0;
+
+        if (isValid) {
+          const emailEnabled = metricForm.recipients.length > 0;
+          requests.push(
+            MetricGoalsService.saveMetricGoal(metric, {
+              threshold: metricForm.threshold as number,
+              unit: metricForm.unit,
+              isActive: true,
+              emailEnabled,
+              recipients: emailEnabled ? metricForm.recipients : [],
+              roomsThresholdCount: emailEnabled
+                ? (metricForm.roomsThresholdCount ?? DEFAULT_ROOMS_THRESHOLD)
+                : 0,
+            }),
+          );
+        } else if (hasExistingGoal) {
+          requests.push(MetricGoalsService.deleteMetricGoal(metric));
+        }
+      });
+
+      await Promise.all(requests);
+      await loadGoals();
+    } finally {
+      savingGoals.value = false;
+    }
+  };
+
+  return {
+    goals,
+    loadingGoals,
+    savingGoals,
+    hasLoadedGoals,
+    hasSeenPopover,
+    hasOpenedDrawer,
+    hasConfiguredGoals,
+    getGoalForMetric,
+    setHasSeenPopover,
+    setHasOpenedDrawer,
+    loadGoals,
+    saveGoals,
+  };
+});
+
+export type { MetricFormState, OperationalAlertsFormState };


### PR DESCRIPTION
## Description
### Type of Change
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
Introduces Operational Alerts for the Live Desk monitoring tab, allowing users to configure time-based threshold alerts for waiting time, first response time, and conversation duration. The feature is gated behind the `insightsOperationalAlerts` feature flag.

### Summary of Changes

- Added an `OperationalAlertsButton` component to the Human Support header that renders only when the monitoring tab is active and the feature flag is enabled. The button shows a popover with a "New" badge until the user opens the drawer for the first time.
- Added an `OperationalAlertsDrawer` component that allows users to enable/disable alerts per metric, configure thresholds with time units (seconds, minutes, hours), and optionally set up email notifications for moderators including a rooms threshold count.
- Added an `OperationalAlertForm` component used within the drawer for each metric, integrating the existing `FilterMultiSelect` to select moderator recipients via the agents source.
- Added a `metricGoals` Pinia store that manages loading, saving, and deleting metric goals, as well as persisting popover/drawer interaction state to local storage scoped by project UUID.
- Added a `metricGoals` API service with `getMetricGoals`, `saveMetricGoal`, and `deleteMetricGoal` methods, including normalization logic for recipient shapes and threshold value resolution.
- Fixed `FilterMultiSelect` label resolution to fall back to `email` when a source entry has a blank or missing `name`.
- Added i18n keys for all new UI strings across English, Spanish, Portuguese, and Romanian locales.