### PR TITLE
refactor: update filter components to use agent emails for improved clarity and functionality

### DIFF
--- a/src/components/insights/humanSupport/Common/Filters/DetailedFilters.vue
+++ b/src/components/insights/humanSupport/Common/Filters/DetailedFilters.vue
@@ -115,7 +115,7 @@ const filters = ref<Record<FilterType, FilterState>>({
       agents: { uuid: string; name: string; email: string }[],
     ) => {
       return agents.map((agent) => ({
-        value: agent.uuid,
+        value: agent.email,
         label: agent.name.trim() || agent.email,
       }));
     },
@@ -178,10 +178,8 @@ const handleFilterChange = (
     return;
   }
 
-  let valueToStore = payload.value;
-  if (filterType === 'attendant' && payload.email) {
-    valueToStore = payload.email;
-  }
+  const valueToStore =
+    filterType === 'attendant' && payload.email ? payload.email : payload.value;
 
   saveAppliedDetailFilter(storeFilterType, valueToStore, payload.label);
 };

--- a/src/components/insights/humanSupport/Common/Filters/FilterSelect.vue
+++ b/src/components/insights/humanSupport/Common/Filters/FilterSelect.vue
@@ -135,37 +135,23 @@ const canLoadMore = () => {
 };
 
 const findSelectedItem = (
-  items: FilterItem[] | TicketIdItem[],
   value: string,
 ): { value: string; label: string; email?: string } | null => {
-  if (!Array.isArray(items)) {
-    return null;
-  }
-
-  if (isTicketIdFilter.value) {
-    const item = (items as TicketIdItem[]).find((d) => d.ticket_id === value);
-    return item ? { value: item.ticket_id, label: item.ticket_id } : null;
-  }
-
-  const item = (items as FilterItem[]).find((d) => {
-    if (props.type === 'contact' && d.external_id) {
-      return d.external_id === value;
-    }
-    return d.uuid === value;
-  });
-
-  if (!item) return null;
-
-  const itemValue =
-    props.type === 'contact' && item.external_id ? item.external_id : item.uuid;
+  const option = options.value.find((o) => o.value === value);
+  if (!option) return null;
 
   const result: { value: string; label: string; email?: string } = {
-    value: itemValue,
-    label: item.name,
+    value: option.value,
+    label: option.label,
   };
 
-  if (props.type === 'attendant' && item.email) {
-    result.email = item.email;
+  if (props.type === 'attendant') {
+    const rawItem = (data.value as FilterItem[]).find(
+      (item) => item.email === option.value || item.uuid === option.value,
+    );
+    if (rawItem?.email) {
+      result.email = rawItem.email;
+    }
   }
 
   return result;
@@ -185,7 +171,7 @@ const handleChange = (selectedValue: string) => {
     return;
   }
 
-  const item = findSelectedItem(data.value, selectedValue);
+  const item = findSelectedItem(selectedValue);
 
   if (item) {
     if (props.modelValue === item.value) {

--- a/src/components/insights/humanSupport/Common/Filters/__tests__/FilterSelect.spec.js
+++ b/src/components/insights/humanSupport/Common/Filters/__tests__/FilterSelect.spec.js
@@ -27,6 +27,12 @@ const mockContactResponse = {
   next: 'http://api.com/next',
 };
 
+const formatAttendantOptions = (agents) =>
+  agents.map((agent) => ({
+    value: agent.email,
+    label: agent.name.trim() || agent.email,
+  }));
+
 const createWrapper = (props = {}, options = {}) => {
   const wrapper = mount(FilterSelect, {
     props: {
@@ -154,21 +160,30 @@ describe('FilterSelect', () => {
   describe('Filter Selection', () => {
     beforeEach(async () => {
       Projects.getProjectSource = vi.fn().mockResolvedValue(mockApiResponse);
-      wrapper = createWrapper();
+      wrapper = createWrapper({ formatOptionsFn: formatAttendantOptions });
       await nextTick();
     });
 
     it('should emit change event when option is selected', async () => {
-      wrapper.vm.handleChange('1');
+      wrapper.vm.handleChange('agent1@test.com');
       await nextTick();
 
       expect(wrapper.emitted('update:modelValue')).toBeTruthy();
       expect(wrapper.emitted('change')).toBeTruthy();
+      expect(wrapper.emitted('update:modelValue')[0]).toEqual([
+        'agent1@test.com',
+      ]);
+      expect(wrapper.emitted('change')[0][0]).toEqual({
+        value: 'agent1@test.com',
+        label: 'Agent 1',
+        email: 'agent1@test.com',
+      });
     });
 
     it('should emit clear event when selection is cleared', async () => {
       wrapper = createWrapper({
-        modelValue: '1',
+        modelValue: 'agent1@test.com',
+        formatOptionsFn: formatAttendantOptions,
       });
       await nextTick();
 
@@ -180,10 +195,11 @@ describe('FilterSelect', () => {
     });
 
     it('should handle attendant selection with email', async () => {
-      wrapper.vm.handleChange('1');
+      wrapper.vm.handleChange('agent1@test.com');
       await nextTick();
 
       const emitted = wrapper.emitted('change')[0][0];
+      expect(emitted.value).toBe('agent1@test.com');
       expect(emitted.email).toBe('agent1@test.com');
     });
 
@@ -202,12 +218,13 @@ describe('FilterSelect', () => {
 
     it('should not emit if same value is selected', async () => {
       wrapper = createWrapper({
-        modelValue: '1',
+        modelValue: 'agent1@test.com',
+        formatOptionsFn: formatAttendantOptions,
       });
       await nextTick();
 
       const emitCountBefore = wrapper.emitted('change')?.length || 0;
-      wrapper.vm.handleChange('1');
+      wrapper.vm.handleChange('agent1@test.com');
       await nextTick();
 
       const emitCountAfter = wrapper.emitted('change')?.length || 0;


### PR DESCRIPTION
## Description

### Type of Change

    - [ ] Bugfix
    - [ ] Feature
    - [ ] Code style update (formatting, local variables)
    - [x] Refactoring (no functional changes, no api changes)
    - [x] Tests
    - [ ] Other

### Motivation and Context

The attendant filter was using `uuid` as the option value, but the API expects the agent's `email` when filtering by attendant. This mismatch caused incorrect filter values to be stored and sent.

### Summary of Changes

- Updated the attendant options formatter to use `agent.email` as the option `value` instead of `agent.uuid`, ensuring the correct identifier is used from the point of option creation.
- Simplified `findSelectedItem` in `FilterSelect.vue` to look up items directly from the already-computed `options` array by value, removing redundant type-specific lookup logic. For attendant filters, the raw item is still referenced to attach the `email` field to the result.
- Removed the post-selection email override logic in `handleFilterChange` within `DetailedFilters.vue`, since the email is now correctly set as the value at the options level, making the override unnecessary.
- Updated tests to reflect that attendant selections are now identified and emitted using `email` as the value rather than `uuid`.