### PR TITLE
[ENGAGE-8790] refactor: update localization keys for agent terminology across multiple languages

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1033,14 +1033,14 @@
     "filters": {
       "sector": "Industry",
       "select_sector": "Select industry",
-      "agent": "Agent",
-      "select_agent": "Select an agent",
+      "representative": "Representative",
+      "select_representative": "Select a representative",
       "queue": "Queue",
       "select_queue": "Select a queue",
       "tag": "Tag",
       "select_tag": "Select a tag",
       "all_sectors": "All industries",
-      "all_agents": "All agents",
+      "all_representatives": "All representatives",
       "all_queues": "All queues",
       "all_tags": "All tags"
     },

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1033,14 +1033,14 @@
     "filters": {
       "sector": "Sector",
       "select_sector": "Selecciona el sector",
-      "agent": "Agente",
-      "select_agent": "Selecciona el agente",
+      "representative": "Representante",
+      "select_representative": "Selecciona el representante",
       "queue": "Cola",
       "select_queue": "Selecciona la cola",
       "tag": "Tag",
       "select_tag": "Selecciona la tag",
       "all_sectors": "Todos los sectores",
-      "all_agents": "Todos los agentes",
+      "all_representatives": "Todos los representantes",
       "all_queues": "Todas las colas",
       "all_tags": "Todas las tags"
     },

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -1033,14 +1033,14 @@
     "filters": {
       "sector": "Setor",
       "select_sector": "Selecione o setor",
-      "agent": "Agente",
-      "select_agent": "Selecione o agente",
+      "representative": "Atendente",
+      "select_representative": "Selecione o atendente",
       "queue": "Fila",
       "select_queue": "Selecione a fila",
       "tag": "Tag",
       "select_tag": "Selecione a tag",
       "all_sectors": "Todos os setores",
-      "all_agents": "Todos os agentes",
+      "all_representatives": "Todos os atendentes",
       "all_queues": "Todas as filas",
       "all_tags": "Todas as tags"
     },

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -1033,14 +1033,14 @@
     "filters": {
       "sector": "Sector de activitate",
       "select_sector": "Selectează un sector de activitate",
-      "agent": "Agent",
-      "select_agent": "Alege un agent",
+      "representative": "Reprezentant",
+      "select_representative": "Selectează un reprezentant",
       "queue": "Coadă",
       "select_queue": "Selectează o coadă",
       "tag": "Etichetă",
       "select_tag": "Alege o etichetă",
       "all_sectors": "Toate sectoarele de activitate",
-      "all_agents": "Toți agenții",
+      "all_representatives": "Toți reprezentanții",
       "all_queues": "Toate cozile",
       "all_tags": "Toate etichetele"
     },


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [x] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Summary of Changes
<!--- Describe your changes in detail -->
- Fix missing translation key
- Replaced "agent" with "representative" in English, Spanish, Portuguese, and Romanian localization files to ensure consistent terminology throughout the application.