### PR TITLE
refactor: improve card click handling in DashboardHeader

### DIFF
--- a/src/components/insights/conversations/DashboardHeader.vue
+++ b/src/components/insights/conversations/DashboardHeader.vue
@@ -224,17 +224,24 @@ const loadCardData = async () => {
 };
 
 const handleCardClick = (cardId: string) => {
-  const statusMap = {
+  const statusMap: Record<string, string> = {
     total_conversations: '',
     resolved: 'optimized_resolution',
     unresolved: 'other_conclusion',
     transferred_to_human: 'transferred_to_human_support',
   };
 
+  const status = statusMap[cardId];
+
+  // The host route is `ai-conversations/:internal+`, so the path requires at
+  // least one segment. `init` means the module root.
+  const path = `ai-conversations:init${status ? `?status=${status}` : ''}`;
+
+  console.log('path', path);
   window.parent.postMessage(
     {
       event: 'redirect',
-      path: `ai-conversations:?status=${statusMap[cardId]}`,
+      path,
     },
     '*',
   );

--- a/src/components/insights/conversations/DashboardHeader.vue
+++ b/src/components/insights/conversations/DashboardHeader.vue
@@ -233,8 +233,6 @@ const handleCardClick = (cardId: string) => {
 
   const status = statusMap[cardId];
 
-  // The host route is `ai-conversations/:internal+`, so the path requires at
-  // least one segment. `init` means the module root.
   const path = `ai-conversations:init${status ? `?status=${status}` : ''}`;
 
   console.log('path', path);

--- a/src/components/insights/conversations/__tests__/DashboardHeader.spec.js
+++ b/src/components/insights/conversations/__tests__/DashboardHeader.spec.js
@@ -766,6 +766,56 @@ describe('DashboardHeader.vue', () => {
     });
   });
 
+  describe('Card click redirect', () => {
+    let postMessageSpy;
+
+    beforeEach(() => {
+      postMessageSpy = vi.fn();
+      window.parent.postMessage = postMessageSpy;
+    });
+
+    it.each([
+      ['resolved', 'ai-conversations:init?status=optimized_resolution'],
+      ['unresolved', 'ai-conversations:init?status=other_conclusion'],
+      [
+        'transferred_to_human',
+        'ai-conversations:init?status=transferred_to_human_support',
+      ],
+    ])('should redirect %s card with status query', (cardId, expectedPath) => {
+      wrapper.vm.handleCardClick(cardId);
+
+      expect(postMessageSpy).toHaveBeenCalledWith(
+        { event: 'redirect', path: expectedPath },
+        '*',
+      );
+    });
+
+    it('should redirect total_conversations card without status query', () => {
+      wrapper.vm.handleCardClick('total_conversations');
+
+      expect(postMessageSpy).toHaveBeenCalledWith(
+        { event: 'redirect', path: 'ai-conversations:init' },
+        '*',
+      );
+    });
+
+    it('should redirect when a card emits click', async () => {
+      const unresolvedCard = wrapper.findAllComponents({
+        name: 'CardConversations',
+      })[2];
+
+      await unresolvedCard.vm.$emit('click');
+
+      expect(postMessageSpy).toHaveBeenCalledWith(
+        {
+          event: 'redirect',
+          path: 'ai-conversations:init?status=other_conclusion',
+        },
+        '*',
+      );
+    });
+  });
+
   describe('Mock mode (shouldUseMock = true)', () => {
     beforeEach(() => {
       mockShouldUseMock.value = true;


### PR DESCRIPTION
## Description
### Type of Change
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
The `ai-conversations` route requires at least one path segment due to its `/:internal+` pattern. The previous redirect path (`ai-conversations:?status=...`) was malformed, omitting the required segment and causing navigation to fail.

### Summary of Changes
- Fixed the redirect path in `handleCardClick` to use `ai-conversations:init` as the base path, where `init` satisfies the required route segment.
- The `status` query parameter is now only appended when a relevant status exists, so clicking the `total_conversations` card redirects to `ai-conversations:init` without any query string.
- Added tests covering all card click redirect scenarios, including cards with a status query, the `total_conversations` card without a query, and a card component emitting a click event.