### PR TITLE
fix: conditionally render RemoveCriterionModal based on isRemoveModalOpen state

### DIFF
--- a/src/components/insights/conversations/ResolutionCriteria/RemoveCriterionModal.vue
+++ b/src/components/insights/conversations/ResolutionCriteria/RemoveCriterionModal.vue
@@ -1,5 +1,6 @@
 <template>
   <UnnnicDialog
+    v-if="isRemoveModalOpen"
     :open="isRemoveModalOpen"
     data-testid="remove-criterion-modal"
     @update:open="handleUpdateOpen"


### PR DESCRIPTION
## Description
### Type of Change
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
The `RemoveCriterionModal` component was not properly resetting its internal state between uses because the `UnnnicDialog` component remained mounted even when closed. This could lead to stale state being displayed when the modal was reopened.

### Summary of Changes
Added a `v-if="isRemoveModalOpen"` directive to the `UnnnicDialog` component in `RemoveCriterionModal.vue`. This ensures the modal is fully unmounted when closed and remounted fresh when opened, preventing any residual state from persisting between interactions.