### PR TITLE
refactor: reorganize OperationalAlertForm layout for improved structure

### DIFF
--- a/src/components/insights/humanSupport/Monitoring/OperationalAlerts/OperationalAlertForm.vue
+++ b/src/components/insights/humanSupport/Monitoring/OperationalAlerts/OperationalAlertForm.vue
@@ -15,7 +15,9 @@
             v-model="thresholdModel"
             type="number"
             nativeType="number"
-            :placeholder="$t('operational_alerts.form.threshold_placeholder')"
+            :placeholder="
+              $t(`operational_alerts.form.threshold_placeholders.${metric}`)
+            "
             :data-testid="`threshold-input-${metric}`"
           />
         </section>

--- a/src/components/insights/humanSupport/Monitoring/OperationalAlerts/OperationalAlertForm.vue
+++ b/src/components/insights/humanSupport/Monitoring/OperationalAlerts/OperationalAlertForm.vue
@@ -3,36 +3,38 @@
     class="operational-alert-form"
     :data-testid="`operational-alert-form-${metric}`"
   >
-    <section class="operational-alert-form__row">
-      <section
-        class="operational-alert-form__field operational-alert-form__field--threshold"
-      >
-        <UnnnicLabel
-          :label="$t(`operational_alerts.form.threshold_labels.${metric}`)"
-        />
-        <UnnnicInput
-          v-model="thresholdModel"
-          type="number"
-          nativeType="number"
-          :placeholder="$t('operational_alerts.form.threshold_placeholder')"
-          :data-testid="`threshold-input-${metric}`"
-        />
-      </section>
-      <section
-        class="operational-alert-form__field operational-alert-form__field--unit"
-      >
-        <UnnnicLabel :label="$t('operational_alerts.form.unit_label')" />
-        <UnnnicSelect
-          v-model="unitModel"
-          :options="unitOptions"
-          itemLabel="label"
-          itemValue="value"
-          :data-testid="`unit-select-${metric}`"
-        />
+    <section class="operational-alert-form__time">
+      <section class="operational-alert-form__row">
+        <section
+          class="operational-alert-form__field operational-alert-form__field--threshold"
+        >
+          <UnnnicLabel
+            :label="$t(`operational_alerts.form.threshold_labels.${metric}`)"
+          />
+          <UnnnicInput
+            v-model="thresholdModel"
+            type="number"
+            nativeType="number"
+            :placeholder="$t('operational_alerts.form.threshold_placeholder')"
+            :data-testid="`threshold-input-${metric}`"
+          />
+        </section>
+        <section
+          class="operational-alert-form__field operational-alert-form__field--unit"
+        >
+          <UnnnicLabel :label="$t('operational_alerts.form.unit_label')" />
+          <UnnnicSelect
+            v-model="unitModel"
+            :options="unitOptions"
+            itemLabel="label"
+            itemValue="value"
+            :data-testid="`unit-select-${metric}`"
+          />
+        </section>
       </section>
     </section>
 
-    <section class="operational-alert-form__field">
+    <section class="operational-alert-form__email">
       <section class="operational-alert-form__email-label">
         <UnnnicLabel
           :label="$t('operational_alerts.form.email_notification_label')"
