### PR TITLE
feat: integrate API operational alerts for cards and tables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "emoji-mart": "^5.6.0",
         "firebase": "^10.13.1",
         "html-rspack-plugin": "^6.0.2",
-        "intl-messageformat": "^11.2.5",
+        "intl-messageformat": "^11.2.9",
         "lodash-es": "^4.17.23",
         "marked": "^14.1.2",
         "mitt": "^3.0.1",
@@ -2823,25 +2823,22 @@
       }
     },
     "node_modules/@formatjs/fast-memoize": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-3.1.5.tgz",
-      "integrity": "sha512-KLi3fan6WnCHmigd9pmEEN8Hid0v4wiFBW576M/d07KMWYecf1CvyMI3n34vCmHT4AoVqG2n702kiHbXjzZX2A==",
-      "license": "MIT"
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-3.1.6.tgz",
+      "integrity": "sha512-H5aexk1Le7T9TPmscacZ+1pR6CTa2n1wq+HDVGXhH8TzUlQQpeXzZs91dRtmFHrbeNbjPFPfQujUqm7MHgVoXQ=="
     },
     "node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "3.5.8",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.8.tgz",
-      "integrity": "sha512-uZLvzLFN7iV2l8cbDdROwgKGtdELeLI4bpnsuz1DnyscHDxn8TdDE0anHzcfjtWK66XYCllGLV3Mi3CYcEPg/g==",
-      "license": "MIT",
+      "version": "3.5.12",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.12.tgz",
+      "integrity": "sha512-YyzzxVgYJ8DELmmkhn0Yr0rUj0dTJFf9Jp628K3S0ysInBWxLVDOS8i3RP91cCp4DMK4WYb4cVMhWA9i4knSJg==",
       "dependencies": {
-        "@formatjs/icu-skeleton-parser": "2.1.8"
+        "@formatjs/icu-skeleton-parser": "2.1.10"
       }
     },
     "node_modules/@formatjs/icu-skeleton-parser": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.8.tgz",
-      "integrity": "sha512-iX5i0O15gPf69l1WqmLFYwn7wq53lauvytvWFnHamIfX/5Ta56gpFj6fdeHRcKTV58IhrKv8QOvWfTYZYm7f+g==",
-      "license": "MIT"
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.10.tgz",
+      "integrity": "sha512-XuSva+8ZGawk8VnD5VD6UeH8KarQ/Z022zgjHDoHmlNiAewstXuuzXc0Hk5pGFSdG+nNw5bfJKXqj1ZXHn9yUA=="
     },
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
@@ -3386,6 +3383,7 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz",
       "integrity": "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==",
+      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "dependencies": {
@@ -3424,6 +3422,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -3443,6 +3442,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -3462,6 +3462,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -3481,6 +3482,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -3500,6 +3502,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -3519,6 +3522,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -3538,6 +3542,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -3557,6 +3562,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -3576,6 +3582,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -3595,6 +3602,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -3614,6 +3622,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -3633,6 +3642,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -3652,6 +3662,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -3668,6 +3679,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
       "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+      "dev": true,
       "optional": true,
       "bin": {
         "detect-libc": "bin/detect-libc.js"
@@ -7382,6 +7394,7 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dev": true,
       "optional": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
@@ -8852,7 +8865,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -8943,13 +8956,12 @@
       "dev": true
     },
     "node_modules/intl-messageformat": {
-      "version": "11.2.5",
-      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-11.2.5.tgz",
-      "integrity": "sha512-zaROHiUsnlSFXVypU54AsQuAm3DLmmSH8KfDhiUuG1XZ9NTQ4o3xlxIJYVNmeWAklyp3CWg0lhexNUnee8PsYQ==",
-      "license": "BSD-3-Clause",
+      "version": "11.2.9",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-11.2.9.tgz",
+      "integrity": "sha512-cGzymZerpDhVXRKjKLgXKda9gI29TU2o88L7gwNMHp3WZVxA/0c5tX52udXbW9JklDApolvMXZG6Dhhdz5eirA==",
       "dependencies": {
-        "@formatjs/fast-memoize": "3.1.5",
-        "@formatjs/icu-messageformat-parser": "3.5.8"
+        "@formatjs/fast-memoize": "3.1.6",
+        "@formatjs/icu-messageformat-parser": "3.5.12"
       }
     },
     "node_modules/ip-address": {
@@ -11022,6 +11034,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true,
       "optional": true
     },
     "node_modules/node-fetch": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "emoji-mart": "^5.6.0",
     "firebase": "^10.13.1",
     "html-rspack-plugin": "^6.0.2",
-    "intl-messageformat": "^11.2.5",
+    "intl-messageformat": "^11.2.9",
     "lodash-es": "^4.17.23",
     "marked": "^14.1.2",
     "mitt": "^3.0.1",

--- a/src/components/insights/dashboards/__tests__/HumanSupport.spec.js
+++ b/src/components/insights/dashboards/__tests__/HumanSupport.spec.js
@@ -22,7 +22,9 @@ config.global.plugins = [
   }),
 ];
 
