### PR TITLE
feat: add feature flag to disable Meta Template API data source selection

### DIFF
--- a/src/components/insights/charts/MultipleLineChart.vue
+++ b/src/components/insights/charts/MultipleLineChart.vue
@@ -65,19 +65,19 @@ import { getPercentageOf } from '@/utils/numbers';
 import i18n from '@/utils/plugins/i18n';
 import weniLoading from '@/assets/images/weni-loading.svg';
 import {
-  colorPurplePlain,
-  colorGreenPlain,
-  colorBluePlain,
-  colorOrangePlain,
+  colorBgPurpleStrong,
+  colorBgGreenStrong,
+  colorBgBlueStrong,
+  colorBgOrangeStrong,
   colorFgMuted,
   colorGray12,
 } from '@weni/unnnic-system/tokens/colors';
 
 const colorsMapper = {
-  'aux-purple-300': colorPurplePlain,
-  'aux-green-300': colorGreenPlain,
-  'aux-blue-300': colorBluePlain,
-  'aux-orange-300': colorOrangePlain,
+  'bg-purple-strong': colorBgPurpleStrong,
+  'bg-green-strong': colorBgGreenStrong,
+  'bg-blue-strong': colorBgBlueStrong,
+  'bg-orange-strong': colorBgOrangeStrong,
 };
 
 const props = defineProps({

--- a/src/components/insights/dashboards/TemplateMessageMeta.vue
+++ b/src/components/insights/dashboards/TemplateMessageMeta.vue
@@ -147,6 +147,14 @@ import { formatValue, formatToPercent } from '@/utils/numbers';
 import { useDashboards } from '@/store/modules/dashboards';
 import { useConfig } from '@/store/modules/config';
 import { useMetaTemplateMessage } from '@/store/modules/templates/metaTemplateMessage';
+import { useFeatureFlag } from '@/store/modules/featureFlag';
+
+const featureFlagStore = useFeatureFlag();
+const { isFeatureFlagEnabled } = featureFlagStore;
+
+const isDisalbledSelectMetaTemplateApi = computed(() =>
+  isFeatureFlagEnabled('analyticsDisabledSelectMetaAPI'),
+);
 
 const dashboardsStore = useDashboards();
 const configStore = useConfig();
@@ -171,6 +179,7 @@ const initialLoading = ref(false);
 const viewTab = ref('home');
 
 const showDataSourceSelect = computed(() => {
+  if (isDisalbledSelectMetaTemplateApi.value) return false;
   return (
     viewTab.value === 'template' &&
     templatePreview.value.category === 'MARKETING'
@@ -386,7 +395,8 @@ const getButtonClicksData = async () => {
       date_start: appliedFilters.value?.date?._start,
       date_end: appliedFilters.value?.date?._end,
       product_type:
-        templatePreview.value.category === 'MARKETING'
+        templatePreview.value.category === 'MARKETING' &&
+        !isDisalbledSelectMetaTemplateApi.value
           ? selectedApiOptions.value
           : undefined,
     };


### PR DESCRIPTION
## Description
### Type of Change
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
Some environments require the ability to disable the Meta Template API data source selector in the analytics dashboard. This change introduces a feature flag to control this behavior without requiring code changes per environment.

### Summary of Changes
- Added a feature flag check for `analyticsDisabledSelectMetaAPI` in the `TemplateMessageMeta` component.
- When the feature flag is enabled, the data source selector is hidden by returning `false` early in the `showDataSourceSelect` computed property.
- When the feature flag is enabled, the `product_type` parameter is forced to `undefined` in the `getButtonClicksData` request, even for `MARKETING` category templates, preventing calls to the Meta Template API.