### PR TITLE
refactor: update agent activation API endpoint in nexus service

### DIFF
--- a/src/components/insights/widgets/conversational/ConversationalCsat.vue
+++ b/src/components/insights/widgets/conversational/ConversationalCsat.vue
@@ -175,11 +175,11 @@ const handleCsatWidgetData = (data: CsatResponse) => {
   };
 
   const formattedData = {
-    '5': `🤩 ${t('conversations_dashboard.csat_widget.very_satisfied')}`,
-    '4': `😁 ${t('conversations_dashboard.csat_widget.satisfied')}`,
-    '3': `😐 ${t('conversations_dashboard.csat_widget.neutral')}`,
-    '2': `☹️ ${t('conversations_dashboard.csat_widget.dissatisfied')}`,
-    '1': `😡 ${t('conversations_dashboard.csat_widget.very_dissatisfied')}`,
+    '5': `${t('conversations_dashboard.csat_widget.very_satisfied')}`,
+    '4': `${t('conversations_dashboard.csat_widget.satisfied')}`,
+    '3': `${t('conversations_dashboard.csat_widget.neutral')}`,
+    '2': `${t('conversations_dashboard.csat_widget.dissatisfied')}`,
+    '1': `${t('conversations_dashboard.csat_widget.very_dissatisfied')}`,
   };
 
   const order = ['5', '4', '3', '2', '1'];

--- a/src/services/api/resources/__tests__/nexus.spec.js
+++ b/src/services/api/resources/__tests__/nexus.spec.js
@@ -50,7 +50,7 @@ describe('Nexus Service', () => {
       const result = await nexus.activateAgent(testAgentUuid);
 
       expect(nexusHttp.post).toHaveBeenCalledWith(
-        '/api/v1/official/agents/',
+        '/api/v1/official/agents',
         { assigned: true },
         {
           params: {
@@ -79,7 +79,7 @@ describe('Nexus Service', () => {
       await nexus.activateAgent(differentAgentUuid);
 
       expect(nexusHttp.post).toHaveBeenCalledWith(
-        '/api/v1/official/agents/',
+        '/api/v1/official/agents',
         { assigned: true },
         {
           params: {

--- a/src/services/api/resources/__tests__/nexus.spec.js
+++ b/src/services/api/resources/__tests__/nexus.spec.js
@@ -43,24 +43,28 @@ describe('Nexus Service', () => {
   describe('activateAgent', () => {
     const testAgentUuid = 'test-agent-uuid';
 
-    it('should call nexusHttp.patch with correct endpoint and payload', async () => {
+    it('should call nexusHttp.post with correct endpoint and payload', async () => {
       const mockResponse = { data: { success: true } };
-      nexusHttp.patch.mockResolvedValueOnce(mockResponse);
+      nexusHttp.post.mockResolvedValueOnce(mockResponse);
 
       const result = await nexus.activateAgent(testAgentUuid);
 
-      expect(nexusHttp.patch).toHaveBeenCalledWith(
-        `/api/project/${mockProject.uuid}/assign/${testAgentUuid}`,
+      expect(nexusHttp.post).toHaveBeenCalledWith(
+        '/api/v1/official/agents/',
+        { assigned: true },
         {
-          assigned: true,
+          params: {
+            project_uuid: mockProject.uuid,
+            agent_uuid: testAgentUuid,
+          },
         },
       );
       expect(result).toEqual(mockResponse);
     });
 
-    it('should handle errors from nexusHttp.patch', async () => {
+    it('should handle errors from nexusHttp.post', async () => {
       const mockError = new Error('API Error');
-      nexusHttp.patch.mockRejectedValueOnce(mockError);
+      nexusHttp.post.mockRejectedValueOnce(mockError);
 
       await expect(nexus.activateAgent(testAgentUuid)).rejects.toThrow(
         'API Error',
@@ -69,15 +73,19 @@ describe('Nexus Service', () => {
 
     it('should work with different agent UUIDs', async () => {
       const mockResponse = { data: { success: true } };
-      nexusHttp.patch.mockResolvedValueOnce(mockResponse);
+      nexusHttp.post.mockResolvedValueOnce(mockResponse);
 
       const differentAgentUuid = 'different-agent-uuid';
       await nexus.activateAgent(differentAgentUuid);
 
-      expect(nexusHttp.patch).toHaveBeenCalledWith(
-        `/api/project/${mockProject.uuid}/assign/${differentAgentUuid}`,
+      expect(nexusHttp.post).toHaveBeenCalledWith(
+        '/api/v1/official/agents/',
+        { assigned: true },
         {
-          assigned: true,
+          params: {
+            project_uuid: mockProject.uuid,
+            agent_uuid: differentAgentUuid,
+          },
         },
       );
     });

--- a/src/services/api/resources/nexus.js
+++ b/src/services/api/resources/nexus.js
@@ -8,7 +8,7 @@ export default {
   },
   async activateAgent(uuid) {
     const { project } = useConfig();
-    const url = '/api/v1/official/agents/';
+    const url = '/api/v1/official/agents';
     const response = await nexusHttp.post(
       url,
       { assigned: true },

--- a/src/services/api/resources/nexus.js
+++ b/src/services/api/resources/nexus.js
@@ -8,11 +8,17 @@ export default {
   },
   async activateAgent(uuid) {
     const { project } = useConfig();
-    return await nexusHttp.patch(
-      `/api/project/${project.uuid}/assign/${uuid}`,
+    const url = '/api/v1/official/agents/';
+    const response = await nexusHttp.post(
+      url,
+      { assigned: true },
       {
-        assigned: true,
+        params: {
+          project_uuid: project.uuid,
+          agent_uuid: uuid,
+        },
       },
     );
+    return response;
   },
 };


### PR DESCRIPTION
## Description
### Type of Change
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
The `activateAgent` endpoint was using an outdated `PATCH` request to `/api/project/{project_uuid}/assign/{agent_uuid}`. This has been updated to use the correct `POST` request to `/api/v1/official/agents/`, passing the project and agent UUIDs as query parameters instead. Additionally, emojis were removed from the CSAT widget rating labels.

### Summary of Changes
- Updated `activateAgent` in the Nexus service to use `nexusHttp.post` against `/api/v1/official/agents/`, with `project_uuid` and `agent_uuid` passed as query params instead of path segments.
- Removed emoji prefixes from CSAT rating labels in `ConversationalCsat.vue`.
- Updated tests for `activateAgent` to reflect the new `POST` method, endpoint, and parameter structure.