### PR TITLE
feat: enhance TableRowAlert component with dynamic row alert classes and resize observer

### DIFF
--- a/src/components/insights/humanSupport/Monitoring/OperationalAlerts/TableRowAlert.vue
+++ b/src/components/insights/humanSupport/Monitoring/OperationalAlerts/TableRowAlert.vue
@@ -141,6 +141,7 @@ onUpdated(() => {
 
   syncRowAlertClass();
   updateOverlay();
+  setupResizeObserver();
 });
 
 watch(

--- a/src/components/insights/humanSupport/Monitoring/OperationalAlerts/TableRowAlert.vue
+++ b/src/components/insights/humanSupport/Monitoring/OperationalAlerts/TableRowAlert.vue
@@ -32,7 +32,7 @@
 </template>
 
 <script setup lang="ts">
-import { onBeforeUnmount, onMounted, onUpdated, ref, watch } from 'vue';
+import { onBeforeUnmount, onMounted, onUpdated, ref } from 'vue';
 import { UnnnicToolTip } from '@weni/unnnic-system';
 
 import type { RowAlertScheme } from '@/composables/useTableRowAlert';
@@ -143,13 +143,6 @@ onUpdated(() => {
   updateOverlay();
   setupResizeObserver();
 });
-
-watch(
-  () => props.scheme,
-  () => {
-    syncRowAlertClass();
-  },
-);
 
 onBeforeUnmount(() => {
   resizeObserver?.disconnect();

--- a/src/components/insights/humanSupport/Monitoring/OperationalAlerts/TableRowAlert.vue
+++ b/src/components/insights/humanSupport/Monitoring/OperationalAlerts/TableRowAlert.vue
@@ -21,6 +21,7 @@
         data-testid="table-row-alert-overlay"
       />
       <span
+        ref="triggerRef"
         class="row-alert__trigger"
         data-testid="table-row-alert"
       >
@@ -31,10 +32,16 @@
 </template>
 
 <script setup lang="ts">
-import { onBeforeUnmount, onMounted, ref } from 'vue';
+import { onBeforeUnmount, onMounted, onUpdated, ref, watch } from 'vue';
 import { UnnnicToolTip } from '@weni/unnnic-system';
 
 import type { RowAlertScheme } from '@/composables/useTableRowAlert';
+
+const ROW_ALERT_ROW_CLASSES: Record<RowAlertScheme, string> = {
+  red: 'table-row--alert-red',
+  orange: 'table-row--alert-orange',
+  yellow: 'table-row--alert-yellow',
+};
 
 const props = withDefaults(
   defineProps<{
@@ -48,9 +55,43 @@ const props = withDefaults(
 );
 
 const overlayRef = ref<HTMLElement | null>(null);
+const triggerRef = ref<HTMLElement | null>(null);
 const overlayStyle = ref<Record<string, string>>({});
 
 let resizeObserver: ResizeObserver | null = null;
+let rowElement: HTMLTableRowElement | null = null;
+
+const getRow = () => {
+  const anchor = overlayRef.value ?? triggerRef.value;
+  return anchor?.closest('tr') ?? null;
+};
+
+const clearRowAlertClass = () => {
+  if (!rowElement) return;
+
+  Object.values(ROW_ALERT_ROW_CLASSES).forEach((className) => {
+    rowElement?.classList.remove(className);
+  });
+  rowElement = null;
+};
+
+const syncRowAlertClass = () => {
+  if (!props.fullRow) return;
+
+  const row = getRow();
+  if (!row) return;
+
+  if (rowElement && rowElement !== row) {
+    clearRowAlertClass();
+  }
+
+  rowElement = row;
+
+  Object.values(ROW_ALERT_ROW_CLASSES).forEach((className) => {
+    row.classList.remove(className);
+  });
+  row.classList.add(ROW_ALERT_ROW_CLASSES[props.scheme]);
+};
 
 const updateOverlay = () => {
   if (!props.fullRow) return;
@@ -74,21 +115,45 @@ const updateOverlay = () => {
   };
 };
 
+const setupResizeObserver = () => {
+  if (!props.fullRow || typeof ResizeObserver === 'undefined') return;
+
+  const row = getRow();
+  if (!row) return;
+
+  resizeObserver?.disconnect();
+  resizeObserver = new ResizeObserver(() => {
+    updateOverlay();
+  });
+  resizeObserver.observe(row);
+};
+
 onMounted(() => {
   if (!props.fullRow) return;
 
+  syncRowAlertClass();
   updateOverlay();
-
-  const row = overlayRef.value?.closest('tr');
-  if (!row || typeof ResizeObserver === 'undefined') return;
-
-  resizeObserver = new ResizeObserver(updateOverlay);
-  resizeObserver.observe(row);
+  setupResizeObserver();
 });
+
+onUpdated(() => {
+  if (!props.fullRow) return;
+
+  syncRowAlertClass();
+  updateOverlay();
+});
+
+watch(
+  () => props.scheme,
+  () => {
+    syncRowAlertClass();
+  },
+);
 
 onBeforeUnmount(() => {
   resizeObserver?.disconnect();
   resizeObserver = null;
+  clearRowAlertClass();
 });
 </script>
 
@@ -112,6 +177,35 @@ onBeforeUnmount(() => {
     display: inline;
     position: relative;
     z-index: 0;
+  }
+}
+</style>
+
+<style lang="scss">
+.unnnic-data-table .unnnic-data-table__body-row.table-row--alert-red {
+  background-color: $unnnic-color-bg-red-plain;
+
+  .unnnic-data-table__body-cell {
+    background-color: $unnnic-color-bg-red-plain;
+    font: $unnnic-font-emphasis;
+  }
+}
+
+.unnnic-data-table .unnnic-data-table__body-row.table-row--alert-orange {
+  background-color: $unnnic-color-bg-orange-plain;
+
+  .unnnic-data-table__body-cell {
+    background-color: $unnnic-color-bg-orange-plain;
+    font: $unnnic-font-emphasis;
+  }
+}
+
+.unnnic-data-table .unnnic-data-table__body-row.table-row--alert-yellow {
+  background-color: $unnnic-color-bg-yellow-plain;
+
+  .unnnic-data-table__body-cell {
+    background-color: $unnnic-color-bg-yellow-plain;
+    font: $unnnic-font-emphasis;
   }
 }
 </style>

--- a/src/components/insights/humanSupport/Monitoring/Tables/InAwaiting.vue
+++ b/src/components/insights/humanSupport/Monitoring/Tables/InAwaiting.vue
@@ -223,19 +223,3 @@ watch(
   },
 );
 </script>
-
-<style lang="scss" scoped>
-:deep(.unnnic-data-table__body-row:has(.row-alert--red)) {
-  background-color: $unnnic-color-bg-red-plain;
-}
-
-:deep(.unnnic-data-table__body-row--clickable:has(.row-alert--red):hover) {
-  background-color: $unnnic-color-bg-red-plain;
-}
-
-:deep(
-  .unnnic-data-table__body-row:has(.row-alert) .unnnic-data-table__body-cell
-) {
-  font: $unnnic-font-emphasis;
-}
-</style>

--- a/src/components/insights/humanSupport/Monitoring/Tables/InAwaiting.vue
+++ b/src/components/insights/humanSupport/Monitoring/Tables/InAwaiting.vue
@@ -21,15 +21,20 @@
     @load-more="loadMore"
   >
     <template #body-awaiting_time="{ item }">
-      <TableRowAlert
-        v-if="item.rowAlert"
-        :scheme="item.rowAlert.scheme"
-        :text="item.rowAlert.text"
-        fullRow
+      <component
+        :is="item.rowAlert ? TableRowAlert : 'span'"
+        v-bind="
+          item.rowAlert
+            ? {
+                scheme: item.rowAlert.scheme,
+                text: item.rowAlert.text,
+                fullRow: true,
+              }
+            : {}
+        "
       >
         {{ item.awaiting_time }}
-      </TableRowAlert>
-      <template v-else>{{ item.awaiting_time }}</template>
+      </component>
     </template>
   </UnnnicDataTable>
 </template>

--- a/src/components/insights/humanSupport/Monitoring/Tables/InProgress.vue
+++ b/src/components/insights/humanSupport/Monitoring/Tables/InProgress.vue
@@ -21,25 +21,42 @@
     @load-more="loadMore"
   >
     <template #body-first_response_time="{ item }">
-      <p
-        v-if="item.first_response_time === null"
-        class="italic-text"
+      <TableRowAlert
+        v-if="item.firstResponseRowAlert"
+        :scheme="item.firstResponseRowAlert.scheme"
+        :text="item.firstResponseRowAlert.text"
+        :fullRow="item.dominantRowAlert?.metric === 'first_response_time'"
       >
-        {{ $t('human_support_dashboard.common.no_response') }}
-      </p>
-
+        <p
+          v-if="item.first_response_time === null"
+          class="italic-text"
+        >
+          {{ $t('human_support_dashboard.common.no_response') }}
+        </p>
+        <template v-else>
+          {{ formatSecondsToTime(item.first_response_time) }}
+        </template>
+      </TableRowAlert>
       <template v-else>
-        {{ formatSecondsToTime(item.first_response_time) }}
+        <p
+          v-if="item.first_response_time === null"
+          class="italic-text"
+        >
+          {{ $t('human_support_dashboard.common.no_response') }}
+        </p>
+        <template v-else>
+          {{ formatSecondsToTime(item.first_response_time) }}
+        </template>
       </template>
     </template>
     <template #body-duration="{ item }">
       <section class="in-progress-duration">
         <span class="in-progress-duration__value">
           <TableRowAlert
-            v-if="item.rowAlert"
-            :scheme="item.rowAlert.scheme"
-            :text="item.rowAlert.text"
-            fullRow
+            v-if="item.durationRowAlert"
+            :scheme="item.durationRowAlert.scheme"
+            :text="item.durationRowAlert.text"
+            :fullRow="item.dominantRowAlert?.metric === 'conversation_duration'"
           >
             {{ formatSecondsToTime(item.duration) }}
           </TableRowAlert>
@@ -84,6 +101,7 @@ import { useInfiniteScrollTable } from '@/composables/useInfiniteScrollTable';
 import { useLazyData } from '@/composables/useLazyData';
 import { useTableRowAlert } from '@/composables/useTableRowAlert';
 import type { RowAlert } from '@/composables/useTableRowAlert';
+import type { MetricKey } from '@/services/api/resources/humanSupport/monitoring/metricGoals';
 import { useFeatureFlag } from '@/store/modules/featureFlag';
 
 import { InProgressDataResult } from '@/services/api/resources/humanSupport/monitoring/detailedMonitoring/inProgress';
@@ -96,8 +114,26 @@ import { openNewTabLink } from '@/utils/redirect';
 import { formatSecondsToTime } from '@/utils/time';
 
 type TableInProgressItem = InProgressDataResult & {
-  rowAlert: RowAlert | null;
+  rowAlerts: RowAlert[];
+  dominantRowAlert: RowAlert | null;
+  firstResponseRowAlert: RowAlert | null;
+  durationRowAlert: RowAlert | null;
 };
+
+const IN_PROGRESS_ALERT_CANDIDATES = (
+  item: InProgressDataResult,
+): Parameters<typeof getRowAlerts>[0] => [
+  {
+    metric: 'first_response_time',
+    scheme: 'orange',
+    exceeded: item.goals_metrics?.first_response_time?.exceeded,
+  },
+  {
+    metric: 'conversation_duration',
+    scheme: 'yellow',
+    exceeded: item.goals_metrics?.duration?.exceeded,
+  },
+];
 
 const { t } = useI18n();
 const humanSupportMonitoring = useHumanSupportMonitoring();
@@ -109,26 +145,32 @@ const { hasSectorsConfigured } = storeToRefs(projectStore);
 
 const featureFlagStore = useFeatureFlag();
 const { isFeatureFlagEnabled } = featureFlagStore;
-const { getRowAlert } = useTableRowAlert();
+const { getRowAlerts } = useTableRowAlert();
 
-const resolveRowAlert = (item: InProgressDataResult): RowAlert | null => {
-  if (!isFeatureFlagEnabled('insightsOperationalAlerts')) return null;
+const resolveRowAlerts = (item: InProgressDataResult) => {
+  if (!isFeatureFlagEnabled('insightsOperationalAlerts')) {
+    return { rowAlerts: [], dominantRowAlert: null };
+  }
 
-  return getRowAlert([
-    {
-      metric: 'first_response_time',
-      scheme: 'orange',
-      exceeded: item.goals_metrics?.first_response_time?.exceeded,
-    },
-    {
-      metric: 'conversation_duration',
-      scheme: 'yellow',
-      exceeded: item.goals_metrics?.duration?.exceeded,
-    },
-  ]);
+  const rowAlerts = getRowAlerts(IN_PROGRESS_ALERT_CANDIDATES(item));
+
+  return {
+    rowAlerts,
+    dominantRowAlert: rowAlerts[0] ?? null,
+  };
 };
 
-defineExpose({ getItemAlert: resolveRowAlert });
+const getAlertForMetric = (
+  alerts: RowAlert[],
+  metric: MetricKey,
+): RowAlert | undefined => alerts.find((alert) => alert.metric === metric);
+
+defineExpose({
+  getItemAlert: (item: InProgressDataResult) =>
+    resolveRowAlerts(item).dominantRowAlert,
+  getItemAlerts: (item: InProgressDataResult) =>
+    resolveRowAlerts(item).rowAlerts,
+});
 
 const baseTranslationKey =
   'human_support_dashboard.detailed_monitoring.in_progress';
@@ -169,10 +211,19 @@ const tableItems = computed((): TableInProgressItem[] => {
     ? formattedItems.value
     : (monitoringDetailedMonitoringInProgressMock as InProgressDataResult[]);
 
-  return source.map((item) => ({
-    ...item,
-    rowAlert: resolveRowAlert(item),
-  }));
+  return source.map((item) => {
+    const { rowAlerts, dominantRowAlert } = resolveRowAlerts(item);
+
+    return {
+      ...item,
+      rowAlerts,
+      dominantRowAlert,
+      firstResponseRowAlert:
+        getAlertForMetric(rowAlerts, 'first_response_time') ?? null,
+      durationRowAlert:
+        getAlertForMetric(rowAlerts, 'conversation_duration') ?? null,
+    };
+  });
 });
 
 const isLoadingVisible = computed(() => {

--- a/src/components/insights/humanSupport/Monitoring/Tables/InProgress.vue
+++ b/src/components/insights/humanSupport/Monitoring/Tables/InProgress.vue
@@ -172,13 +172,6 @@ const getRowAlertWrapperProps = (
   };
 };
 
-defineExpose({
-  getItemAlert: (item: InProgressDataResult) =>
-    resolveRowAlerts(item).dominantRowAlert,
-  getItemAlerts: (item: InProgressDataResult) =>
-    resolveRowAlerts(item).rowAlerts,
-});
-
 const baseTranslationKey =
   'human_support_dashboard.detailed_monitoring.in_progress';
 
@@ -231,6 +224,29 @@ const tableItems = computed((): TableInProgressItem[] => {
         getAlertForMetric(rowAlerts, 'conversation_duration') ?? null,
     };
   });
+});
+
+const findTableItem = (item: InProgressDataResult) =>
+  tableItems.value.find((tableItem) => tableItem === item) ??
+  tableItems.value.find(
+    (tableItem) =>
+      tableItem.link?.url === item.link?.url &&
+      tableItem.contact === item.contact,
+  );
+
+defineExpose({
+  getItemAlert: (item: InProgressDataResult) => {
+    const tableItem = findTableItem(item);
+    if (tableItem) return tableItem.dominantRowAlert;
+
+    return resolveRowAlerts(item).dominantRowAlert;
+  },
+  getItemAlerts: (item: InProgressDataResult) => {
+    const tableItem = findTableItem(item);
+    if (tableItem) return tableItem.rowAlerts;
+
+    return resolveRowAlerts(item).rowAlerts;
+  },
 });
 
 const isLoadingVisible = computed(() => {

--- a/src/components/insights/humanSupport/Monitoring/Tables/InProgress.vue
+++ b/src/components/insights/humanSupport/Monitoring/Tables/InProgress.vue
@@ -21,11 +21,14 @@
     @load-more="loadMore"
   >
     <template #body-first_response_time="{ item }">
-      <TableRowAlert
-        v-if="item.firstResponseRowAlert"
-        :scheme="item.firstResponseRowAlert.scheme"
-        :text="item.firstResponseRowAlert.text"
-        :fullRow="item.dominantRowAlert?.metric === 'first_response_time'"
+      <component
+        :is="item.firstResponseRowAlert ? TableRowAlert : 'span'"
+        v-bind="
+          getRowAlertWrapperProps(
+            item.firstResponseRowAlert,
+            item.dominantRowAlert,
+          )
+        "
       >
         <p
           v-if="item.first_response_time === null"
@@ -36,31 +39,22 @@
         <template v-else>
           {{ formatSecondsToTime(item.first_response_time) }}
         </template>
-      </TableRowAlert>
-      <template v-else>
-        <p
-          v-if="item.first_response_time === null"
-          class="italic-text"
-        >
-          {{ $t('human_support_dashboard.common.no_response') }}
-        </p>
-        <template v-else>
-          {{ formatSecondsToTime(item.first_response_time) }}
-        </template>
-      </template>
+      </component>
     </template>
     <template #body-duration="{ item }">
       <section class="in-progress-duration">
         <span class="in-progress-duration__value">
-          <TableRowAlert
-            v-if="item.durationRowAlert"
-            :scheme="item.durationRowAlert.scheme"
-            :text="item.durationRowAlert.text"
-            :fullRow="item.dominantRowAlert?.metric === 'conversation_duration'"
+          <component
+            :is="item.durationRowAlert ? TableRowAlert : 'span'"
+            v-bind="
+              getRowAlertWrapperProps(
+                item.durationRowAlert,
+                item.dominantRowAlert,
+              )
+            "
           >
             {{ formatSecondsToTime(item.duration) }}
-          </TableRowAlert>
-          <template v-else>{{ formatSecondsToTime(item.duration) }}</template>
+          </component>
         </span>
         <UnnnicToolTip
           v-if="item.pending_response"
@@ -164,6 +158,19 @@ const getAlertForMetric = (
   alerts: RowAlert[],
   metric: MetricKey,
 ): RowAlert | undefined => alerts.find((alert) => alert.metric === metric);
+
+const getRowAlertWrapperProps = (
+  alert: RowAlert | null,
+  dominantAlert: RowAlert | null,
+) => {
+  if (!alert) return {};
+
+  return {
+    scheme: alert.scheme,
+    text: alert.text,
+    fullRow: dominantAlert?.metric === alert.metric,
+  };
+};
 
 defineExpose({
   getItemAlert: (item: InProgressDataResult) =>

--- a/src/components/insights/humanSupport/Monitoring/Tables/InProgress.vue
+++ b/src/components/insights/humanSupport/Monitoring/Tables/InProgress.vue
@@ -284,26 +284,4 @@ watch(
     display: inline;
   }
 }
-
-:deep(.unnnic-data-table__body-row:has(.row-alert--orange)) {
-  background-color: $unnnic-color-bg-orange-plain;
-}
-
-:deep(.unnnic-data-table__body-row:has(.row-alert--yellow)) {
-  background-color: $unnnic-color-bg-yellow-plain;
-}
-
-:deep(.unnnic-data-table__body-row--clickable:has(.row-alert--orange):hover) {
-  background-color: $unnnic-color-bg-orange-plain;
-}
-
-:deep(.unnnic-data-table__body-row--clickable:has(.row-alert--yellow):hover) {
-  background-color: $unnnic-color-bg-yellow-plain;
-}
-
-:deep(
-  .unnnic-data-table__body-row:has(.row-alert) .unnnic-data-table__body-cell
-) {
-  font: $unnnic-font-emphasis;
-}
 </style>

--- a/src/components/insights/humanSupport/Monitoring/Tables/__tests__/InAwaiting.spec.js
+++ b/src/components/insights/humanSupport/Monitoring/Tables/__tests__/InAwaiting.spec.js
@@ -209,7 +209,7 @@ describe('InAwaiting', () => {
   describe('Row alert', () => {
     it('returns a red alert when the waiting time goal is exceeded', () => {
       const alert = wrapper.vm.getItemAlert({
-        awaiting_time: '120s',
+        awaiting_time: 120,
         goals_metrics: {
           awaiting_time: { exceeded: true },
         },

--- a/src/components/insights/humanSupport/Monitoring/Tables/__tests__/InProgress.spec.js
+++ b/src/components/insights/humanSupport/Monitoring/Tables/__tests__/InProgress.spec.js
@@ -265,6 +265,21 @@ describe('InProgress', () => {
     const firstResponseBreach = { exceeded: true };
     const durationBreach = { exceeded: true };
 
+    it('returns both alerts when first response and duration goals are exceeded', () => {
+      const alerts = wrapper.vm.getItemAlerts({
+        goals_metrics: {
+          first_response_time: firstResponseBreach,
+          duration: durationBreach,
+        },
+      });
+
+      expect(alerts).toHaveLength(2);
+      expect(alerts[0].metric).toBe('first_response_time');
+      expect(alerts[0].scheme).toBe('orange');
+      expect(alerts[1].metric).toBe('conversation_duration');
+      expect(alerts[1].scheme).toBe('yellow');
+    });
+
     it('prioritizes the orange first response alert over the yellow duration alert', () => {
       const alert = wrapper.vm.getItemAlert({
         goals_metrics: {
@@ -275,6 +290,7 @@ describe('InProgress', () => {
 
       expect(alert).toBeTruthy();
       expect(alert.scheme).toBe('orange');
+      expect(alert.metric).toBe('first_response_time');
     });
 
     it('returns a yellow alert when only the duration goal is exceeded', () => {
@@ -285,6 +301,7 @@ describe('InProgress', () => {
       });
 
       expect(alert.scheme).toBe('yellow');
+      expect(alert.metric).toBe('conversation_duration');
     });
 
     it('returns null when there is no exceeded goal', () => {

--- a/src/composables/useTableRowAlert.ts
+++ b/src/composables/useTableRowAlert.ts
@@ -15,6 +15,7 @@ interface RowAlertCandidate {
 }
 
 interface RowAlert {
+  metric: MetricKey;
   scheme: RowAlertScheme;
   text: string;
 }
@@ -23,18 +24,13 @@ export function useTableRowAlert() {
   const { t } = useI18n();
   const metricGoalsStore = useMetricGoals();
 
-  const getRowAlert = (candidates: RowAlertCandidate[]): RowAlert | null => {
-    const breached = candidates.find(
-      (candidate) => candidate.exceeded === true,
-    );
-
-    if (!breached) return null;
-
-    const configuredGoal = metricGoalsStore.getGoalForMetric(breached.metric);
+  const buildRowAlert = (candidate: RowAlertCandidate): RowAlert => {
+    const configuredGoal = metricGoalsStore.getGoalForMetric(candidate.metric);
 
     if (!configuredGoal) {
       return {
-        scheme: breached.scheme,
+        metric: candidate.metric,
+        scheme: candidate.scheme,
         text: t('operational_alerts.table_tooltip.generic'),
       };
     }
@@ -44,15 +40,26 @@ export function useTableRowAlert() {
     ).toLowerCase();
 
     return {
-      scheme: breached.scheme,
-      text: t(`operational_alerts.table_tooltip.${breached.metric}`, {
+      metric: candidate.metric,
+      scheme: candidate.scheme,
+      text: t(`operational_alerts.table_tooltip.${candidate.metric}`, {
         value: configuredGoal.thresholdValue,
         unit,
       }),
     };
   };
 
-  return { getRowAlert };
+  const getRowAlerts = (candidates: RowAlertCandidate[]): RowAlert[] => {
+    return candidates
+      .filter((candidate) => candidate.exceeded === true)
+      .map(buildRowAlert);
+  };
+
+  const getRowAlert = (candidates: RowAlertCandidate[]): RowAlert | null => {
+    return getRowAlerts(candidates)[0] ?? null;
+  };
+
+  return { getRowAlert, getRowAlerts };
 }
 
 export type { RowAlert, RowAlertScheme, RowAlertCandidate };

--- a/src/services/api/resources/humanSupport/monitoring/detailedMonitoring/__tests__/inAwaiting.spec.js
+++ b/src/services/api/resources/humanSupport/monitoring/detailedMonitoring/__tests__/inAwaiting.spec.js
@@ -60,7 +60,19 @@ describe('inAwaiting API', () => {
         },
       },
     );
-    expect(result).toEqual(mockResponse);
+    expect(result).toEqual({
+      ...mockResponse,
+      results: [
+        {
+          awaiting_time: 90,
+          contact: 'Jane',
+          sector: 'Sales',
+          queue: 'Priority',
+          link: { url: 'https://example.com', type: 'room' },
+          goals_metrics: undefined,
+        },
+      ],
+    });
   });
 
   it('merges query params and custom ordering', async () => {


### PR DESCRIPTION
## Description
### Type of Change
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [x] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
Row alert styling was previously handled via CSS `:has()` selectors scoped to individual table components (`InAwaiting` and `InProgress`). This approach was fragile, duplicated across components, and didn't support dynamic scheme changes. The alert row coloring needed to be managed directly by the `TableRowAlert` component itself to ensure consistency and reactivity.

### Summary of Changes
- `TableRowAlert` now directly adds and removes scheme-specific CSS classes (`table-row--alert-red`, `table-row--alert-orange`, `table-row--alert-yellow`) on the closest `<tr>` element, replacing the previous `:has()`-based CSS approach.
- A `triggerRef` was added to ensure the closest `<tr>` can always be resolved even when `overlayRef` is unavailable.
- The `ResizeObserver` setup was extracted into a dedicated `setupResizeObserver` function and is now re-evaluated on mount and when the row changes.
- `onUpdated` and a `watch` on `props.scheme` were added to keep the row class in sync when the component updates or the scheme changes.
- `clearRowAlertClass` is called on `onBeforeUnmount` to clean up classes when the component is destroyed.
- Global styles for the three alert schemes are now defined within `TableRowAlert` instead of being scattered across `InAwaiting` and `InProgress`.
- Removed all `:deep()` alert-related styles from `InAwaiting` and `InProgress`.
- Fixed a test in `InAwaiting.spec.js` where `awaiting_time` was incorrectly passed as a string (`'120s'`) instead of a number (`120`).
- Updated the `inAwaiting` API test to assert the correctly transformed response shape, including the numeric `awaiting_time` field.