-const mockIsFeatureFlagEnabled = vi.fn(() => true);
+const mockIsFeatureFlagEnabled = vi.fn(
+  (flag) => flag === 'insights-new-human-dashboard',
+);
 
 vi.mock('@/services/api/resources/projects', () => ({
   default: {
@@ -40,8 +42,8 @@ const createWrapper = (options = {}) => {
   return mount(HumanSupport, {
     global: {
       stubs: {
-        Analysis: true,
-        Monitoring: true,
+        MonitoringView: true,
+        AnalysisView: true,
       },
       ...options.global,
     },

--- a/src/components/insights/humanSupport/Monitoring/Monitoring.vue
+++ b/src/components/insights/humanSupport/Monitoring/Monitoring.vue
@@ -78,8 +78,8 @@ const shouldConnectMetricGoalsSocket = computed(
 const loadOperationalAlertsData = () => {
   if (!isFeatureFlagEnabled('insightsOperationalAlerts')) return;
 
-  humanSupportMonitoringStore.loadTimeMetricsData();
-  metricGoalsStore.loadGoals();
+  void humanSupportMonitoringStore.loadTimeMetricsData();
+  void metricGoalsStore.loadGoals().catch(() => undefined);
 };
 
 onMounted(() => {

--- a/src/components/insights/humanSupport/Monitoring/Monitoring.vue
+++ b/src/components/insights/humanSupport/Monitoring/Monitoring.vue
@@ -33,7 +33,7 @@
 </template>
 
 <script setup lang="ts">
-import { onUnmounted, watch, ref, computed } from 'vue';
+import { onMounted, onUnmounted, watch, ref, computed } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useTimeoutFn, useElementVisibility } from '@vueuse/core';
 
@@ -41,6 +41,7 @@ import { useHumanSupportMonitoring } from '@/store/modules/humanSupport/monitori
 import { useFeatureFlag } from '@/store/modules/featureFlag';
 import { useProject } from '@/store/modules/project';
 import { useConfig } from '@/store/modules/config';
+import { useMetricGoals } from '@/store/modules/humanSupport/metricGoals';
 import { useMetricGoalsSocket } from '@/composables/useMetricGoalsSocket';
 
 import StatusCards from './StatusCards.vue';
@@ -53,8 +54,15 @@ import LazyWidget from '@/components/insights/Layout/LazyWidget.vue';
 
 const { isFeatureFlagEnabled } = useFeatureFlag();
 
+const humanSupportMonitoringStore = useHumanSupportMonitoring();
+const { setRefreshDataMonitoring } = humanSupportMonitoringStore;
+const { autoRefresh, forceLoadDetailed } = storeToRefs(
+  humanSupportMonitoringStore,
+);
+
 const configStore = useConfig();
 const { token, project } = storeToRefs(configStore);
+const metricGoalsStore = useMetricGoals();
 const {
   connect: connectMetricGoalsSocket,
   disconnect: disconnectMetricGoalsSocket,
@@ -67,12 +75,24 @@ const shouldConnectMetricGoalsSocket = computed(
     !!project.value?.uuid,
 );
 
+const loadOperationalAlertsData = () => {
+  if (!isFeatureFlagEnabled('insightsOperationalAlerts')) return;
+
+  humanSupportMonitoringStore.loadTimeMetricsData();
+  metricGoalsStore.loadGoals();
+};
+
+onMounted(() => {
+  loadOperationalAlertsData();
+});
+
 watch(
   [shouldConnectMetricGoalsSocket, () => project.value?.uuid, token],
   ([enabled], previous) => {
     const wasEnabled = previous?.[0];
 
     if (enabled) {
+      loadOperationalAlertsData();
       connectMetricGoalsSocket();
       return;
     }
@@ -95,13 +115,6 @@ let autoRefreshInterval: ReturnType<typeof setInterval> | null = null;
 let timeoutStop: (() => void) | null = null;
 
 const AUTO_REFRESH_INTERVAL = 60 * 1000;
-
-const humanSupportMonitoringStore = useHumanSupportMonitoring();
-
-const { setRefreshDataMonitoring } = humanSupportMonitoringStore;
-const { autoRefresh, forceLoadDetailed } = storeToRefs(
-  humanSupportMonitoringStore,
-);
 
 const monitoringRef = ref(null);
 const isVisible = useElementVisibility(monitoringRef);

--- a/src/components/insights/humanSupport/Monitoring/OperationalAlerts/TableRowAlert.vue
+++ b/src/components/insights/humanSupport/Monitoring/OperationalAlerts/TableRowAlert.vue
@@ -1,5 +1,11 @@
 <template>
-  <span :class="['row-alert', `row-alert--${scheme}`]">
+  <span
+    :class="[
+      'row-alert',
+      `row-alert--${scheme}`,
+      { 'row-alert--full-row': fullRow },
+    ]"
+  >
     <UnnnicToolTip
       enabled
       :text="text"
@@ -7,6 +13,13 @@
       maxWidth="320px"
       data-testid="table-row-alert-tooltip"
     >
+      <span
+        v-if="fullRow"
+        ref="overlayRef"
+        class="row-alert__overlay"
+        :style="overlayStyle"
+        data-testid="table-row-alert-overlay"
+      />
       <span
         class="row-alert__trigger"
         data-testid="table-row-alert"
@@ -18,22 +31,87 @@
 </template>
 
 <script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref } from 'vue';
 import { UnnnicToolTip } from '@weni/unnnic-system';
 
 import type { RowAlertScheme } from '@/composables/useTableRowAlert';
 
-defineProps<{
-  scheme: RowAlertScheme;
-  text: string;
-}>();
+const props = withDefaults(
+  defineProps<{
+    scheme: RowAlertScheme;
+    text: string;
+    fullRow?: boolean;
+  }>(),
+  {
+    fullRow: false,
+  },
+);
+
+const overlayRef = ref<HTMLElement | null>(null);
+const overlayStyle = ref<Record<string, string>>({});
+
+let resizeObserver: ResizeObserver | null = null;
+
+const updateOverlay = () => {
+  if (!props.fullRow) return;
+
+  const overlay = overlayRef.value;
+  if (!overlay) return;
+
+  const row = overlay.closest('tr');
+  const cell = overlay.closest('td');
+
+  if (!row || !cell) return;
+
+  const rowRect = row.getBoundingClientRect();
+  const cellRect = cell.getBoundingClientRect();
+
+  overlayStyle.value = {
+    width: `${rowRect.width}px`,
+    height: `${rowRect.height}px`,
+    left: `${cellRect.left - rowRect.left}px`,
+    top: `${cellRect.top - rowRect.top}px`,
+  };
+};
+
+onMounted(() => {
+  if (!props.fullRow) return;
+
+  updateOverlay();
+
+  const row = overlayRef.value?.closest('tr');
+  if (!row || typeof ResizeObserver === 'undefined') return;
+
+  resizeObserver = new ResizeObserver(updateOverlay);
+  resizeObserver.observe(row);
+});
+
+onBeforeUnmount(() => {
+  resizeObserver?.disconnect();
+  resizeObserver = null;
+});
 </script>
 
 <style scoped lang="scss">
 .row-alert {
   display: inline;
 
+  &--full-row {
+    display: block;
+    position: relative;
+  }
+
+  &__overlay {
+    position: absolute;
+    z-index: 1;
+    opacity: 0;
+    cursor: default;
+  }
+
   &__trigger {
     display: inline;
+    position: relative;
+    z-index: 0;
   }
 }
 </style>

--- a/src/components/insights/humanSupport/Monitoring/StatusCards.vue
+++ b/src/components/insights/humanSupport/Monitoring/StatusCards.vue
@@ -39,7 +39,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, useTemplateRef } from 'vue';
+import { computed, onUnmounted, useTemplateRef } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useMouseInElement } from '@vueuse/core';
 
@@ -127,7 +127,11 @@ const getTooltipSide = (index: number) => {
   return 'top';
 };
 
+let scrollTimeout: ReturnType<typeof setTimeout> | null = null;
+
 const scrollToDetailedMonitoring = () => {
+  if (typeof document === 'undefined') return;
+
   const detailedMonitoringElement = document.querySelector(
     '[id="detailed-monitoring"]',
   );
@@ -150,8 +154,20 @@ const handleCardClick = (id: CardId) => {
 
   setActiveDetailedTab(status[id] as ActiveDetailedTab);
   setForceLoadDetailed(true);
-  setTimeout(scrollToDetailedMonitoring, 100);
+
+  if (scrollTimeout) {
+    clearTimeout(scrollTimeout);
+  }
+
+  scrollTimeout = setTimeout(scrollToDetailedMonitoring, 100);
 };
+
+onUnmounted(() => {
+  if (scrollTimeout) {
+    clearTimeout(scrollTimeout);
+    scrollTimeout = null;
+  }
+});
 </script>
 
 <style scoped lang="scss">

--- a/src/components/insights/humanSupport/Monitoring/Tables/InAwaiting.vue
+++ b/src/components/insights/humanSupport/Monitoring/Tables/InAwaiting.vue
@@ -25,6 +25,7 @@
         v-if="item.rowAlert"
         :scheme="item.rowAlert.scheme"
         :text="item.rowAlert.text"
+        fullRow
       >
         {{ item.awaiting_time }}
       </TableRowAlert>
@@ -72,7 +73,7 @@ const resolveRowAlert = (item: InAwaitingDataResult): RowAlert | null => {
     {
       metric: 'waiting_time',
       scheme: 'red',
-      goal: item.waiting_time_goal,
+      exceeded: item.goals_metrics?.awaiting_time?.exceeded,
     },
   ]);
 };
@@ -230,5 +231,11 @@ watch(
 
 :deep(.unnnic-data-table__body-row--clickable:has(.row-alert--red):hover) {
   background-color: $unnnic-color-bg-red-plain;
+}
+
+:deep(
+  .unnnic-data-table__body-row:has(.row-alert) .unnnic-data-table__body-cell
+) {
+  font: $unnnic-font-emphasis;
 }
 </style>

--- a/src/components/insights/humanSupport/Monitoring/Tables/InProgress.vue
+++ b/src/components/insights/humanSupport/Monitoring/Tables/InProgress.vue
@@ -39,6 +39,7 @@
             v-if="item.rowAlert"
             :scheme="item.rowAlert.scheme"
             :text="item.rowAlert.text"
+            fullRow
           >
             {{ formatSecondsToTime(item.duration) }}
           </TableRowAlert>
@@ -117,12 +118,12 @@ const resolveRowAlert = (item: InProgressDataResult): RowAlert | null => {
     {
       metric: 'first_response_time',
       scheme: 'orange',
-      goal: item.first_response_time_goal,
+      exceeded: item.goals_metrics?.first_response_time?.exceeded,
     },
     {
       metric: 'conversation_duration',
       scheme: 'yellow',
-      goal: item.conversation_duration_goal,
+      exceeded: item.goals_metrics?.duration?.exceeded,
     },
   ]);
 };
@@ -298,5 +299,11 @@ watch(
 
 :deep(.unnnic-data-table__body-row--clickable:has(.row-alert--yellow):hover) {
   background-color: $unnnic-color-bg-yellow-plain;
+}
+
+:deep(
+  .unnnic-data-table__body-row:has(.row-alert) .unnnic-data-table__body-cell
+) {
+  font: $unnnic-font-emphasis;
 }
 </style>

--- a/src/components/insights/humanSupport/Monitoring/Tables/__tests__/InAwaiting.spec.js
+++ b/src/components/insights/humanSupport/Monitoring/Tables/__tests__/InAwaiting.spec.js
@@ -207,15 +207,11 @@ describe('InAwaiting', () => {
   });
 
   describe('Row alert', () => {
-    it('returns a red alert when the waiting time goal is breached', () => {
+    it('returns a red alert when the waiting time goal is exceeded', () => {
       const alert = wrapper.vm.getItemAlert({
         awaiting_time: '120s',
-        waiting_time_goal: {
-          thresholdSeconds: 60,
-          thresholdValue: 1,
-          unit: 'm',
-          isBreached: true,
-          breachedRoomsCount: 3,
+        goals_metrics: {
+          awaiting_time: { exceeded: true },
         },
       });
 

--- a/src/components/insights/humanSupport/Monitoring/Tables/__tests__/InProgress.spec.js
+++ b/src/components/insights/humanSupport/Monitoring/Tables/__tests__/InProgress.spec.js
@@ -262,40 +262,32 @@ describe('InProgress', () => {
   });
 
   describe('Row alert', () => {
-    const firstResponseBreach = {
-      thresholdSeconds: 60,
-      thresholdValue: 1,
-      unit: 'm',
-      isBreached: true,
-      breachedRoomsCount: 2,
-    };
-    const durationBreach = {
-      thresholdSeconds: 600,
-      thresholdValue: 10,
-      unit: 'm',
-      isBreached: true,
-      breachedRoomsCount: 3,
-    };
+    const firstResponseBreach = { exceeded: true };
+    const durationBreach = { exceeded: true };
 
     it('prioritizes the orange first response alert over the yellow duration alert', () => {
       const alert = wrapper.vm.getItemAlert({
-        first_response_time_goal: firstResponseBreach,
-        conversation_duration_goal: durationBreach,
+        goals_metrics: {
+          first_response_time: firstResponseBreach,
+          duration: durationBreach,
+        },
       });
 
       expect(alert).toBeTruthy();
       expect(alert.scheme).toBe('orange');
     });
 
-    it('returns a yellow alert when only the duration goal is breached', () => {
+    it('returns a yellow alert when only the duration goal is exceeded', () => {
       const alert = wrapper.vm.getItemAlert({
-        conversation_duration_goal: durationBreach,
+        goals_metrics: {
+          duration: durationBreach,
+        },
       });
 
       expect(alert.scheme).toBe('yellow');
     });
 
-    it('returns null when there is no breached goal', () => {
+    it('returns null when there is no exceeded goal', () => {
       expect(wrapper.vm.getItemAlert({})).toBeNull();
     });
   });

--- a/src/components/insights/humanSupport/Monitoring/TimeMetrics.vue
+++ b/src/components/insights/humanSupport/Monitoring/TimeMetrics.vue
@@ -186,7 +186,8 @@ const getCardAlert = (id: CardId) => {
   if (!isFeatureFlagEnabled('insightsOperationalAlerts')) return undefined;
 
   const { goalKey, scheme } = cardAlertConfig[id];
-  const apiGoal = widgetData.value[goalKey] as MetricGoalBreach | undefined;
+  const cardData = widgetData.value[id];
+  const apiGoal = cardData?.[goalKey] as MetricGoalBreach | undefined;
   const metric = METRIC_BY_GOAL_KEY[goalKey];
   const liveGoal = liveBreaches.value[metric];
 

--- a/src/components/insights/humanSupport/Monitoring/TimeMetrics.vue
+++ b/src/components/insights/humanSupport/Monitoring/TimeMetrics.vue
@@ -43,7 +43,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, useTemplateRef } from 'vue';
+import { computed, onUnmounted, useTemplateRef } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useI18n } from 'vue-i18n';
 import { useMouseInElement } from '@vueuse/core';
@@ -222,7 +222,11 @@ const getTooltipSide = (index: number) => {
   return 'top';
 };
 
+let scrollTimeout: ReturnType<typeof setTimeout> | null = null;
+
 const scrollToDetailedMonitoring = () => {
+  if (typeof document === 'undefined') return;
+
   const detailedMonitoringElement = document.querySelector(
     '[id="detailed-monitoring"]',
   );
@@ -244,8 +248,20 @@ const handleCardClick = (id: CardId) => {
 
   setActiveDetailedTab(status[id] as ActiveDetailedTab);
   setForceLoadDetailed(true);
-  setTimeout(scrollToDetailedMonitoring, 100);
+
+  if (scrollTimeout) {
+    clearTimeout(scrollTimeout);
+  }
+
+  scrollTimeout = setTimeout(scrollToDetailedMonitoring, 100);
 };
+
+onUnmounted(() => {
+  if (scrollTimeout) {
+    clearTimeout(scrollTimeout);
+    scrollTimeout = null;
+  }
+});
 </script>
 
 <style scoped lang="scss">

--- a/src/components/insights/humanSupport/Monitoring/__tests__/StatusCards.spec.js
+++ b/src/components/insights/humanSupport/Monitoring/__tests__/StatusCards.spec.js
@@ -132,6 +132,7 @@ describe('ServiceStatus', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.useRealTimers();
     Object.assign(mockMonitoringStore, {
       loadServiceStatusData: vi.fn(),
       setActiveDetailedTab: vi.fn(),
@@ -348,6 +349,8 @@ describe('ServiceStatus', () => {
 
   describe('Card click navigation', () => {
     it('should force-load the detailed section and switch tab on click', () => {
+      vi.useFakeTimers();
+
       wrapper.vm.handleCardClick('is_waiting');
 
       expect(mockMonitoringStore.setActiveDetailedTab).toHaveBeenCalledWith(
@@ -356,6 +359,9 @@ describe('ServiceStatus', () => {
       expect(mockMonitoringStore.setForceLoadDetailed).toHaveBeenCalledWith(
         true,
       );
+
+      vi.runAllTimers();
+      vi.useRealTimers();
     });
 
     it('should not navigate when the finished card is clicked', () => {

--- a/src/components/insights/humanSupport/Monitoring/__tests__/TimeMetrics.spec.js
+++ b/src/components/insights/humanSupport/Monitoring/__tests__/TimeMetrics.spec.js
@@ -317,12 +317,15 @@ describe('TimeMetrics', () => {
         timeMetricsData: {
           value: {
             ...defaultTimeMetricsData,
-            waiting_time_goal: {
-              thresholdSeconds: 60,
-              thresholdValue: 1,
-              unit: 'm',
-              isBreached: true,
-              breachedRoomsCount: 7,
+            average_time_is_waiting: {
+              ...defaultTimeMetricsData.average_time_is_waiting,
+              waiting_time_goal: {
+                thresholdSeconds: 60,
+                thresholdValue: 1,
+                unit: 'm',
+                isBreached: true,
+                breachedRoomsCount: 7,
+              },
             },
           },
         },
@@ -340,19 +343,25 @@ describe('TimeMetrics', () => {
         timeMetricsData: {
           value: {
             ...defaultTimeMetricsData,
-            first_response_time_goal: {
-              thresholdSeconds: 60,
-              thresholdValue: 1,
-              unit: 'm',
-              isBreached: true,
-              breachedRoomsCount: 4,
+            average_time_first_response: {
+              ...defaultTimeMetricsData.average_time_first_response,
+              first_response_time_goal: {
+                thresholdSeconds: 60,
+                thresholdValue: 1,
+                unit: 'm',
+                isBreached: true,
+                breachedRoomsCount: 4,
+              },
             },
-            conversation_duration_goal: {
-              thresholdSeconds: 600,
-              thresholdValue: 10,
-              unit: 'm',
-              isBreached: true,
-              breachedRoomsCount: 3,
+            average_time_chat: {
+              ...defaultTimeMetricsData.average_time_chat,
+              conversation_duration_goal: {
+                thresholdSeconds: 600,
+                thresholdValue: 10,
+                unit: 'm',
+                isBreached: true,
+                breachedRoomsCount: 3,
+              },
             },
           },
         },

--- a/src/components/insights/humanSupport/Monitoring/mocks.ts
+++ b/src/components/insights/humanSupport/Monitoring/mocks.ts
@@ -5,29 +5,38 @@ const monitoringStatusCardsMock = {
 };
 
 const monitoringTimeMetricsMock = {
-  average_time_is_waiting: { average: 40, max: 105 },
-  average_time_first_response: { average: 72, max: 143 },
-  average_time_chat: { average: 1710, max: 2423 },
-  waiting_time_goal: {
-    thresholdSeconds: 60,
-    thresholdValue: 1,
-    unit: 'm',
-    isBreached: true,
-    breachedRoomsCount: 7,
+  average_time_is_waiting: {
+    average: 40,
+    max: 105,
+    waiting_time_goal: {
+      thresholdSeconds: 60,
+      thresholdValue: 1,
+      unit: 'm',
+      isBreached: true,
+      breachedRoomsCount: 7,
+    },
   },
-  first_response_time_goal: {
-    thresholdSeconds: 60,
-    thresholdValue: 1,
-    unit: 'm',
-    isBreached: true,
-    breachedRoomsCount: 4,
+  average_time_first_response: {
+    average: 72,
+    max: 143,
+    first_response_time_goal: {
+      thresholdSeconds: 60,
+      thresholdValue: 1,
+      unit: 'm',
+      isBreached: true,
+      breachedRoomsCount: 4,
+    },
   },
-  conversation_duration_goal: {
-    thresholdSeconds: 600,
-    thresholdValue: 10,
-    unit: 'm',
-    isBreached: true,
-    breachedRoomsCount: 3,
+  average_time_chat: {
+    average: 1710,
+    max: 2423,
+    conversation_duration_goal: {
+      thresholdSeconds: 600,
+      thresholdValue: 10,
+      unit: 'm',
+      isBreached: true,
+      breachedRoomsCount: 3,
+    },
   },
 };
 
@@ -221,12 +230,8 @@ const monitoringDetailedMonitoringInProgressMock = [
       url: '',
       type: 'internal',
     },
-    conversation_duration_goal: {
-      thresholdSeconds: 600,
-      thresholdValue: 10,
-      unit: 'm',
-      isBreached: true,
-      breachedRoomsCount: 1,
+    goals_metrics: {
+      duration: { exceeded: true },
     },
   },
   {
@@ -243,19 +248,9 @@ const monitoringDetailedMonitoringInProgressMock = [
       url: '',
       type: 'internal',
     },
-    first_response_time_goal: {
-      thresholdSeconds: 60,
-      thresholdValue: 1,
-      unit: 'm',
-      isBreached: true,
-      breachedRoomsCount: 1,
-    },
-    conversation_duration_goal: {
-      thresholdSeconds: 600,
-      thresholdValue: 10,
-      unit: 'm',
-      isBreached: true,
-      breachedRoomsCount: 1,
+    goals_metrics: {
+      first_response_time: { exceeded: true },
+      duration: { exceeded: true },
     },
   },
   {

--- a/src/composables/__tests__/useMetricGoalsSocket.spec.js
+++ b/src/composables/__tests__/useMetricGoalsSocket.spec.js
@@ -247,6 +247,48 @@ describe('useMetricGoalsSocket', () => {
     ).toBe(12);
   });
 
+  it('should not show toast when breach was already hydrated from API', () => {
+    const { connect } = useMetricGoalsSocket();
+    const alertsStore = useMetricGoalAlerts();
+
+    alertsStore.hydrateFromApiGoals({
+      average_time_is_waiting: {
+        average: 120,
+        max: 300,
+        waiting_time_goal: {
+          thresholdSeconds: 60,
+          thresholdValue: 1,
+          unit: 'm',
+          isBreached: true,
+          breachedRoomsCount: 7,
+        },
+      },
+      average_time_first_response: { average: 45, max: 90 },
+      average_time_chat: { average: 600, max: 1200 },
+    });
+
+    connect();
+    MockWebSocket.instances[0].emitMessage({
+      type: 'metric_goal.violated',
+      content: {
+        project_uuid: 'project-1',
+        metric: 'waiting_time',
+        state: 'violating',
+        transition: 'new',
+        violating_count: 8,
+        max_value_seconds: 300,
+        threshold_seconds: 60,
+        rooms_threshold_count: 2,
+        rooms_threshold_percent: null,
+        active_rooms_count: null,
+        detected_at: '2026-06-23T18:55:36+00:00',
+      },
+    });
+
+    expect(showMetricGoalToast).not.toHaveBeenCalled();
+    expect(alertsStore.liveBreaches.waiting_time?.breachedRoomsCount).toBe(8);
+  });
+
   it('should clear live breach on resolved events', () => {
     const { connect } = useMetricGoalsSocket();
     const alertsStore = useMetricGoalAlerts();

--- a/src/composables/useMetricGoalsSocket.ts
+++ b/src/composables/useMetricGoalsSocket.ts
@@ -1,5 +1,6 @@
 import { useConfig } from '@/store/modules/config';
 import { useMetricGoalAlerts } from '@/store/modules/humanSupport/metricGoalAlerts';
+import type { MetricGoalSocketViolatedContent } from '@/store/modules/humanSupport/metricGoalAlerts';
 import { useHumanSupportMonitoring } from '@/store/modules/humanSupport/monitoring';
 import env from '@/utils/env';
 import { showMetricGoalToast } from '@/utils/showMetricGoalToast';
@@ -40,19 +41,14 @@ export function useMetricGoalsSocket() {
     }, REFRESH_PULSE_MS);
   };
 
-  const handleViolatingContent = (
-    content: MetricGoalSocketViolatedContent,
-    options: { isNew: boolean },
-  ) => {
+  const handleViolatingContent = (content: MetricGoalSocketViolatedContent) => {
     const wasAlreadyBreaching = metricGoalAlertsStore.isMetricBreaching(
       content.metric,
     );
 
     metricGoalAlertsStore.applyUpdate(content);
 
-    const shouldShowToast = options.isNew || !wasAlreadyBreaching;
-
-    if (shouldShowToast) {
+    if (!wasAlreadyBreaching) {
       showMetricGoalToast(content);
       triggerSilentRefresh();
     }
@@ -64,17 +60,15 @@ export function useMetricGoalsSocket() {
       const { type, content } = payload;
 
       if (type === 'metric_goal.violated') {
-        if (content.transition === 'new') {
-          handleViolatingContent(content, { isNew: true });
-        } else if (content.transition === 'update') {
-          handleViolatingContent(content, { isNew: false });
+        if (content.transition === 'new' || content.transition === 'update') {
+          handleViolatingContent(content);
         }
 
         return;
       }
 
       if (type === 'metric_goal.update') {
-        handleViolatingContent(content, { isNew: false });
+        handleViolatingContent(content);
         return;
       }
 

--- a/src/composables/useTableRowAlert.ts
+++ b/src/composables/useTableRowAlert.ts
@@ -1,17 +1,17 @@
 import { useI18n } from 'vue-i18n';
 
 import type {
-  MetricGoalBreach,
   MetricKey,
   TimeUnit,
 } from '@/services/api/resources/humanSupport/monitoring/metricGoals';
+import { useMetricGoals } from '@/store/modules/humanSupport/metricGoals';
 
 type RowAlertScheme = 'red' | 'orange' | 'yellow';
 
 interface RowAlertCandidate {
   metric: MetricKey;
   scheme: RowAlertScheme;
-  goal?: MetricGoalBreach;
+  exceeded?: boolean;
 }
 
 interface RowAlert {
@@ -21,22 +21,32 @@ interface RowAlert {
 
 export function useTableRowAlert() {
   const { t } = useI18n();
+  const metricGoalsStore = useMetricGoals();
 
   const getRowAlert = (candidates: RowAlertCandidate[]): RowAlert | null => {
     const breached = candidates.find(
-      (candidate) => candidate.goal?.isBreached,
+      (candidate) => candidate.exceeded === true,
     );
 
-    if (!breached?.goal) return null;
+    if (!breached) return null;
+
+    const configuredGoal = metricGoalsStore.getGoalForMetric(breached.metric);
+
+    if (!configuredGoal) {
+      return {
+        scheme: breached.scheme,
+        text: t('operational_alerts.table_tooltip.generic'),
+      };
+    }
 
     const unit = t(
-      `operational_alerts.unit_word${breached.goal.thresholdValue === 1 ? '_singular' : 's'}.${breached.goal.unit as TimeUnit}`,
+      `operational_alerts.unit_word${configuredGoal.thresholdValue === 1 ? '_singular' : 's'}.${configuredGoal.unit as TimeUnit}`,
     ).toLowerCase();
 
     return {
       scheme: breached.scheme,
       text: t(`operational_alerts.table_tooltip.${breached.metric}`, {
-        value: breached.goal.thresholdValue,
+        value: configuredGoal.thresholdValue,
         unit,
       }),
     };

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1058,6 +1058,7 @@
     "table_tooltip": {
       "conversation_duration": "This chat has exceeded the {value}-{unit} time limit.",
       "first_response_time": "This chat has exceeded the {value}-{unit} time limit for the first response.",
+      "generic": "This chat has exceeded the configured time limit.",
       "waiting_time": "This chat has exceeded the {value}-{unit} waiting time limit."
     },
     "toast": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1058,6 +1058,7 @@
     "table_tooltip": {
       "conversation_duration": "Este chat superó el límite de {value} {unit}.",
       "first_response_time": "Este chat superó el límite de {value} {unit} para la primera respuesta.",
+      "generic": "Este chat superó el límite de tiempo configurado.",
       "waiting_time": "Este chat superó el límite de {value} {unit} de espera."
     },
     "toast": {

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -1058,6 +1058,7 @@
     "table_tooltip": {
       "conversation_duration": "Este chat ultrapassou o limite de {value} {unit}.",
       "first_response_time": "Este chat ultrapassou o limite de {value} {unit} para a primeira resposta.",
+      "generic": "Este chat ultrapassou o limite de tempo configurado.",
       "waiting_time": "Este chat ultrapassou o limite de {value} {unit} de espera."
     },
     "toast": {

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -1048,6 +1048,7 @@
     "table_tooltip": {
       "conversation_duration": "Această conversație a depășit limita de {value} {unit}.",
       "first_response_time": "Această conversație a depășit limita de {value} {unit} pentru primul răspuns.",
+      "generic": "Această conversație a depășit limita de timp configurată.",
       "waiting_time": "Această conversație a depășit limita de {value} {unit} de așteptare."
     },
     "toast": {

--- a/src/services/api/resources/humanSupport/monitoring/__tests__/timeMetrics.spec.js
+++ b/src/services/api/resources/humanSupport/monitoring/__tests__/timeMetrics.spec.js
@@ -64,23 +64,26 @@ describe('timeMetrics API', () => {
       expect(result).toEqual(mockHttpResponse);
     });
 
-    it('should normalize goal breach fields from the API response', async () => {
+    it('should normalize nested goal breach fields from the API response', async () => {
       http.get.mockResolvedValue({
-        average_time_is_waiting: { average: 120, max: 300 },
+        average_time_is_waiting: {
+          average: 120,
+          max: 300,
+          waiting_time_goal: {
+            threshold_seconds: 60,
+            threshold_value: 1,
+            unit: 'm',
+            is_breached: true,
+            breached_rooms_count: 7,
+          },
+        },
         average_time_first_response: { average: 45, max: 90 },
         average_time_chat: { average: 600, max: 1200 },
-        waiting_time_goal: {
-          threshold_seconds: 60,
-          threshold_value: 1,
-          unit: 'm',
-          is_breached: true,
-          breached_rooms_count: 7,
-        },
       });
 
       const result = await timeMetrics.getTimeMetricsData();
 
-      expect(result.waiting_time_goal).toEqual({
+      expect(result.average_time_is_waiting.waiting_time_goal).toEqual({
         thresholdSeconds: 60,
         thresholdValue: 1,
         unit: 'm',

--- a/src/services/api/resources/humanSupport/monitoring/detailedMonitoring/inAwaiting.ts
+++ b/src/services/api/resources/humanSupport/monitoring/detailedMonitoring/inAwaiting.ts
@@ -2,7 +2,11 @@ import http from '@/services/api/http';
 import { useConfig } from '@/store/modules/config';
 import { useHumanSupport } from '@/store/modules/humanSupport/humanSupport';
 import { createRequestQuery } from '@/utils/request';
-import { MetricGoalBreach, MetricGoalBreachApi, normalizeMetricGoalBreach } from '@/services/api/resources/humanSupport/monitoring/metricGoals';
+import {
+  GoalsMetrics,
+  GoalsMetricsApi,
+  normalizeGoalsMetrics,
+} from '@/services/api/resources/humanSupport/monitoring/metricGoals';
 
 interface InAwaitingData {
   next: string;
@@ -20,7 +24,7 @@ interface InAwaitingDataResult {
     url: string;
     type: string;
   };
-  waiting_time_goal?: MetricGoalBreach;
+  goals_metrics?: GoalsMetrics;
 }
 
 interface QueryParams {
@@ -65,8 +69,8 @@ export default {
         params: formattedParams,
       },
     )) as InAwaitingData & {
-      results: (Omit<InAwaitingDataResult, 'waiting_time_goal'> & {
-        waiting_time_goal?: MetricGoalBreachApi;
+      results: (Omit<InAwaitingDataResult, 'goals_metrics'> & {
+        goals_metrics?: GoalsMetricsApi;
       })[];
     };
 
@@ -74,9 +78,7 @@ export default {
       ...response,
       results: response.results.map((result) => ({
         ...result,
-        waiting_time_goal: result.waiting_time_goal
-          ? normalizeMetricGoalBreach(result.waiting_time_goal)
-          : undefined,
+        goals_metrics: normalizeGoalsMetrics(result.goals_metrics),
       })),
     };
   },

--- a/src/services/api/resources/humanSupport/monitoring/detailedMonitoring/inProgress.ts
+++ b/src/services/api/resources/humanSupport/monitoring/detailedMonitoring/inProgress.ts
@@ -3,9 +3,9 @@ import { useConfig } from '@/store/modules/config';
 import { useHumanSupport } from '@/store/modules/humanSupport/humanSupport';
 import { createRequestQuery } from '@/utils/request';
 import {
-  MetricGoalBreach,
-  MetricGoalBreachApi,
-  normalizeMetricGoalBreach,
+  GoalsMetrics,
+  GoalsMetricsApi,
+  normalizeGoalsMetrics,
 } from '@/services/api/resources/humanSupport/monitoring/metricGoals';
 
 interface InProgressData {
@@ -17,6 +17,7 @@ interface InProgressData {
 
 interface InProgressDataResult {
   agent: string;
+  agent_email?: string;
   duration: number;
   first_response_time: number;
   pending_response: boolean;
@@ -28,8 +29,7 @@ interface InProgressDataResult {
     url: string;
     type: string;
   };
-  first_response_time_goal?: MetricGoalBreach;
-  conversation_duration_goal?: MetricGoalBreach;
+  goals_metrics?: GoalsMetrics;
 }
 
 interface QueryParams {
@@ -74,9 +74,8 @@ export default {
         params: formattedParams,
       },
     )) as InProgressData & {
-      results: (Omit<InProgressDataResult, 'first_response_time_goal' | 'conversation_duration_goal'> & {
-        first_response_time_goal?: MetricGoalBreachApi;
-        conversation_duration_goal?: MetricGoalBreachApi;
+      results: (Omit<InProgressDataResult, 'goals_metrics'> & {
+        goals_metrics?: GoalsMetricsApi;
       })[];
     };
 
@@ -84,12 +83,7 @@ export default {
       ...response,
       results: response.results.map((result) => ({
         ...result,
-        first_response_time_goal: result.first_response_time_goal
-          ? normalizeMetricGoalBreach(result.first_response_time_goal)
-          : undefined,
-        conversation_duration_goal: result.conversation_duration_goal
-          ? normalizeMetricGoalBreach(result.conversation_duration_goal)
-          : undefined,
+        goals_metrics: normalizeGoalsMetrics(result.goals_metrics),
       })),
     };
   },

--- a/src/services/api/resources/humanSupport/monitoring/metricGoals.ts
+++ b/src/services/api/resources/humanSupport/monitoring/metricGoals.ts
@@ -24,6 +24,26 @@ interface MetricGoalBreach {
   breachedRoomsCount: number;
 }
 
+interface GoalsMetricEntryApi {
+  exceeded: boolean;
+}
+
+interface GoalsMetricsApi {
+  awaiting_time?: GoalsMetricEntryApi;
+  first_response_time?: GoalsMetricEntryApi;
+  duration?: GoalsMetricEntryApi;
+}
+
+interface GoalsMetricEntry {
+  exceeded: boolean;
+}
+
+interface GoalsMetrics {
+  awaiting_time?: GoalsMetricEntry;
+  first_response_time?: GoalsMetricEntry;
+  duration?: GoalsMetricEntry;
+}
+
 interface MetricGoalRecipientApi {
   uuid: string;
   first_name?: string;
@@ -44,7 +64,10 @@ interface MetricGoalApi {
   unit: TimeUnit;
   is_active: boolean;
   email_enabled: boolean;
-  recipients: MetricGoalRecipientApi[] | MetricGoalRecipientApiPayload[] | string[];
+  recipients:
+    | MetricGoalRecipientApi[]
+    | MetricGoalRecipientApiPayload[]
+    | string[];
   rooms_threshold_count: number;
   rooms_threshold_percent?: number | null;
 }
@@ -99,6 +122,24 @@ const normalizeMetricGoalBreach = (
   isBreached: breach.is_breached,
   breachedRoomsCount: breach.breached_rooms_count,
 });
+
+const normalizeGoalsMetrics = (
+  goalsMetrics?: GoalsMetricsApi,
+): GoalsMetrics | undefined => {
+  if (!goalsMetrics) return undefined;
+
+  return {
+    awaiting_time: goalsMetrics.awaiting_time
+      ? { exceeded: goalsMetrics.awaiting_time.exceeded }
+      : undefined,
+    first_response_time: goalsMetrics.first_response_time
+      ? { exceeded: goalsMetrics.first_response_time.exceeded }
+      : undefined,
+    duration: goalsMetrics.duration
+      ? { exceeded: goalsMetrics.duration.exceeded }
+      : undefined,
+  };
+};
 
 const UNIT_SECONDS: Record<TimeUnit, number> = {
   s: 1,
@@ -211,7 +252,9 @@ const normalizeGoal = (goal: MetricGoalApi): MetricGoal => {
   };
 };
 
-const toSavePayload = (params: MetricGoalSaveParams): MetricGoalSavePayload => ({
+const toSavePayload = (
+  params: MetricGoalSaveParams,
+): MetricGoalSavePayload => ({
   threshold: params.threshold,
   unit: params.unit,
   is_active: params.isActive,
@@ -276,6 +319,10 @@ export default {
 };
 
 export type {
+  GoalsMetricEntry,
+  GoalsMetricEntryApi,
+  GoalsMetrics,
+  GoalsMetricsApi,
   MetricGoal,
   MetricGoalApi,
   MetricGoalBreach,
@@ -287,4 +334,8 @@ export type {
   MetricGoalsResponse,
 };
 
-export { formatRecipientLabel, normalizeMetricGoalBreach };
+export {
+  formatRecipientLabel,
+  normalizeGoalsMetrics,
+  normalizeMetricGoalBreach,
+};

--- a/src/services/api/resources/humanSupport/monitoring/timeMetrics.ts
+++ b/src/services/api/resources/humanSupport/monitoring/timeMetrics.ts
@@ -9,27 +9,32 @@ import {
   normalizeMetricGoalBreach,
 } from '@/services/api/resources/humanSupport/monitoring/metricGoals';
 
-interface AverageTimeData {
+interface AverageTimeDataApi {
   average: number;
   max: number;
-}
-
-interface TimeMetricsDataResponseApi {
-  average_time_is_waiting: AverageTimeData;
-  average_time_first_response: AverageTimeData;
-  average_time_chat: AverageTimeData;
   waiting_time_goal?: MetricGoalBreachApi;
   first_response_time_goal?: MetricGoalBreachApi;
   conversation_duration_goal?: MetricGoalBreachApi;
+}
+
+interface AverageTimeData {
+  average: number;
+  max: number;
+  waiting_time_goal?: MetricGoalBreach;
+  first_response_time_goal?: MetricGoalBreach;
+  conversation_duration_goal?: MetricGoalBreach;
+}
+
+interface TimeMetricsDataResponseApi {
+  average_time_is_waiting: AverageTimeDataApi;
+  average_time_first_response: AverageTimeDataApi;
+  average_time_chat: AverageTimeDataApi;
 }
 
 interface TimeMetricsDataResponse {
   average_time_is_waiting: AverageTimeData;
   average_time_first_response: AverageTimeData;
   average_time_chat: AverageTimeData;
-  waiting_time_goal?: MetricGoalBreach;
-  first_response_time_goal?: MetricGoalBreach;
-  conversation_duration_goal?: MetricGoalBreach;
 }
 
 interface QueryParams {
@@ -38,21 +43,32 @@ interface QueryParams {
   tags?: string[];
 }
 
+const normalizeAverageTimeData = (
+  data: AverageTimeDataApi,
+): AverageTimeData => ({
+  average: data.average,
+  max: data.max,
+  waiting_time_goal: data.waiting_time_goal
+    ? normalizeMetricGoalBreach(data.waiting_time_goal)
+    : undefined,
+  first_response_time_goal: data.first_response_time_goal
+    ? normalizeMetricGoalBreach(data.first_response_time_goal)
+    : undefined,
+  conversation_duration_goal: data.conversation_duration_goal
+    ? normalizeMetricGoalBreach(data.conversation_duration_goal)
+    : undefined,
+});
+
 const normalizeTimeMetricsResponse = (
   response: TimeMetricsDataResponseApi,
 ): TimeMetricsDataResponse => ({
-  average_time_is_waiting: response.average_time_is_waiting,
-  average_time_first_response: response.average_time_first_response,
-  average_time_chat: response.average_time_chat,
-  waiting_time_goal: response.waiting_time_goal
-    ? normalizeMetricGoalBreach(response.waiting_time_goal)
-    : undefined,
-  first_response_time_goal: response.first_response_time_goal
-    ? normalizeMetricGoalBreach(response.first_response_time_goal)
-    : undefined,
-  conversation_duration_goal: response.conversation_duration_goal
-    ? normalizeMetricGoalBreach(response.conversation_duration_goal)
-    : undefined,
+  average_time_is_waiting: normalizeAverageTimeData(
+    response.average_time_is_waiting,
+  ),
+  average_time_first_response: normalizeAverageTimeData(
+    response.average_time_first_response,
+  ),
+  average_time_chat: normalizeAverageTimeData(response.average_time_chat),
 });
 
 export default {
@@ -88,5 +104,10 @@ export default {
   },
 };
 
-export type { TimeMetricsDataResponse, QueryParams, MetricGoalBreach };
+export type {
+  AverageTimeData,
+  TimeMetricsDataResponse,
+  QueryParams,
+  MetricGoalBreach,
+};
 export type { TimeUnit } from '@/services/api/resources/humanSupport/monitoring/metricGoals';

--- a/src/store/modules/humanSupport/__tests__/metricGoalAlerts.unit.spec.js
+++ b/src/store/modules/humanSupport/__tests__/metricGoalAlerts.unit.spec.js
@@ -81,6 +81,38 @@ describe('useMetricGoalAlerts Store', () => {
     expect(store.isMetricBreaching('waiting_time')).toBe(true);
   });
 
+  it('should hydrate live breaches from API goals', () => {
+    store.hydrateFromApiGoals({
+      average_time_is_waiting: {
+        average: 120,
+        max: 300,
+        waiting_time_goal: {
+          thresholdSeconds: 60,
+          thresholdValue: 1,
+          unit: 'm',
+          isBreached: true,
+          breachedRoomsCount: 7,
+        },
+      },
+      average_time_first_response: {
+        average: 45,
+        max: 90,
+        first_response_time_goal: {
+          thresholdSeconds: 60,
+          thresholdValue: 1,
+          unit: 'm',
+          isBreached: false,
+          breachedRoomsCount: 0,
+        },
+      },
+      average_time_chat: { average: 600, max: 1200 },
+    });
+
+    expect(store.isMetricBreaching('waiting_time')).toBe(true);
+    expect(store.isMetricBreaching('first_response_time')).toBe(false);
+    expect(store.liveBreaches.waiting_time?.breachedRoomsCount).toBe(7);
+  });
+
   it('should reset all live breaches and connection state', () => {
     store.applyViolated(violatedContent);
     store.setConnectionState('connected');

--- a/src/store/modules/humanSupport/metricGoalAlerts.ts
+++ b/src/store/modules/humanSupport/metricGoalAlerts.ts
@@ -5,6 +5,7 @@ import type {
   MetricGoalBreach,
   MetricKey,
 } from '@/services/api/resources/humanSupport/monitoring/metricGoals';
+import type { TimeMetricsDataResponse } from '@/services/api/resources/humanSupport/monitoring/timeMetrics';
 import { deriveThresholdFromSeconds } from '@/utils/metricGoalThreshold';
 
 const LIVE_METRIC_KEYS: MetricKey[] = [
@@ -90,6 +91,34 @@ export const useMetricGoalAlerts = defineStore('metricGoalAlerts', () => {
   const isMetricBreaching = (metric: MetricKey): boolean =>
     liveBreaches.value[metric]?.isBreached === true;
 
+  const hydrateFromApiGoals = (data: TimeMetricsDataResponse) => {
+    const mappings: { metric: MetricKey; goal?: MetricGoalBreach }[] = [
+      {
+        metric: 'waiting_time',
+        goal: data.average_time_is_waiting?.waiting_time_goal,
+      },
+      {
+        metric: 'first_response_time',
+        goal: data.average_time_first_response?.first_response_time_goal,
+      },
+      {
+        metric: 'conversation_duration',
+        goal: data.average_time_chat?.conversation_duration_goal,
+      },
+    ];
+
+    mappings.forEach(({ metric, goal }) => {
+      if (goal?.isBreached) {
+        liveBreaches.value[metric] = goal;
+        return;
+      }
+
+      if (goal) {
+        liveBreaches.value[metric] = null;
+      }
+    });
+  };
+
   const reset = () => {
     liveBreaches.value = createEmptyLiveBreaches();
     connectionState.value = 'disconnected';
@@ -103,6 +132,7 @@ export const useMetricGoalAlerts = defineStore('metricGoalAlerts', () => {
     applyUpdate,
     applyResolved,
     isMetricBreaching,
+    hydrateFromApiGoals,
     reset,
   };
 });

--- a/src/store/modules/humanSupport/monitoring.ts
+++ b/src/store/modules/humanSupport/monitoring.ts
@@ -7,6 +7,7 @@ import { ServicesOpenByHourData } from '@/services/api/resources/humanSupport/mo
 import ServiceStatusService from '@/services/api/resources/humanSupport/monitoring/serviceStatus';
 import TimeMetricsService from '@/services/api/resources/humanSupport/monitoring/timeMetrics';
 import ServicesOpenByHourService from '@/services/api/resources/humanSupport/monitoring/servicesOpenByHour';
+import { useMetricGoalAlerts } from '@/store/modules/humanSupport/metricGoalAlerts';
 
 export type ActiveDetailedTab =
   | 'in_awaiting'
@@ -102,6 +103,7 @@ export const useHumanSupportMonitoring = defineStore(
         const data = await TimeMetricsService.getTimeMetricsData();
 
         timeMetricsData.value = data;
+        useMetricGoalAlerts().hydrateFromApiGoals(data);
       } catch (error) {
         console.error('Error loading time metrics data:', error);
       } finally {


### PR DESCRIPTION
## Description
### Type of Change
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [x] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
The operational alerts system needed to be aligned with a revised API contract where goal breach data is now nested within each metric's own object rather than returned as top-level fields. Additionally, row-level alert indicators needed to visually cover the entire table row, and the socket toast logic needed to avoid showing duplicate notifications when a breach was already known from the initial API load.

### Summary of Changes

- **API contract alignment**: Goal breach fields (`waiting_time_goal`, `first_response_time_goal`, `conversation_duration_goal`) are now nested inside their respective `average_time_*` objects in the time metrics response, and the normalization logic was updated accordingly.

- **Detailed monitoring tables**: The `InAwaiting` and `InProgress` table results now use a unified `goals_metrics` field (with an `exceeded` boolean per metric) instead of individual goal breach objects per row. The `useTableRowAlert` composable was updated to read `exceeded` directly and look up threshold details from the `metricGoals` store, with a generic fallback tooltip when no configured goal is found.

- **Full-row alert overlay**: `TableRowAlert` gained a `fullRow` prop that, when enabled, renders an absolutely-positioned transparent overlay sized to cover the entire table row, enabling the tooltip trigger to span the full row. A `ResizeObserver` keeps the overlay dimensions in sync. Both `InAwaiting` and `InProgress` now pass `fullRow` to their alert cells, and rows with an active alert render their text in emphasis font weight.

- **API hydration of live breaches**: `useMetricGoalAlerts` gained a `hydrateFromApiGoals` action that pre-populates `liveBreaches` from the time metrics API response on load. This is called from `loadTimeMetricsData` in the monitoring store and also on mount in `Monitoring.vue`, ensuring the socket handler does not show a toast for breaches that were already known from the initial fetch.

- **Socket toast deduplication**: `handleViolatingContent` no longer accepts an `isNew` option; it only shows a toast when the metric was not already breaching, regardless of whether the socket event transition is `new` or `update`.

- **Scroll timeout cleanup**: `StatusCards` and `TimeMetrics` now store their `setTimeout` references and clear them in `onUnmounted` to prevent potential memory leaks and post-unmount side effects.

- **`intl-messageformat` upgraded** from `^11.2.5` to `^11.2.9`, pulling in updated `@formatjs` dependencies.

- **Locale additions**: A generic fallback tooltip string (`"generic"`) was added to all four locale files for cases where a row alert is triggered but no configured goal threshold is available.