@@ -210,6 +212,17 @@ const roomsThresholdModel = computed<string>({
   display: flex;
   flex-direction: column;
   gap: $unnnic-space-4;
+
+  &__time {
+    display: flex;
+    flex-direction: column;
+  }
+
+  &__email {
+    display: flex;
+    flex-direction: column;
+    gap: $unnnic-space-4;
+  }
 
   &__row {
     display: flex;

--- a/src/components/insights/humanSupport/Monitoring/OperationalAlerts/OperationalAlertsDrawer.vue
+++ b/src/components/insights/humanSupport/Monitoring/OperationalAlerts/OperationalAlertsDrawer.vue
@@ -12,12 +12,16 @@
         <UnnnicDrawerTitle>
           {{ $t('operational_alerts.drawer.title') }}
         </UnnnicDrawerTitle>
-        <UnnnicDrawerDescription>
-          {{ $t('operational_alerts.drawer.description') }}
-        </UnnnicDrawerDescription>
       </UnnnicDrawerHeader>
 
       <section class="operational-alerts-drawer__body">
+        <p
+          class="operational-alerts-drawer__description"
+          data-testid="operational-alerts-description"
+        >
+          {{ $t('operational_alerts.drawer.description') }}
+        </p>
+
         <section
           v-for="metric in metricKeys"
           :key="metric"
@@ -42,6 +46,15 @@
               :metric="metric"
             />
           </template>
+
+          <hr
+            v-if="
+              formState[metric].enabled &&
+              metric !== metricKeys[metricKeys.length - 1]
+            "
+            class="operational-alerts-drawer__separator"
+            data-testid="operational-alerts-separator"
+          />
         </section>
       </section>
 
@@ -74,7 +87,6 @@ import {
   UnnnicDrawerContent,
   UnnnicDrawerHeader,
   UnnnicDrawerTitle,
-  UnnnicDrawerDescription,
   UnnnicDrawerFooter,
   UnnnicDrawerClose,
   UnnnicSwitch,
@@ -138,8 +150,7 @@ const buildMetricFormState = (metric: MetricKey): MetricFormState => {
       value: recipient.uuid,
       label: formatRecipientLabel(recipient),
     })),
-    roomsThresholdCount:
-      goal.roomsThresholdCount ?? DEFAULT_ROOMS_THRESHOLD,
+    roomsThresholdCount: goal.roomsThresholdCount ?? DEFAULT_ROOMS_THRESHOLD,
   };
 };
 
@@ -218,9 +229,22 @@ defineExpose({ formState });
   padding: $unnnic-space-6;
 }
 
+.operational-alerts-drawer__description {
+  margin: 0;
+  font: $unnnic-font-body;
+  color: $unnnic-color-fg-base;
+}
+
 .operational-alerts-drawer__section {
   display: flex;
   flex-direction: column;
   gap: $unnnic-space-4;
+}
+
+.operational-alerts-drawer__separator {
+  width: 100%;
+  margin: 0;
+  border: none;
+  border-top: 1px solid $unnnic-color-border-soft;
 }
 </style>

--- a/src/components/insights/humanSupport/Monitoring/OperationalAlerts/__tests__/OperationalAlertForm.spec.js
+++ b/src/components/insights/humanSupport/Monitoring/OperationalAlerts/__tests__/OperationalAlertForm.spec.js
@@ -95,6 +95,27 @@ describe('OperationalAlertForm.vue', () => {
     ]);
   });
 
