### PR TITLE
refactor: update watch function in Monitoring.vue for improved reactivity

### DIFF
--- a/src/components/insights/humanSupport/Monitoring/Monitoring.vue
+++ b/src/components/insights/humanSupport/Monitoring/Monitoring.vue
@@ -87,7 +87,11 @@ onMounted(() => {
 });
 
 watch(
-  [shouldConnectMetricGoalsSocket, () => project.value?.uuid, token],
+  [
+    () => shouldConnectMetricGoalsSocket.value,
+    () => project.value?.uuid,
+    () => token.value,
+  ],
   ([enabled], previous) => {
     const wasEnabled = previous?.[0];
 


### PR DESCRIPTION
## Description
### Type of Change
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
The `watch` call in `Monitoring.vue` was passing reactive refs directly instead of getter functions, which could cause the watcher to not properly track changes to `shouldConnectMetricGoalsSocket` and `token`.

### Summary of Changes
Updated the `watch` dependencies to use getter functions (`() => shouldConnectMetricGoalsSocket.value` and `() => token.value`) instead of passing the refs directly, ensuring the watcher correctly reacts to value changes.