### PR TITLE
[ENGAGE-8864] feat: add viewer permission verification and hide operational alerts for viewers

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -153,6 +153,7 @@ export default {
       this.getDashboards().then(() => {
         this.handleRedirectToHumanServiceDashboard();
       });
+      this.verifyIsViewerPermission();
     } catch (error) {
       console.error(error);
     }
@@ -177,7 +178,7 @@ export default {
       'checkHasAbandonedCartRecoveryConfigured',
       'getAbandonedCartRecoveryCost',
     ]),
-    ...mapActions(useUser, ['setEmail']),
+    ...mapActions(useUser, ['setEmail', 'verifyIsViewerPermission']),
     ...mapActions(useOnboarding, [
       'setOnboardingRef',
       'setShowCreateDashboardOnboarding',

--- a/src/components/insights/Layout/Headers/HeaderHumanSupport.vue
+++ b/src/components/insights/Layout/Headers/HeaderHumanSupport.vue
@@ -31,6 +31,10 @@ import { useHumanSupport } from '@/store/modules/humanSupport/humanSupport';
 import { useDashboards } from '@/store/modules/dashboards';
 import { useProject } from '@/store/modules/project';
 import { useFeatureFlag } from '@/store/modules/featureFlag';
+import { useUser } from '@/store/modules/user';
+
+const userStore = useUser();
+const { isViewerPermission } = storeToRefs(userStore);
 
 const projectStore = useProject();
 const { hasSectorsConfigured } = storeToRefs(projectStore);
@@ -48,6 +52,9 @@ const isMonitoring = computed(() => activeTab.value === 'monitoring');
 const hasFilters = computed(() => !!currentDashboardFilters.value.length);
 
 const showOperationalAlerts = computed(
-  () => isMonitoring.value && isFeatureFlagEnabled('insightsOperationalAlerts'),
+  () =>
+    isMonitoring.value &&
+    isFeatureFlagEnabled('insightsOperationalAlerts') &&
+    !isViewerPermission.value,
 );
 </script>

--- a/src/components/insights/humanSupport/Monitoring/OperationalAlerts/OperationalAlertForm.vue
+++ b/src/components/insights/humanSupport/Monitoring/OperationalAlerts/OperationalAlertForm.vue
@@ -18,6 +18,7 @@
             :placeholder="
               $t(`operational_alerts.form.threshold_placeholders.${metric}`)
             "
+            :disabled="readonly"
             :data-testid="`threshold-input-${metric}`"
           />
         </section>
@@ -30,6 +31,7 @@
             :options="unitOptions"
             itemLabel="label"
             itemValue="value"
+            :disabled="readonly"
             :data-testid="`unit-select-${metric}`"
           />
         </section>
@@ -68,6 +70,7 @@
             :modelValue="selectedRecipients"
             source="agents"
             keyValueField="uuid"
+            :disabled="readonly"
             :placeholder="
               $t('operational_alerts.form.send_email_to_placeholder')
             "
@@ -88,6 +91,7 @@
             type="number"
             nativeType="number"
             :placeholder="$t('operational_alerts.form.when_placeholder')"
+            :disabled="readonly"
             :data-testid="`when-input-${metric}`"
           />
           <p class="operational-alert-form__helper">
@@ -125,6 +129,7 @@ interface RecipientOption {
 
 defineProps<{
   metric: MetricKey;
+  readonly?: boolean;
 }>();
 
 const model = defineModel<MetricFormState>({ required: true });

--- a/src/components/insights/humanSupport/Monitoring/OperationalAlerts/OperationalAlertForm.vue
+++ b/src/components/insights/humanSupport/Monitoring/OperationalAlerts/OperationalAlertForm.vue
@@ -18,7 +18,6 @@
             :placeholder="
               $t(`operational_alerts.form.threshold_placeholders.${metric}`)
             "
-            :disabled="readonly"
             :data-testid="`threshold-input-${metric}`"
           />
         </section>
@@ -31,7 +30,6 @@
             :options="unitOptions"
             itemLabel="label"
             itemValue="value"
-            :disabled="readonly"
             :data-testid="`unit-select-${metric}`"
           />
         </section>
@@ -70,7 +68,6 @@
             :modelValue="selectedRecipients"
             source="agents"
             keyValueField="uuid"
-            :disabled="readonly"
             :placeholder="
               $t('operational_alerts.form.send_email_to_placeholder')
             "
@@ -91,7 +88,6 @@
             type="number"
             nativeType="number"
             :placeholder="$t('operational_alerts.form.when_placeholder')"
-            :disabled="readonly"
             :data-testid="`when-input-${metric}`"
           />
           <p class="operational-alert-form__helper">
@@ -129,7 +125,6 @@ interface RecipientOption {
 
 defineProps<{
   metric: MetricKey;
-  readonly?: boolean;
 }>();
 
 const model = defineModel<MetricFormState>({ required: true });

--- a/src/components/insights/humanSupport/Monitoring/OperationalAlerts/OperationalAlertsDrawer.vue
+++ b/src/components/insights/humanSupport/Monitoring/OperationalAlerts/OperationalAlertsDrawer.vue
@@ -32,7 +32,6 @@
             v-model="formState[metric].enabled"
             :textRight="$t(`operational_alerts.sections.${metric}`)"
             :data-testid="`operational-alerts-switch-${metric}`"
-            :disabled="isViewerPermission"
           />
 
           <template v-if="formState[metric].enabled">
@@ -45,7 +44,6 @@
             <OperationalAlertForm
               v-model="formState[metric]"
               :metric="metric"
-              :readonly="isViewerPermission"
             />
           </template>
 
@@ -65,12 +63,11 @@
           <UnnnicButton
             class="secondary"
             type="tertiary"
-            :text="!isViewerPermission ? $t('cancel') : $t('close')"
+            :text="$t('cancel')"
             :disabled="savingGoals"
           />
         </UnnnicDrawerClose>
         <UnnnicButton
-          v-if="!isViewerPermission"
           class="primary"
           type="primary"
           :text="$t('save')"
@@ -103,11 +100,6 @@ import {
   MetricKey,
   formatRecipientLabel,
 } from '@/services/api/resources/humanSupport/monitoring/metricGoals';
-
-import { useUser } from '@/store/modules/user';
-
-const userStore = useUser();
-const { isViewerPermission } = storeToRefs(userStore);
 
 defineProps<{
   modelValue: boolean;

--- a/src/components/insights/humanSupport/Monitoring/OperationalAlerts/OperationalAlertsDrawer.vue
+++ b/src/components/insights/humanSupport/Monitoring/OperationalAlerts/OperationalAlertsDrawer.vue
@@ -32,6 +32,7 @@
             v-model="formState[metric].enabled"
             :textRight="$t(`operational_alerts.sections.${metric}`)"
             :data-testid="`operational-alerts-switch-${metric}`"
+            :disabled="isViewerPermission"
           />
 
           <template v-if="formState[metric].enabled">
@@ -44,6 +45,7 @@
             <OperationalAlertForm
               v-model="formState[metric]"
               :metric="metric"
+              :readonly="isViewerPermission"
             />
           </template>
 
@@ -63,11 +65,12 @@
           <UnnnicButton
             class="secondary"
             type="tertiary"
-            :text="$t('cancel')"
+            :text="!isViewerPermission ? $t('cancel') : $t('close')"
             :disabled="savingGoals"
           />
         </UnnnicDrawerClose>
         <UnnnicButton
+          v-if="!isViewerPermission"
           class="primary"
           type="primary"
           :text="$t('save')"
@@ -81,18 +84,7 @@
 </template>
 
 <script setup lang="ts">
-import {
-  UnnnicButton,
-  UnnnicDrawerNext,
-  UnnnicDrawerContent,
-  UnnnicDrawerHeader,
-  UnnnicDrawerTitle,
-  UnnnicDrawerFooter,
-  UnnnicDrawerClose,
-  UnnnicSwitch,
-  UnnnicDisclaimer,
-  unnnicCallAlert,
-} from '@weni/unnnic-system';
+import { unnnicCallAlert } from '@weni/unnnic-system';
 import { reactive, computed } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useI18n } from 'vue-i18n';
@@ -106,10 +98,16 @@ import {
   MetricFormState,
   OperationalAlertsFormState,
 } from '@/store/modules/humanSupport/metricGoals';
+
 import {
   MetricKey,
   formatRecipientLabel,
 } from '@/services/api/resources/humanSupport/monitoring/metricGoals';
+
+import { useUser } from '@/store/modules/user';
+
+const userStore = useUser();
+const { isViewerPermission } = storeToRefs(userStore);
 
 defineProps<{
   modelValue: boolean;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -529,6 +529,7 @@
   "online_agents": "Online agents",
   "chats_per_agents": "Chats per agent",
   "closeds": "Closed",
+  "close": "Close",
   "finished": "Completed",
   "in_progress": "In progress",
   "waiting": "Waiting",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -529,6 +529,7 @@
   "online_agents": "Agentes online",
   "chats_per_agents": "Chats por agente",
   "closeds": "Cerrados",
+  "close": "Cerrar",
   "finished": "Finalizados",
   "in_progress": "En curso",
   "waiting": "Esperando",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -529,6 +529,7 @@
   "online_agents": "Atendentes online",
   "chats_per_agents": "Chats por atendente",
   "closeds": "Encerrados",
+  "close": "Fechar",
   "finished": "Finalizado",
   "in_progress": "Em andamento",
   "waiting": "Em espera",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -529,6 +529,7 @@
   "online_agents": "Agenți online",
   "chats_per_agents": "Chaturi per agent",
   "closeds": "Închise",
+  "close": "Închide",
   "finished": "Finalizat",
   "in_progress": "În curs",
   "waiting": "În așteptare",

--- a/src/services/api/resources/user.ts
+++ b/src/services/api/resources/user.ts
@@ -1,0 +1,14 @@
+import http from '@/services/api/http';
+import { useConfig } from '@/store/modules/config';
+
+export default {
+  async verifyIsViewerPermission(): Promise<boolean> {
+    const { project } = useConfig();
+
+    const response = (await http.get(
+      `/projects/${project.uuid}/verify_viewer/`,
+    )) as boolean;
+
+    return response;
+  },
+};

--- a/src/store/modules/user.ts
+++ b/src/store/modules/user.ts
@@ -11,6 +11,9 @@ export const useUser = defineStore('user', () => {
   };
 
   const verifyIsViewerPermission = async () => {
+    // TODO: Remove this after testing
+    isViewerPermission.value = true;
+    return;
     const response = await User.verifyIsViewerPermission();
     isViewerPermission.value = response;
   };

--- a/src/store/modules/user.ts
+++ b/src/store/modules/user.ts
@@ -1,12 +1,19 @@
+import { ref } from 'vue';
 import { defineStore } from 'pinia';
+import User from '@/services/api/resources/user';
 
-export const useUser = defineStore('user', {
-  state: () => ({
-    email: '' as String,
-  }),
-  actions: {
-    setEmail(email: string) {
-      this.email = email;
-    },
-  },
+export const useUser = defineStore('user', () => {
+  const email = ref('');
+  const isViewerPermission = ref(false);
+
+  const setEmail = (value: string) => {
+    email.value = value;
+  };
+
+  const verifyIsViewerPermission = async () => {
+    const response = await User.verifyIsViewerPermission();
+    isViewerPermission.value = response;
+  };
+
+  return { email, isViewerPermission, setEmail, verifyIsViewerPermission };
 });

--- a/src/store/modules/user.ts
+++ b/src/store/modules/user.ts
@@ -12,8 +12,8 @@ export const useUser = defineStore('user', () => {
 
   const verifyIsViewerPermission = async () => {
     // TODO: Remove this after testing
-    isViewerPermission.value = true;
-    return;
+    // isViewerPermission.value = true;
+    // return;
     const response = await User.verifyIsViewerPermission();
     isViewerPermission.value = response;
   };

--- a/src/store/modules/user.ts
+++ b/src/store/modules/user.ts
@@ -11,9 +11,6 @@ export const useUser = defineStore('user', () => {
   };
 
   const verifyIsViewerPermission = async () => {
-    // TODO: Remove this after testing
-    // isViewerPermission.value = true;
-    // return;
     const response = await User.verifyIsViewerPermission();
     isViewerPermission.value = response;
   };


### PR DESCRIPTION
## Description
### Type of Change
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
Users with viewer-level permissions should not have access to certain features, such as Operational Alerts. This change introduces a permission check to identify viewer users and restrict their access accordingly.

### Summary of Changes
- Added a new `verifyIsViewerPermission` API call that checks whether the current user has viewer-level permissions for the project by hitting the `/projects/{uuid}/verify_viewer/` endpoint.
- Introduced `isViewerPermission` state to the `useUser` store and exposed the `verifyIsViewerPermission` action.
- Called `verifyIsViewerPermission` during app initialization so the permission state is available throughout the application.
- Hidden the Operational Alerts button in `HeaderHumanSupport` for users with viewer permissions.
- Added the `close` translation key across all supported locales (English, Spanish, Portuguese, and Romanian).