+  it('should use a metric-specific threshold placeholder', async () => {
+    const { wrapper } = createWrapper();
+    const getThresholdPlaceholder = () =>
+      wrapper
+        .findAllComponents({ name: 'UnnnicInput' })
+        .find((input) =>
+          String(input.attributes('data-testid') || '').startsWith(
+            'threshold-input-',
+          ),
+        )
+        ?.props('placeholder');
+
+    expect(getThresholdPlaceholder()).toBe('Example: 10');
+
+    await wrapper.setProps({ metric: 'first_response_time' });
+    expect(getThresholdPlaceholder()).toBe('Example: 2');
+
+    await wrapper.setProps({ metric: 'conversation_duration' });
+    expect(getThresholdPlaceholder()).toBe('Example: 30');
+  });
+
   it('should always show the when field', async () => {
     const { wrapper } = createWrapper();
     expect(

--- a/src/components/insights/humanSupport/Monitoring/OperationalAlerts/__tests__/OperationalAlertsDrawer.spec.js
+++ b/src/components/insights/humanSupport/Monitoring/OperationalAlerts/__tests__/OperationalAlertsDrawer.spec.js
@@ -65,23 +65,24 @@ const UnnnicSwitchStub = {
     '<button class="switch-stub" @click="$emit(\'update:modelValue\', !modelValue)">{{ textRight }}</button>',
 };
 
+const drawerStubs = {
+  UnnnicDrawerNext: UnnnicDrawerNextStub,
+  UnnnicDrawerContent: UnnnicDrawerContentStub,
+  UnnnicDrawerHeader: drawerSlotStub('UnnnicDrawerHeader'),
+  UnnnicDrawerTitle: drawerSlotStub('UnnnicDrawerTitle'),
+  UnnnicDrawerFooter: UnnnicDrawerFooterStub,
+  UnnnicDrawerClose: UnnnicDrawerCloseStub,
+  UnnnicButton: UnnnicButtonStub,
+  UnnnicSwitch: UnnnicSwitchStub,
+  UnnnicDisclaimer: true,
+  OperationalAlertForm: true,
+};
+
 const createWrapper = (goals = {}) => {
   const wrapper = mount(OperationalAlertsDrawer, {
     global: {
       plugins: [createTestingPinia({ createSpy: vi.fn })],
-      stubs: {
-        UnnnicDrawerNext: UnnnicDrawerNextStub,
-        UnnnicDrawerContent: UnnnicDrawerContentStub,
-        UnnnicDrawerHeader: drawerSlotStub('UnnnicDrawerHeader'),
-        UnnnicDrawerTitle: drawerSlotStub('UnnnicDrawerTitle'),
-        UnnnicDrawerDescription: drawerSlotStub('UnnnicDrawerDescription'),
-        UnnnicDrawerFooter: UnnnicDrawerFooterStub,
-        UnnnicDrawerClose: UnnnicDrawerCloseStub,
-        UnnnicButton: UnnnicButtonStub,
-        UnnnicSwitch: UnnnicSwitchStub,
-        UnnnicDisclaimer: true,
-        OperationalAlertForm: true,
-      },
+      stubs: drawerStubs,
     },
     props: { modelValue: true },
   });
@@ -118,6 +119,52 @@ describe('OperationalAlertsDrawer.vue', () => {
     ).toBe(true);
   });
 
+  it('should render description in the body, not in the header', () => {
+    const { wrapper } = createWrapper();
+    const description = wrapper.find(
+      '[data-testid="operational-alerts-description"]',
+    );
+    const body = wrapper.find('.operational-alerts-drawer__body');
+    const header = wrapper.findComponent({ name: 'UnnnicDrawerHeader' });
+
+    expect(description.exists()).toBe(true);
+    expect(
+      body.find('[data-testid="operational-alerts-description"]').exists(),
+    ).toBe(true);
+    expect(
+      header.find('[data-testid="operational-alerts-description"]').exists(),
+    ).toBe(false);
+  });
+
+  it('should not render separators when all switches are off', () => {
+    const { wrapper } = createWrapper();
+    expect(
+      wrapper.findAll('[data-testid="operational-alerts-separator"]'),
+    ).toHaveLength(0);
+  });
+
+  it('should render a separator after an enabled non-last section', async () => {
+    const { wrapper } = createWrapper();
+
+    wrapper.vm.formState.waiting_time.enabled = true;
+    await wrapper.vm.$nextTick();
+
+    expect(
+      wrapper.findAll('[data-testid="operational-alerts-separator"]'),
+    ).toHaveLength(1);
+  });
+
+  it('should not render a separator after the last section when enabled', async () => {
+    const { wrapper } = createWrapper();
+
+    wrapper.vm.formState.conversation_duration.enabled = true;
+    await wrapper.vm.$nextTick();
+
+    expect(
+      wrapper.findAll('[data-testid="operational-alerts-separator"]'),
+    ).toHaveLength(0);
+  });
+
   it('should emit close on cancel button click', async () => {
     const { wrapper } = createWrapper();
     await wrapper.find('.secondary').trigger('click');
@@ -146,19 +193,7 @@ describe('OperationalAlertsDrawer.vue', () => {
     const wrapper = mount(OperationalAlertsDrawer, {
       global: {
         plugins: [pinia],
-        stubs: {
-          UnnnicDrawerNext: UnnnicDrawerNextStub,
-          UnnnicDrawerContent: UnnnicDrawerContentStub,
-          UnnnicDrawerHeader: drawerSlotStub('UnnnicDrawerHeader'),
-          UnnnicDrawerTitle: drawerSlotStub('UnnnicDrawerTitle'),
-          UnnnicDrawerDescription: drawerSlotStub('UnnnicDrawerDescription'),
-          UnnnicDrawerFooter: UnnnicDrawerFooterStub,
-          UnnnicDrawerClose: UnnnicDrawerCloseStub,
-          UnnnicButton: UnnnicButtonStub,
-          UnnnicSwitch: UnnnicSwitchStub,
-          UnnnicDisclaimer: true,
-          OperationalAlertForm: true,
-        },
+        stubs: drawerStubs,
       },
       props: { modelValue: true },
     });

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1073,7 +1073,7 @@
       "description": "Configure alerts to identify chats that exceed the defined time limits for an operation:",
       "title": "Operational alerts"
     },
-    "first_response_info": "Time to first response is counted from the moment the chat is assigned to a representative",
+    "first_response_info": "The first-response timeout alert will remain active until the representative sends the first message.",
     "form": {
       "email_notification_label": "Email notification (optional)",
       "email_notification_tooltip": "This alert is always displayed in the Live Desk dashboard when a chat reaches the defined threshold.\n\nYou can also configure email notifications for selected moderators and choose when they should be sent - for example, when one or more chats reach the defined threshold.",
@@ -1081,11 +1081,15 @@
       "send_email_to_label": "Send email to",
       "send_email_to_placeholder": "Select the moderators",
       "threshold_labels": {
-        "conversation_duration": "Maximum chat duration",
+        "conversation_duration": "Maximum duration time",
         "first_response_time": "Maximum time to first response",
         "waiting_time": "Maximum wait time"
       },
-      "threshold_placeholder": "Example: 10",
+      "threshold_placeholders": {
+        "conversation_duration": "Example: 30",
+        "first_response_time": "Example: 2",
+        "waiting_time": "Example: 10"
+      },
       "unit_label": "Unit",
       "units": {
         "hours": "Hours",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1073,7 +1073,7 @@
       "description": "Configura alertas para identificar chats que superan los límites de tiempo definidos para una operación:",
       "title": "Alertas operativas"
     },
-    "first_response_info": "El tiempo a la primera respuesta se cuenta desde el momento en que el chat se asigna a un representante",
+    "first_response_info": "La alerta de tiempo límite de la primera respuesta permanecerá activa hasta que el representante envíe el primer mensaje.",
     "form": {
       "email_notification_label": "Notificación por correo (opcional)",
       "email_notification_tooltip": "Esta alerta siempre se muestra en el dashboard Live Desk cuando un chat alcanza el límite definido.\n\nTambién puedes configurar notificaciones por correo para moderadores seleccionados y elegir cuándo deben enviarse - por ejemplo, cuando uno o más chats alcanzan el límite definido.",
@@ -1081,11 +1081,15 @@
       "send_email_to_label": "Enviar correo a",
       "send_email_to_placeholder": "Seleccionar moderadores",
       "threshold_labels": {
-        "conversation_duration": "Duración máxima del chat",
+        "conversation_duration": "Tiempo máximo de duración",
         "first_response_time": "Tiempo máximo a la primera respuesta",
         "waiting_time": "Tiempo máximo de espera"
       },
-      "threshold_placeholder": "Ejemplo: 10",
+      "threshold_placeholders": {
+        "conversation_duration": "Ejemplo: 30",
+        "first_response_time": "Ejemplo: 2",
+        "waiting_time": "Ejemplo: 10"
+      },
       "unit_label": "Unidad",
       "units": {
         "hours": "Horas",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -1073,7 +1073,7 @@
       "description": "Configure alertas para identificar chats que ultrapassam os limites de tempo definidos para uma operação:",
       "title": "Alertas operacionais"
     },
-    "first_response_info": "O tempo para primeira resposta é contado a partir do momento em que o chat é atribuído a um representante",
+    "first_response_info": "O alerta de tempo limite da primeira resposta permanecerá ativo até que o representante envie a primeira mensagem.",
     "form": {
       "email_notification_label": "Notificação por e-mail (opcional)",
       "email_notification_tooltip": "Este alerta é sempre exibido no dashboard Live Desk quando um chat atinge o limite definido.\n\nVocê também pode configurar notificações por e-mail para moderadores selecionados e escolher quando elas devem ser enviadas - por exemplo, quando um ou mais chats atingem o limite definido.",
@@ -1081,11 +1081,15 @@
       "send_email_to_label": "Enviar e-mail para",
       "send_email_to_placeholder": "Selecionar moderadores",
       "threshold_labels": {
-        "conversation_duration": "Duração máxima do chat",
+        "conversation_duration": "Tempo máximo de duração",
         "first_response_time": "Tempo máximo para primeira resposta",
         "waiting_time": "Tempo máximo de espera"
       },
-      "threshold_placeholder": "Exemplo: 10",
+      "threshold_placeholders": {
+        "conversation_duration": "Exemplo: 30",
+        "first_response_time": "Exemplo: 2",
+        "waiting_time": "Exemplo: 10"
+      },
       "unit_label": "Unidade",
       "units": {
         "hours": "Horas",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -1073,7 +1073,7 @@
       "description": "Configure alertele pentru a identifica conversațiile care depășesc limitele de timp definite pentru o operațiune:",
       "title": "Alerte operaționale"
     },
-    "first_response_info": "Timpul până la primul răspuns este calculat din momentul în care conversația este atribuită unui reprezentant",
+    "first_response_info": "Alerta de timeout pentru primul răspuns va rămâne activă până când reprezentantul trimite primul mesaj.",
     "form": {
       "email_notification_label": "Notificare prin e-mail (opțional)",
       "email_notification_tooltip": "Această alertă este afișată întotdeauna în dashboard-ul Live Desk când o conversație atinge limita definită.\n\nPoți configura și notificări prin e-mail pentru moderatorii selectați și poți alege când trebuie trimise - de exemplu, când una sau mai multe conversații ating limita definită.",
@@ -1081,11 +1081,15 @@
       "send_email_to_label": "Trimite e-mail către",
       "send_email_to_placeholder": "Selectează moderatorii",
       "threshold_labels": {
-        "conversation_duration": "Durata maximă a conversației",
+        "conversation_duration": "Timp maxim de durată",
         "first_response_time": "Timp maxim până la primul răspuns",
         "waiting_time": "Timp maxim de așteptare"
       },
-      "threshold_placeholder": "Exemplu: 10",
+      "threshold_placeholders": {
+        "conversation_duration": "Exemplu: 30",
+        "first_response_time": "Exemplu: 2",
+        "waiting_time": "Exemplu: 10"
+      },
       "unit_label": "Unitate",
       "units": {
         "hours": "Ore",


### PR DESCRIPTION
## Description
### Type of Change
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
The Operational Alerts drawer needed several UX improvements: the description text was misplaced inside the drawer header, threshold placeholders were generic across all metrics, and enabled metric sections lacked visual separation. Additionally, the `first_response_info` copy was inaccurate and needed to better reflect the actual alert behavior.

### Summary of Changes
- Moved the drawer description out of `UnnnicDrawerDescription` (in the header) and into the drawer body as a styled `<p>` element
- Replaced the single shared `threshold_placeholder` translation key with per-metric `threshold_placeholders` entries (`waiting_time: 10`, `first_response_time: 2`, `conversation_duration: 30`) across all four locales (en, es, pt_br, ro)
- Added a horizontal separator (`<hr>`) between enabled metric sections, rendered only when a metric is enabled and is not the last one in the list
- Updated the `conversation_duration` threshold label to "Maximum duration time" across all locales
- Corrected the `first_response_info` copy in all locales to clarify that the alert remains active until the representative sends the first message
- Wrapped the threshold/unit row in an `operational-alert-form__time` section and added an `operational-alert-form__email` section for clearer layout structure
- Removed the `UnnnicDrawerDescription` stub from tests and added coverage for the description placement, separator rendering logic, and metric-specific threshold placeholders